### PR TITLE
feat: add tmux launch workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Thanks @RobertTLange for PR #1, adding the tmux launch workflow.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ headless opencode --show-config
 headless gemini --prompt "Summarize the codebase" --print-command
 headless pi --prompt "Summarize this repo" --json
 headless codex --prompt "Fix the failing tests" --tmux
+headless --list
 ```
 
 Pipe a prompt over stdin:
@@ -76,11 +77,12 @@ Claude tmux launches include `--dangerously-skip-permissions` and pre-trust the 
 Cursor tmux launches pre-trust the launch directory so the detached session does not block on workspace trust.
 Gemini tmux launches include `--skip-trust` so the detached session does not block on the folder trust prompt.
 OpenCode tmux launches start the TUI, wake it, paste the prompt through a tmux buffer, and then send `Enter` so the prompt is submitted after the TUI is ready.
+Use `headless --list` to list active tmux sessions created by Headless, or `headless codex --list` to list sessions for one agent.
 
 ## CLI Reference
 
 ```bash
-headless [agent] (--prompt <text> | --prompt-file <path>) [options]
+headless [agent] (--prompt <text> | --prompt-file <path> | --list | --show-config) [options]
 ```
 
 Options:
@@ -91,6 +93,7 @@ Options:
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--json`: print the raw agent JSON trace instead of extracting the final message.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
+- `--list`: list active tmux sessions created by Headless.
 - `--print-command`: print the shell command without executing it.
 - `--show-config`: print config paths and auth seed paths for an agent.
 - `--help`: show usage.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ tmux attach-session -t headless-claude-12345
 
 `--json` is only for headless execution and cannot be combined with `--tmux`. Use `--print-command --tmux` to preview the tmux command without launching a session.
 Claude tmux launches include `--dangerously-skip-permissions` and pre-trust the launch directory so the detached session does not block on directory trust or permission prompts.
+Gemini tmux launches include `--skip-trust` so the detached session does not block on the folder trust prompt.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ tmux attach-session -t headless-claude-12345
 Claude tmux launches include `--dangerously-skip-permissions` and pre-trust the launch directory so the detached session does not block on directory trust or permission prompts.
 Cursor tmux launches pre-trust the launch directory so the detached session does not block on workspace trust.
 Gemini tmux launches include `--skip-trust` so the detached session does not block on the folder trust prompt.
+OpenCode tmux launches start the TUI, wake it, paste the prompt through a tmux buffer, and then send `Enter` so the prompt is submitted after the TUI is ready.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 </p>
 
 Headless normalizes the small but annoying differences between coding-agent CLIs. It gives each agent the same prompt, model, workdir, dry-run, and config-inspection interface while preserving the native command flags needed for non-interactive execution.
+Pass `--tmux` when you want the same prompt launched in an interactive agent session instead.
 
 ## Quick Start
 
@@ -38,6 +39,7 @@ headless claude --prompt-file prompt.md --work-dir /path/to/project
 headless opencode --show-config
 headless gemini --prompt "Summarize the codebase" --print-command
 headless pi --prompt "Summarize this repo" --json
+headless codex --prompt "Fix the failing tests" --tmux
 ```
 
 Pipe a prompt over stdin:
@@ -60,6 +62,17 @@ printf "Review this diff" | headless pi --model claude-opus
 By default, Headless prints the agent's final assistant message. Pass `--json` to print the raw native JSON trace.
 When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`.
 
+## Tmux Mode
+
+`--tmux` creates a detached tmux session named `headless-<agent>-<pid>`, starts the selected agent in interactive mode with the prompt as its initial message, prints an attach command, and exits.
+
+```bash
+headless claude --prompt-file task.md --work-dir /path/to/project --tmux
+tmux attach-session -t headless-claude-12345
+```
+
+`--json` is only for headless execution and cannot be combined with `--tmux`. Use `--print-command --tmux` to preview the tmux command without launching a session.
+
 ## CLI Reference
 
 ```bash
@@ -73,6 +86,7 @@ Options:
 - `--model`, `--agent-model`: model override passed to the agent CLI.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--json`: print the raw agent JSON trace instead of extracting the final message.
+- `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
 - `--print-command`: print the shell command without executing it.
 - `--show-config`: print config paths and auth seed paths for an agent.
 - `--help`: show usage.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ tmux attach-session -t headless-claude-12345
 
 `--json` is only for headless execution and cannot be combined with `--tmux`. Use `--print-command --tmux` to preview the tmux command without launching a session.
 Claude tmux launches include `--dangerously-skip-permissions` and pre-trust the launch directory so the detached session does not block on directory trust or permission prompts.
+Cursor tmux launches pre-trust the launch directory so the detached session does not block on workspace trust.
 Gemini tmux launches include `--skip-trust` so the detached session does not block on the folder trust prompt.
 
 ## CLI Reference

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ tmux attach-session -t headless-claude-12345
 ```
 
 `--json` is only for headless execution and cannot be combined with `--tmux`. Use `--print-command --tmux` to preview the tmux command without launching a session.
+Claude tmux launches include `--dangerously-skip-permissions` and pre-trust the launch directory so the detached session does not block on directory trust or permission prompts.
 
 ## CLI Reference
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -90,6 +90,7 @@ function buildGemini(options: BuildOptions): BuiltCommand {
 
 function buildInteractiveGemini(options: BuildOptions): BuiltCommand {
   const args = withModel([], options.model);
+  args.push("--skip-trust");
   args.push(options.prompt);
   return { command: "gemini", args };
 }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -161,6 +161,7 @@ const harnesses: Record<AgentName, AgentHarness> = {
     buildCommand: buildClaude,
     buildInteractiveCommand: (options) => {
       const args = withModel([], options.model);
+      args.push("--dangerously-skip-permissions");
       args.push(options.prompt);
       return { command: "claude", args };
     },

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -108,7 +108,6 @@ function buildOpencode(options: BuildOptions): BuiltCommand {
 
 function buildInteractiveOpencode(options: BuildOptions): BuiltCommand {
   const args = withModel([], options.model);
-  args.push("--prompt", options.prompt);
   return { command: "opencode", args };
 }
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -39,6 +39,13 @@ function buildCodex(options: BuildOptions, env: Env): BuiltCommand {
   return { command: "codex", args, stdinText: options.prompt };
 }
 
+function buildInteractiveCodex(options: BuildOptions, env: Env): BuiltCommand {
+  const model = options.model || env.CODEX_MODEL;
+  const args = withModel([], model);
+  args.push(options.prompt);
+  return { command: "codex", args };
+}
+
 function buildCursor(options: BuildOptions, env: Env): BuiltCommand {
   const command = env.CURSOR_CLI_BIN || "agent";
   const args = ["-p", "--force", "--output-format", "stream-json"];
@@ -54,6 +61,21 @@ function buildCursor(options: BuildOptions, env: Env): BuiltCommand {
   return { command, args };
 }
 
+function buildInteractiveCursor(options: BuildOptions, env: Env): BuiltCommand {
+  const command = env.CURSOR_CLI_BIN || "agent";
+  const args: string[] = [];
+
+  if (env.CURSOR_API_KEY) {
+    args.push("--api-key", env.CURSOR_API_KEY);
+  }
+  if (options.model) {
+    args.push("--model", options.model);
+  }
+  args.push(options.prompt);
+
+  return { command, args };
+}
+
 function buildGemini(options: BuildOptions): BuiltCommand {
   const args = withModel([], options.model);
 
@@ -66,6 +88,12 @@ function buildGemini(options: BuildOptions): BuiltCommand {
   return { command: "gemini", args };
 }
 
+function buildInteractiveGemini(options: BuildOptions): BuiltCommand {
+  const args = withModel([], options.model);
+  args.push(options.prompt);
+  return { command: "gemini", args };
+}
+
 function buildOpencode(options: BuildOptions): BuiltCommand {
   const args = ["run", "--format", "json"];
 
@@ -74,6 +102,12 @@ function buildOpencode(options: BuildOptions): BuiltCommand {
   }
   args.push(options.prompt);
 
+  return { command: "opencode", args };
+}
+
+function buildInteractiveOpencode(options: BuildOptions): BuiltCommand {
+  const args = withModel([], options.model);
+  args.push("--prompt", options.prompt);
   return { command: "opencode", args };
 }
 
@@ -97,6 +131,26 @@ function buildPi(options: BuildOptions, env: Env): BuiltCommand {
   return { command, args };
 }
 
+function buildInteractivePi(options: BuildOptions, env: Env): BuiltCommand {
+  const command = env.PI_CODING_AGENT_BIN || "pi";
+  const args: string[] = [];
+
+  if (env.PI_CODING_AGENT_PROVIDER) {
+    args.push("--provider", env.PI_CODING_AGENT_PROVIDER);
+  }
+  if (options.model) {
+    args.push("--model", options.model);
+  } else if (env.PI_CODING_AGENT_MODEL) {
+    args.push("--model", env.PI_CODING_AGENT_MODEL);
+  }
+  if (env.PI_CODING_AGENT_MODELS) {
+    args.push("--models", env.PI_CODING_AGENT_MODELS);
+  }
+  args.push(options.prompt);
+
+  return { command, args };
+}
+
 const harnesses: Record<AgentName, AgentHarness> = {
   claude: {
     name: "claude",
@@ -105,6 +159,11 @@ const harnesses: Record<AgentName, AgentHarness> = {
     workspaceConfigRelDir: ".claude",
     seedPaths: [".claude/settings.json", ".claude/.credentials.json", ".claude/auth.json"],
     buildCommand: buildClaude,
+    buildInteractiveCommand: (options) => {
+      const args = withModel([], options.model);
+      args.push(options.prompt);
+      return { command: "claude", args };
+    },
   },
   codex: {
     name: "codex",
@@ -113,6 +172,7 @@ const harnesses: Record<AgentName, AgentHarness> = {
     workspaceConfigRelDir: ".codex",
     seedPaths: [".codex/auth.json", ".codex/config.toml"],
     buildCommand: buildCodex,
+    buildInteractiveCommand: buildInteractiveCodex,
   },
   cursor: {
     name: "cursor",
@@ -121,6 +181,7 @@ const harnesses: Record<AgentName, AgentHarness> = {
     workspaceConfigRelDir: ".cursor",
     seedPaths: [".cursor/cli-config.json"],
     buildCommand: buildCursor,
+    buildInteractiveCommand: buildInteractiveCursor,
   },
   gemini: {
     name: "gemini",
@@ -135,6 +196,7 @@ const harnesses: Record<AgentName, AgentHarness> = {
       ".gemini/installation_id",
     ],
     buildCommand: buildGemini,
+    buildInteractiveCommand: buildInteractiveGemini,
   },
   opencode: {
     name: "opencode",
@@ -143,6 +205,7 @@ const harnesses: Record<AgentName, AgentHarness> = {
     workspaceConfigRelDir: ".opencode",
     seedPaths: [".config/opencode"],
     buildCommand: buildOpencode,
+    buildInteractiveCommand: buildInteractiveOpencode,
   },
   pi: {
     name: "pi",
@@ -151,6 +214,7 @@ const harnesses: Record<AgentName, AgentHarness> = {
     workspaceConfigRelDir: ".pi/agent",
     seedPaths: [".pi/agent/auth.json", ".pi/agent/settings.json"],
     buildCommand: buildPi,
+    buildInteractiveCommand: buildInteractivePi,
   },
 };
 
@@ -167,10 +231,22 @@ export function getAgentHarness(name: AgentName): AgentHarness {
 }
 
 export function getAgentConfig(name: AgentName): AgentConfig {
-  const { buildCommand: _buildCommand, ...config } = harnesses[name];
+  const {
+    buildCommand: _buildCommand,
+    buildInteractiveCommand: _buildInteractiveCommand,
+    ...config
+  } = harnesses[name];
   return { ...config, seedPaths: [...config.seedPaths] };
 }
 
 export function buildAgentCommand(name: AgentName, options: BuildOptions, env: Env = process.env): BuiltCommand {
   return getAgentHarness(name).buildCommand(options, env);
+}
+
+export function buildInteractiveAgentCommand(
+  name: AgentName,
+  options: BuildOptions,
+  env: Env = process.env,
+): BuiltCommand {
+  return getAgentHarness(name).buildInteractiveCommand(options, env);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -281,6 +281,12 @@ interface ExecuteResult {
 interface TmuxCommands {
   sessionName: string;
   newSession: BuiltCommand;
+  postLaunch: TmuxPostLaunchCommand[];
+}
+
+interface TmuxPostLaunchCommand {
+  command: BuiltCommand;
+  delayMs: number;
 }
 
 function suppressKnownStderr(agent: AgentName, text: string): string {
@@ -367,17 +373,55 @@ async function executeCommand(
 function buildTmuxCommands(
   agent: AgentName,
   command: BuiltCommand,
+  prompt: string,
   cwd: string | undefined,
+  env: Env,
 ): TmuxCommands {
   const sessionName = `headless-${agent}-${process.pid}`;
   const startDir = cwd ?? process.cwd();
+  const opencodeWakeDelayMs = parseDelayMs(
+    env.HEADLESS_TMUX_OPENCODE_WAKE_DELAY_MS ?? env.HEADLESS_TMUX_OPENCODE_ENTER_DELAY_MS,
+    4000,
+  );
+  const opencodePasteDelayMs = parseDelayMs(env.HEADLESS_TMUX_OPENCODE_PASTE_DELAY_MS, 1000);
+  const opencodeSubmitDelayMs = parseDelayMs(env.HEADLESS_TMUX_OPENCODE_SUBMIT_DELAY_MS, 1000);
+  const opencodePromptBuffer = `${sessionName}-prompt`;
   return {
     sessionName,
     newSession: {
       command: "tmux",
       args: ["new-session", "-d", "-s", sessionName, "-c", startDir, quoteCommand(command)],
     },
+    postLaunch:
+      agent === "opencode"
+        ? [
+            {
+              command: { command: "tmux", args: ["send-keys", "-t", sessionName, "Space", "BSpace"] },
+              delayMs: opencodeWakeDelayMs,
+            },
+            {
+              command: { command: "tmux", args: ["set-buffer", "-b", opencodePromptBuffer, prompt] },
+              delayMs: opencodePasteDelayMs,
+            },
+            {
+              command: { command: "tmux", args: ["paste-buffer", "-d", "-b", opencodePromptBuffer, "-t", sessionName] },
+              delayMs: 0,
+            },
+            {
+              command: { command: "tmux", args: ["send-keys", "-t", sessionName, "Enter"] },
+              delayMs: opencodeSubmitDelayMs,
+            },
+          ]
+        : [],
   };
+}
+
+function parseDelayMs(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
 function trustClaudeWorkspace(cwd: string | undefined, env: Env): void {
@@ -447,13 +491,32 @@ async function executeSimpleCommand(
   });
 }
 
+async function waitForDelay(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return;
+  }
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function executeTmuxCommands(
   commands: TmuxCommands,
   cwd: string | undefined,
   env: Env,
   stderr: (text: string) => void,
 ): Promise<number> {
-  return await executeSimpleCommand(commands.newSession, cwd, env, stderr);
+  const launchCode = await executeSimpleCommand(commands.newSession, cwd, env, stderr);
+  if (launchCode !== 0) {
+    return launchCode;
+  }
+
+  for (const postLaunch of commands.postLaunch) {
+    await waitForDelay(postLaunch.delayMs);
+    const code = await executeSimpleCommand(postLaunch.command, cwd, env, stderr);
+    if (code !== 0) {
+      return code;
+    }
+  }
+  return 0;
 }
 
 export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number> {
@@ -491,10 +554,13 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         },
         env,
       );
-      const tmuxCommands = buildTmuxCommands(parsed.agent, tmuxCommand, cwd);
+      const tmuxCommands = buildTmuxCommands(parsed.agent, tmuxCommand, prompt.prompt, cwd, env);
 
       if (parsed.printCommand) {
         stdout(`${quoteCommand(tmuxCommands.newSession)}\n`);
+        for (const postLaunch of tmuxCommands.postLaunch) {
+          stdout(`${quoteCommand(postLaunch.command)}\n`);
+        }
         return 0;
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import {
   closeSync,
   constants,
   existsSync,
+  mkdirSync,
   openSync,
   readFileSync,
   realpathSync,
@@ -400,6 +401,25 @@ function trustClaudeWorkspace(cwd: string | undefined, env: Env): void {
   writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
 }
 
+function cursorProjectKey(workspace: string): string {
+  return workspace.replace(/^\/+/, "").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function trustCursorWorkspace(cwd: string | undefined, env: Env): void {
+  const homeDir = env.HOME;
+  if (!homeDir) {
+    throw new CliError("HOME is required to trust Cursor workspace");
+  }
+
+  const workspace = realpathSync(cwd ?? process.cwd());
+  const projectDir = join(homeDir, ".cursor", "projects", cursorProjectKey(workspace));
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(
+    join(projectDir, ".workspace-trusted"),
+    `${JSON.stringify({ trustedAt: new Date().toISOString(), workspacePath: workspace }, null, 2)}\n`,
+  );
+}
+
 async function executeSimpleCommand(
   command: BuiltCommand,
   cwd: string | undefined,
@@ -480,6 +500,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
 
       if (parsed.agent === "claude") {
         trustClaudeWorkspace(cwd, env);
+      }
+      if (parsed.agent === "cursor") {
+        trustCursorWorkspace(cwd, env);
       }
 
       const code = await executeTmuxCommands(tmuxCommands, cwd, env, stderr);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
   readFileSync,
   realpathSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
 import { spawn } from "node:child_process";
 import { delimiter, join } from "node:path";
@@ -378,6 +379,27 @@ function buildTmuxCommands(
   };
 }
 
+function trustClaudeWorkspace(cwd: string | undefined, env: Env): void {
+  const homeDir = env.HOME;
+  if (!homeDir) {
+    throw new CliError("HOME is required to trust Claude workspace");
+  }
+
+  const workspace = realpathSync(cwd ?? process.cwd());
+  const configPath = join(homeDir, ".claude.json");
+  const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, "utf8")) : {};
+  const projects =
+    config.projects && typeof config.projects === "object" && !Array.isArray(config.projects) ? config.projects : {};
+  const project =
+    projects[workspace] && typeof projects[workspace] === "object" && !Array.isArray(projects[workspace])
+      ? projects[workspace]
+      : {};
+
+  projects[workspace] = { ...project, hasTrustDialogAccepted: true };
+  config.projects = projects;
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+
 async function executeSimpleCommand(
   command: BuiltCommand,
   cwd: string | undefined,
@@ -454,6 +476,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (parsed.printCommand) {
         stdout(`${quoteCommand(tmuxCommands.newSession)}\n`);
         return 0;
+      }
+
+      if (parsed.agent === "claude") {
+        trustClaudeWorkspace(cwd, env);
       }
 
       const code = await executeTmuxCommands(tmuxCommands, cwd, env, stderr);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ interface ParsedArgs {
   json: boolean;
   printCommand: boolean;
   showConfig: boolean;
+  list: boolean;
   tmux: boolean;
   help: boolean;
 }
@@ -58,7 +59,7 @@ class CliError extends Error {
 
 function usage(): string {
   return [
-    "Usage: headless [agent] (--prompt <text> | --prompt-file <path>) [options]",
+    "Usage: headless [agent] (--prompt <text> | --prompt-file <path> | --list | --show-config) [options]",
     "",
     `Agents: ${listAgents().join(", ")}`,
     "",
@@ -69,6 +70,7 @@ function usage(): string {
     "  --work-dir, -C <path> Run from this directory.",
     "  --json               Print raw agent JSON trace output.",
     "  --tmux               Launch an interactive agent in a tmux session.",
+    "  --list               List active headless tmux sessions.",
     "  --print-command      Print the command without executing it.",
     "  --show-config        Print harness config paths and auth seed paths.",
     "  -h, --help           Show this help.",
@@ -79,7 +81,14 @@ function usage(): string {
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
-  const parsed: ParsedArgs = { json: false, printCommand: false, showConfig: false, tmux: false, help: false };
+  const parsed: ParsedArgs = {
+    json: false,
+    printCommand: false,
+    showConfig: false,
+    list: false,
+    tmux: false,
+    help: false,
+  };
   const args = [...argv];
 
   if (args.length === 0) {
@@ -127,6 +136,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--tmux":
         parsed.tmux = true;
+        break;
+      case "--list":
+        parsed.list = true;
         break;
       case "--print-command":
         parsed.printCommand = true;
@@ -278,6 +290,12 @@ interface ExecuteResult {
   stdout: string;
 }
 
+interface CaptureResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
 interface TmuxCommands {
   sessionName: string;
   newSession: BuiltCommand;
@@ -287,6 +305,11 @@ interface TmuxCommands {
 interface TmuxPostLaunchCommand {
   command: BuiltCommand;
   delayMs: number;
+}
+
+interface HeadlessTmuxSession {
+  name: string;
+  agent: AgentName;
 }
 
 function suppressKnownStderr(agent: AgentName, text: string): string {
@@ -424,6 +447,85 @@ function parseDelayMs(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
+async function captureSimpleCommand(
+  command: BuiltCommand,
+  cwd: string | undefined,
+  env: Env,
+): Promise<CaptureResult> {
+  return await new Promise<CaptureResult>((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    const child = spawn(command.command, command.args, {
+      cwd,
+      env: env as NodeJS.ProcessEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      stderr += `${error.message}\n`;
+      resolve({ code: 127, stdout, stderr });
+    });
+    child.on("close", (code, signal) => {
+      resolve({ code: signal ? 1 : (code ?? 1), stdout, stderr });
+    });
+  });
+}
+
+function parseHeadlessTmuxSession(name: string): HeadlessTmuxSession | undefined {
+  const match = /^headless-([a-z]+)-\d+$/.exec(name);
+  if (!match) {
+    return undefined;
+  }
+  const agent = match[1];
+  if (!isAgentName(agent)) {
+    return undefined;
+  }
+  return { name, agent };
+}
+
+function renderHeadlessTmuxSessions(sessions: HeadlessTmuxSession[]): string {
+  if (sessions.length === 0) {
+    return "No active headless tmux sessions\n";
+  }
+  return sessions
+    .map((session) => `${session.name}\t${session.agent}\ttmux attach-session -t ${session.name}`)
+    .join("\n")
+    .concat("\n");
+}
+
+async function listHeadlessTmuxSessions(agent: AgentName | undefined, env: Env): Promise<string> {
+  const result = await captureSimpleCommand(
+    { command: "tmux", args: ["list-sessions", "-F", "#{session_name}"] },
+    undefined,
+    env,
+  );
+
+  if (result.code !== 0) {
+    if (result.stderr.includes("no server running")) {
+      return renderHeadlessTmuxSessions([]);
+    }
+    throw new CliError(result.stderr.trim() || "could not list tmux sessions");
+  }
+
+  const sessions = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseHeadlessTmuxSession)
+    .filter((session): session is HeadlessTmuxSession => Boolean(session))
+    .filter((session) => agent === undefined || session.agent === agent);
+
+  return renderHeadlessTmuxSessions(sessions);
+}
+
 function trustClaudeWorkspace(cwd: string | undefined, env: Env): void {
   const homeDir = env.HOME;
   if (!homeDir) {
@@ -529,6 +631,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
 
     if (parsed.help) {
       stdout(usage());
+      return 0;
+    }
+    if (parsed.list) {
+      stdout(await listHeadlessTmuxSessions(parsed.agent, env));
       return 0;
     }
     if (!parsed.agent) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,27 @@
 #!/usr/bin/env node
 
-import { accessSync, closeSync, constants, existsSync, openSync, readFileSync, realpathSync, statSync } from "node:fs";
+import {
+  accessSync,
+  closeSync,
+  constants,
+  existsSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { spawn } from "node:child_process";
 import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { buildAgentCommand, getAgentConfig, getAgentHarness, isAgentName, listAgents } from "./agents.js";
+import {
+  buildAgentCommand,
+  buildInteractiveAgentCommand,
+  getAgentConfig,
+  getAgentHarness,
+  isAgentName,
+  listAgents,
+} from "./agents.js";
 import { extractFinalMessage } from "./output.js";
 import { quoteCommand } from "./shell.js";
 import type { AgentName, BuiltCommand, Env } from "./types.js";
@@ -19,6 +35,7 @@ interface ParsedArgs {
   json: boolean;
   printCommand: boolean;
   showConfig: boolean;
+  tmux: boolean;
   help: boolean;
 }
 
@@ -49,6 +66,7 @@ function usage(): string {
     "  --prompt-file <path>  Read prompt from a file.",
     "  --work-dir, -C <path> Run from this directory.",
     "  --json               Print raw agent JSON trace output.",
+    "  --tmux               Launch an interactive agent in a tmux session.",
     "  --print-command      Print the command without executing it.",
     "  --show-config        Print harness config paths and auth seed paths.",
     "  -h, --help           Show this help.",
@@ -59,7 +77,7 @@ function usage(): string {
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
-  const parsed: ParsedArgs = { json: false, printCommand: false, showConfig: false, help: false };
+  const parsed: ParsedArgs = { json: false, printCommand: false, showConfig: false, tmux: false, help: false };
   const args = [...argv];
 
   if (args.length === 0) {
@@ -104,6 +122,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--json":
         parsed.json = true;
+        break;
+      case "--tmux":
+        parsed.tmux = true;
         break;
       case "--print-command":
         parsed.printCommand = true;
@@ -157,7 +178,11 @@ async function readStdin(): Promise<string> {
   return data;
 }
 
-async function resolvePrompt(parsed: ParsedArgs, deps: CliDeps): Promise<{ prompt: string; promptFile?: string }> {
+async function resolvePrompt(
+  parsed: ParsedArgs,
+  deps: CliDeps,
+  options: { forceText?: boolean } = {},
+): Promise<{ prompt: string; promptFile?: string }> {
   if (parsed.prompt && parsed.promptFile) {
     throw new CliError("use either --prompt or --prompt-file, not both");
   }
@@ -171,7 +196,7 @@ async function resolvePrompt(parsed: ParsedArgs, deps: CliDeps): Promise<{ promp
     if (!existsSync(parsed.promptFile) || !statSync(parsed.promptFile).isFile()) {
       throw new CliError(`prompt file not found: ${parsed.promptFile}`);
     }
-    if (harness.promptFileMode === "stdin") {
+    if (!options.forceText && harness.promptFileMode === "stdin") {
       return { prompt: "", promptFile: parsed.promptFile };
     }
     return { prompt: readFileSync(parsed.promptFile, "utf8") };
@@ -249,6 +274,11 @@ function selectDefaultAgent(env: Env): AgentName {
 interface ExecuteResult {
   code: number;
   stdout: string;
+}
+
+interface TmuxCommands {
+  sessionName: string;
+  newSession: BuiltCommand;
 }
 
 function suppressKnownStderr(agent: AgentName, text: string): string {
@@ -332,6 +362,58 @@ async function executeCommand(
   }
 }
 
+function buildTmuxCommands(
+  agent: AgentName,
+  command: BuiltCommand,
+  cwd: string | undefined,
+): TmuxCommands {
+  const sessionName = `headless-${agent}-${process.pid}`;
+  const startDir = cwd ?? process.cwd();
+  return {
+    sessionName,
+    newSession: {
+      command: "tmux",
+      args: ["new-session", "-d", "-s", sessionName, "-c", startDir, quoteCommand(command)],
+    },
+  };
+}
+
+async function executeSimpleCommand(
+  command: BuiltCommand,
+  cwd: string | undefined,
+  env: Env,
+  stderr: (text: string) => void,
+): Promise<number> {
+  return await new Promise<number>((resolve) => {
+    const child = spawn(command.command, command.args, {
+      cwd,
+      env: env as NodeJS.ProcessEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", () => undefined);
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => stderr(chunk));
+    child.on("error", (error) => {
+      stderr(`${error.message}\n`);
+      resolve(127);
+    });
+    child.on("close", (code, signal) => {
+      resolve(signal ? 1 : (code ?? 1));
+    });
+  });
+}
+
+async function executeTmuxCommands(
+  commands: TmuxCommands,
+  cwd: string | undefined,
+  env: Env,
+  stderr: (text: string) => void,
+): Promise<number> {
+  return await executeSimpleCommand(commands.newSession, cwd, env, stderr);
+}
+
 export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number> {
   const stdout = deps.stdout ?? ((text: string) => process.stdout.write(text));
   const stderr = deps.stderr ?? ((text: string) => process.stderr.write(text));
@@ -347,13 +429,41 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (!parsed.agent) {
       parsed.agent = selectDefaultAgent(env);
     }
+    if (parsed.tmux && parsed.json) {
+      throw new CliError("--json cannot be used with --tmux");
+    }
     if (parsed.showConfig) {
       stdout(renderConfig(parsed.agent));
       return 0;
     }
 
     const cwd = validateWorkDir(parsed.workDir);
-    const prompt = await resolvePrompt(parsed, deps);
+    const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux });
+
+    if (parsed.tmux) {
+      const tmuxCommand = buildInteractiveAgentCommand(
+        parsed.agent,
+        {
+          prompt: prompt.prompt,
+          model: parsed.model,
+        },
+        env,
+      );
+      const tmuxCommands = buildTmuxCommands(parsed.agent, tmuxCommand, cwd);
+
+      if (parsed.printCommand) {
+        stdout(`${quoteCommand(tmuxCommands.newSession)}\n`);
+        return 0;
+      }
+
+      const code = await executeTmuxCommands(tmuxCommands, cwd, env, stderr);
+      if (code === 0) {
+        stdout(`tmux session: ${tmuxCommands.sessionName}\n`);
+        stdout(`attach: tmux attach-session -t ${tmuxCommands.sessionName}\n`);
+      }
+      return code;
+    }
+
     const command = buildAgentCommand(
       parsed.agent,
       {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,7 +1,6 @@
 import type { BuiltCommand } from "./types.js";
 
 const safeShellToken = /^[A-Za-z0-9_./:=@%+-]+$/;
-const shellSpecialChars = /([\\\s"'`$!&|;<>()[\]{}*?])/g;
 
 export function quoteArg(value: string): string {
   if (value === "") {
@@ -10,7 +9,7 @@ export function quoteArg(value: string): string {
   if (safeShellToken.test(value)) {
     return value;
   }
-  return value.replace(shellSpecialChars, "\\$1");
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 export function quoteCommand(command: BuiltCommand): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,4 +27,5 @@ export interface AgentConfig {
 
 export interface AgentHarness extends AgentConfig {
   buildCommand(options: BuildOptions, env: Env): BuiltCommand;
+  buildInteractiveCommand(options: BuildOptions, env: Env): BuiltCommand;
 }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -131,7 +131,7 @@ test("builds interactive commands for tmux mode", () => {
 
   assert.deepEqual(buildInteractiveAgentCommand("opencode", { prompt: "hello", model: "oc-model" }, {}), {
     command: "opencode",
-    args: ["--model", "oc-model", "--prompt", "hello"],
+    args: ["--model", "oc-model"],
   });
 
   assert.deepEqual(
@@ -459,6 +459,59 @@ test("CLI --tmux launches an interactive tmux session and sends the prompt", asy
   }
 });
 
+test("CLI --tmux sends Enter after launching opencode prompt", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "tmux.jsonl");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(
+      ["opencode", "--prompt", "hello world", "--model", "oc-model", "--work-dir", dir, "--tmux"],
+      {
+        env: {
+          ...process.env,
+          HEADLESS_TMUX_CAPTURE: captureFile,
+          HEADLESS_TMUX_OPENCODE_ENTER_DELAY_MS: "0",
+          HEADLESS_TMUX_OPENCODE_PASTE_DELAY_MS: "0",
+          HEADLESS_TMUX_OPENCODE_SUBMIT_DELAY_MS: "0",
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdout: (text) => stdout.push(text),
+      },
+    );
+
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const sessionName = calls[0][3];
+    assert.equal(code, 0);
+    assert.deepEqual(calls, [
+      ["new-session", "-d", "-s", sessionName, "-c", dir, "opencode --model oc-model"],
+      ["send-keys", "-t", sessionName, "Space", "BSpace"],
+      ["set-buffer", "-b", `${sessionName}-prompt`, "hello world"],
+      ["paste-buffer", "-d", "-b", `${sessionName}-prompt`, "-t", sessionName],
+      ["send-keys", "-t", sessionName, "Enter"],
+    ]);
+    assert.match(sessionName, /^headless-opencode-\d+$/);
+    assert.match(stdout.join(""), new RegExp(`tmux attach-session -t ${sessionName}`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --tmux marks Claude workspaces trusted before launch", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
@@ -565,6 +618,26 @@ test("CLI --tmux --print-command prints tmux commands without executing them", a
   assert.match(stdout.join(""), /hello/);
   assert.match(stdout.join(""), /world/);
   assert.doesNotMatch(stdout.join(""), /send-keys/);
+});
+
+test("CLI --tmux --print-command includes opencode Enter submit command", async () => {
+  const stdout: string[] = [];
+  const code = await runCli(["opencode", "--prompt", "hello world", "--tmux", "--print-command"], {
+    env: {
+      ...process.env,
+      HEADLESS_TMUX_OPENCODE_ENTER_DELAY_MS: "0",
+      HEADLESS_TMUX_OPENCODE_PASTE_DELAY_MS: "0",
+      HEADLESS_TMUX_OPENCODE_SUBMIT_DELAY_MS: "0",
+    },
+    stdout: (text) => stdout.push(text),
+  });
+
+  assert.equal(code, 0);
+  assert.match(stdout.join(""), /^tmux new-session -d -s headless-opencode-\d+ -c /);
+  assert.match(stdout.join(""), /\ntmux send-keys -t headless-opencode-\d+ Space BSpace\n/);
+  assert.match(stdout.join(""), /\ntmux set-buffer -b headless-opencode-\d+-prompt hello\\ world\n/);
+  assert.match(stdout.join(""), /\ntmux paste-buffer -d -b headless-opencode-\d+-prompt -t headless-opencode-\d+\n/);
+  assert.match(stdout.join(""), /\ntmux send-keys -t headless-opencode-\d+ Enter\n$/);
 });
 
 test("CLI rejects --json with --tmux", async () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -505,6 +505,54 @@ test("CLI --tmux marks Claude workspaces trusted before launch", async () => {
   }
 });
 
+test("CLI --tmux marks Cursor workspaces trusted before launch", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const homeDir = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const projectDir = join(dir, "project");
+    const captureFile = join(dir, "tmux.jsonl");
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const code = await runCli(["cursor", "--prompt", "hello", "--work-dir", projectDir, "--tmux"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_CAPTURE: captureFile,
+        HOME: homeDir,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: () => undefined,
+    });
+
+    const workspace = realpathSync(projectDir);
+    const projectKey = workspace.replace(/^\/+/, "").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    const trustPath = join(homeDir, ".cursor", "projects", projectKey, ".workspace-trusted");
+    const trust = JSON.parse(readFileSync(trustPath, "utf8"));
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(code, 0);
+    assert.equal(trust.workspacePath, workspace);
+    assert.match(trust.trustedAt, /^\d{4}-\d{2}-\d{2}T/);
+    assert.match(calls[0][6], /agent hello/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --tmux --print-command prints tmux commands without executing them", async () => {
   const stdout: string[] = [];
   const code = await runCli(["pi", "--prompt", "hello world", "--tmux", "--print-command"], {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -126,7 +126,7 @@ test("builds interactive commands for tmux mode", () => {
 
   assert.deepEqual(buildInteractiveAgentCommand("gemini", { prompt: "hello", model: "gemini-model" }, {}), {
     command: "gemini",
-    args: ["--model", "gemini-model", "hello"],
+    args: ["--model", "gemini-model", "--skip-trust", "hello"],
   });
 
   assert.deepEqual(buildInteractiveAgentCommand("opencode", { prompt: "hello", model: "oc-model" }, {}), {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -207,14 +207,14 @@ test("exposes config metadata", () => {
 test("quotes commands for print-command output", () => {
   assert.equal(
     quoteCommand({ command: "codex", args: ["exec", "hello world"], stdinFile: "/tmp/prompt file.md" }),
-    "codex exec hello\\ world < /tmp/prompt\\ file.md",
+    "codex exec 'hello world' < '/tmp/prompt file.md'",
   );
 });
 
 test("quotes commands with stdin text for print-command output", () => {
   assert.equal(
     quoteCommand({ command: "codex", args: ["exec", "-"], stdinText: "hello world" }),
-    "printf %s hello\\ world | codex exec -",
+    "printf %s 'hello world' | codex exec -",
   );
 });
 
@@ -230,7 +230,7 @@ test("CLI print-command reads argument-mode prompt files", async () => {
     });
 
     assert.equal(code, 0);
-    assert.equal(stdout.join(""), "opencode run --format json from\\ file\n");
+    assert.equal(stdout.join(""), "opencode run --format json 'from file'\n");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -245,7 +245,7 @@ test("CLI accepts stdin fallback", async () => {
   });
 
   assert.equal(code, 0);
-  assert.equal(stdout.join(""), "pi --no-session --mode json stdin\\ prompt\n");
+  assert.equal(stdout.join(""), "pi --no-session --mode json 'stdin prompt'\n");
 });
 
 test("CLI auto-selects the preferred installed agent when omitted", async () => {
@@ -450,10 +450,70 @@ test("CLI --tmux launches an interactive tmux session and sends the prompt", asy
     const sessionName = calls[0][3];
     assert.equal(code, 0);
     assert.deepEqual(calls, [
-      ["new-session", "-d", "-s", sessionName, "-c", dir, "codex --model gpt-next hello\\ world"],
+      ["new-session", "-d", "-s", sessionName, "-c", dir, "codex --model gpt-next 'hello world'"],
     ]);
     assert.match(sessionName, /^headless-codex-\d+$/);
     assert.match(stdout.join(""), new RegExp(`tmux attach-session -t ${sessionName}`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --tmux preserves multiline prompt-file text through the tmux shell command", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const agentCaptureFile = join(dir, "agent-argv.json");
+    const promptFile = join(dir, "prompt.md");
+    writeFileSync(promptFile, "line one\nline two");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      const codex = join(binDir, "codex");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const { spawnSync } = require('node:child_process');",
+          "const args = process.argv.slice(2);",
+          "if (args[0] !== 'new-session') process.exit(2);",
+          "const shellCommand = args[6];",
+          "const result = spawnSync('/bin/sh', ['-c', shellCommand], { cwd: args[5], env: process.env });",
+          "process.exit(result.status ?? 1);",
+          "",
+        ].join("\n"),
+      );
+      await writeFile(
+        codex,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "fs.writeFileSync(process.env.HEADLESS_AGENT_CAPTURE, JSON.stringify(process.argv.slice(2)));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+      await chmod(codex, 0o755);
+    });
+
+    const code = await runCli(
+      ["codex", "--prompt-file", promptFile, "--model", "gpt-next", "--work-dir", dir, "--tmux"],
+      {
+        env: {
+          ...process.env,
+          HEADLESS_AGENT_CAPTURE: agentCaptureFile,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdout: () => undefined,
+      },
+    );
+
+    assert.equal(code, 0);
+    assert.deepEqual(JSON.parse(readFileSync(agentCaptureFile, "utf8")), [
+      "--model",
+      "gpt-next",
+      "line one\nline two",
+    ]);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -635,7 +695,7 @@ test("CLI --tmux --print-command includes opencode Enter submit command", async 
   assert.equal(code, 0);
   assert.match(stdout.join(""), /^tmux new-session -d -s headless-opencode-\d+ -c /);
   assert.match(stdout.join(""), /\ntmux send-keys -t headless-opencode-\d+ Space BSpace\n/);
-  assert.match(stdout.join(""), /\ntmux set-buffer -b headless-opencode-\d+-prompt hello\\ world\n/);
+  assert.match(stdout.join(""), /\ntmux set-buffer -b headless-opencode-\d+-prompt 'hello world'\n/);
   assert.match(stdout.join(""), /\ntmux paste-buffer -d -b headless-opencode-\d+-prompt -t headless-opencode-\d+\n/);
   assert.match(stdout.join(""), /\ntmux send-keys -t headless-opencode-\d+ Enter\n$/);
 });

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -6,7 +6,7 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { buildAgentCommand, getAgentConfig, listAgents } from "../src/agents.ts";
+import { buildAgentCommand, buildInteractiveAgentCommand, getAgentConfig, listAgents } from "../src/agents.ts";
 import { runCli } from "../src/cli.ts";
 import { quoteCommand } from "../src/shell.ts";
 
@@ -111,6 +111,45 @@ test("builds claude, cursor, gemini, opencode, and pi prompt commands", () => {
     command: "pi",
     args: ["--no-session", "--mode", "json", "--model", "pi-model", "hello"],
   });
+});
+
+test("builds interactive commands for tmux mode", () => {
+  assert.deepEqual(buildInteractiveAgentCommand("codex", { prompt: "hello", model: "gpt-next" }, {}), {
+    command: "codex",
+    args: ["--model", "gpt-next", "hello"],
+  });
+
+  assert.deepEqual(buildInteractiveAgentCommand("claude", { prompt: "hello", model: "sonnet" }, {}), {
+    command: "claude",
+    args: ["--model", "sonnet", "hello"],
+  });
+
+  assert.deepEqual(buildInteractiveAgentCommand("gemini", { prompt: "hello", model: "gemini-model" }, {}), {
+    command: "gemini",
+    args: ["--model", "gemini-model", "hello"],
+  });
+
+  assert.deepEqual(buildInteractiveAgentCommand("opencode", { prompt: "hello", model: "oc-model" }, {}), {
+    command: "opencode",
+    args: ["--model", "oc-model", "--prompt", "hello"],
+  });
+
+  assert.deepEqual(
+    buildInteractiveAgentCommand(
+      "pi",
+      { prompt: "hello" },
+      {
+        PI_CODING_AGENT_BIN: "pi-agent",
+        PI_CODING_AGENT_PROVIDER: "bedrock",
+        PI_CODING_AGENT_MODEL: "opus",
+        PI_CODING_AGENT_MODELS: "opus,sonnet",
+      },
+    ),
+    {
+      command: "pi-agent",
+      args: ["--provider", "bedrock", "--model", "opus", "--models", "opus,sonnet", "hello"],
+    },
+  );
 });
 
 test("forwards cursor and pi environment-backed options", () => {
@@ -374,6 +413,74 @@ test("CLI --json prints raw trace output", async () => {
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
+});
+
+test("CLI --tmux launches an interactive tmux session and sends the prompt", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "tmux.jsonl");
+    const promptFile = join(dir, "prompt.md");
+    writeFileSync(promptFile, "hello world");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(
+      ["codex", "--prompt-file", promptFile, "--model", "gpt-next", "--work-dir", dir, "--tmux"],
+      {
+        env: { ...process.env, HEADLESS_TMUX_CAPTURE: captureFile, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+        stdout: (text) => stdout.push(text),
+      },
+    );
+
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const sessionName = calls[0][3];
+    assert.equal(code, 0);
+    assert.deepEqual(calls, [
+      ["new-session", "-d", "-s", sessionName, "-c", dir, "codex --model gpt-next hello\\ world"],
+    ]);
+    assert.match(sessionName, /^headless-codex-\d+$/);
+    assert.match(stdout.join(""), new RegExp(`tmux attach-session -t ${sessionName}`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --tmux --print-command prints tmux commands without executing them", async () => {
+  const stdout: string[] = [];
+  const code = await runCli(["pi", "--prompt", "hello world", "--tmux", "--print-command"], {
+    stdout: (text) => stdout.push(text),
+  });
+
+  assert.equal(code, 0);
+  assert.match(stdout.join(""), /^tmux new-session -d -s headless-pi-\d+ -c /);
+  assert.match(stdout.join(""), /pi/);
+  assert.match(stdout.join(""), /hello/);
+  assert.match(stdout.join(""), /world/);
+  assert.doesNotMatch(stdout.join(""), /send-keys/);
+});
+
+test("CLI rejects --json with --tmux", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["codex", "--prompt", "hello", "--json", "--tmux"], {
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /--json cannot be used with --tmux/);
 });
 
 test("CLI suppresses known Gemini startup warnings", async () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -121,7 +121,7 @@ test("builds interactive commands for tmux mode", () => {
 
   assert.deepEqual(buildInteractiveAgentCommand("claude", { prompt: "hello", model: "sonnet" }, {}), {
     command: "claude",
-    args: ["--model", "sonnet", "hello"],
+    args: ["--model", "sonnet", "--dangerously-skip-permissions", "hello"],
   });
 
   assert.deepEqual(buildInteractiveAgentCommand("gemini", { prompt: "hello", model: "gemini-model" }, {}), {
@@ -454,6 +454,52 @@ test("CLI --tmux launches an interactive tmux session and sends the prompt", asy
     ]);
     assert.match(sessionName, /^headless-codex-\d+$/);
     assert.match(stdout.join(""), new RegExp(`tmux attach-session -t ${sessionName}`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --tmux marks Claude workspaces trusted before launch", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const homeDir = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const projectDir = join(dir, "project");
+    const captureFile = join(dir, "tmux.jsonl");
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    writeFileSync(join(homeDir, ".claude.json"), JSON.stringify({ projects: { "/existing": { keep: true } } }));
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const code = await runCli(["claude", "--prompt", "hello", "--work-dir", projectDir, "--tmux"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_CAPTURE: captureFile,
+        HOME: homeDir,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: () => undefined,
+    });
+
+    const config = JSON.parse(readFileSync(join(homeDir, ".claude.json"), "utf8"));
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(code, 0);
+    assert.deepEqual(config.projects["/existing"], { keep: true });
+    assert.equal(config.projects[realpathSync(projectDir)].hasTrustDialogAccepted, true);
+    assert.match(calls[0][6], /claude .*--dangerously-skip-permissions .*hello/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -640,6 +640,108 @@ test("CLI --tmux --print-command includes opencode Enter submit command", async 
   assert.match(stdout.join(""), /\ntmux send-keys -t headless-opencode-\d+ Enter\n$/);
 });
 
+test("CLI --list lists active headless tmux sessions", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}') process.exit(2);",
+          "process.stdout.write('headless-codex-123\\nother\\nheadless-opencode-456\\nheadless-unknown-789\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["--list"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(
+      stdout.join(""),
+      [
+        "headless-codex-123\tcodex\ttmux attach-session -t headless-codex-123",
+        "headless-opencode-456\topencode\ttmux attach-session -t headless-opencode-456",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI agent --list filters active headless tmux sessions by agent", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "process.stdout.write('headless-codex-123\\nheadless-opencode-456\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["opencode", "--list"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "headless-opencode-456\topencode\ttmux attach-session -t headless-opencode-456\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --list treats missing tmux server as no active sessions", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "process.stderr.write('no server running on /private/tmp/tmux-501/default\\n');",
+          "process.exit(1);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["--list"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "No active headless tmux sessions\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI rejects --json with --tmux", async () => {
   const stderr: string[] = [];
   const code = await runCli(["codex", "--prompt", "hello", "--json", "--tmux"], {


### PR DESCRIPTION
## Summary
- add `--tmux` interactive launch mode for supported agents
- pre-trust Claude and Cursor workspaces and skip Gemini trust prompts in tmux mode
- make OpenCode tmux prompt submission reliable via wake, tmux buffer paste, and delayed Enter
- add `--list` to show active Headless-created tmux sessions

## Why
Detached tmux agent sessions need to start without blocking on workspace trust prompts and need the initial prompt to be submitted reliably. This also makes active Headless tmux sessions discoverable from the CLI.

## Testing
- `npm run check`
- real temp-HOME OpenCode tmux smoke test: prompt submitted and pane entered running state
- `headless --list` local smoke test
