### PR TITLE
feat: stream agent traces in real time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added `--debug` mode to stream the raw agent trace and append the extracted final assistant message.
+- Changed `--json` mode to stream raw agent trace output in real time instead of printing one final buffered dump.
+
 ## 0.1.0 - 2026-04-24
 
 - Initial npm release of Headless CLI as `@roberttlange/headless`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ printf "Review this diff" | headless pi --model claude-opus
 
 Pass `--allow read-only` to use each agent's read-only/planning mode where available. Pass `--allow yolo` to explicitly request each agent's native auto-approve/bypass mode. When `--allow` is omitted, Headless preserves its existing default command shapes.
 
-By default, Headless prints the agent's final assistant message. Pass `--json` to print the raw native JSON trace.
+By default, Headless prints the agent's final assistant message. Pass `--json` to stream the raw native JSON trace.
 When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`.
 
 ## 3 Execution Modes
@@ -93,7 +93,7 @@ headless codex --prompt "Fix the failing tests"
 
 ### 2) JSON mode (`--json`)
 
-JSON mode runs headless in the current terminal and prints the agent's native JSON trace for scripting or post-processing.
+JSON mode runs headless in the current terminal and streams the agent's native JSON trace for scripting or post-processing.
 
 ```bash
 headless pi --prompt "Summarize this repo" --json
@@ -130,7 +130,7 @@ Options:
 - `--model`, `--agent-model`: model override passed to the agent CLI.
 - `--allow`: permission mode, either `read-only` or `yolo`.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
-- `--json`: print the raw agent JSON trace instead of extracting the final message.
+- `--json`: stream the raw agent JSON trace instead of extracting the final message.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
 - `--check`: check which supported agent binaries are installed and print their versions.
 - `--list`: list active tmux sessions created by Headless.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ headless claude --prompt-file prompt.md --work-dir /path/to/project
 headless opencode --show-config
 # Show the backend command without executing it.
 headless gemini --prompt "Summarize the codebase" --print-command
-# Emit structured JSON output for scripting.
+# Stream structured JSON output for scripting.
 headless pi --prompt "Summarize this repo" --json
+# Stream JSON output and append the extracted final message.
+headless codex --prompt "Fix the failing tests" --debug
 # Launch in tmux for persistent interactive sessions.
 headless codex --prompt "Fix the failing tests" --tmux
 # Restrict tool permissions to read-only actions.
@@ -78,10 +80,10 @@ printf "Review this diff" | headless pi --model claude-opus
 
 Pass `--allow read-only` to use each agent's read-only/planning mode where available. Pass `--allow yolo` to explicitly request each agent's native auto-approve/bypass mode. When `--allow` is omitted, Headless preserves its existing default command shapes.
 
-By default, Headless prints the agent's final assistant message. Pass `--json` to stream the raw native JSON trace.
+By default, Headless prints the agent's final assistant message. Pass `--json` to stream the raw native JSON trace, or `--debug` to stream the trace and append the extracted final message.
 When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`.
 
-## 3 Execution Modes
+## 4 Execution Modes
 
 ### 1) Raw mode (default)
 
@@ -101,7 +103,17 @@ headless pi --prompt "Summarize this repo" --json
 
 `--json` only applies to headless execution and cannot be combined with `--tmux`.
 
-### 3) tmux mode (`--tmux`)
+### 3) Debug mode (`--debug`)
+
+Debug mode runs headless in the current terminal, streams the agent's native JSON trace, then appends the extracted final assistant message.
+
+```bash
+headless codex --prompt "Fix the failing tests" --debug
+```
+
+`--debug` only applies to headless execution and cannot be combined with `--json` or `--tmux`.
+
+### 4) tmux mode (`--tmux`)
 
 tmux mode creates a detached session named `headless-<agent>-<pid>`, starts the selected agent in interactive mode with the prompt as its initial message, prints an attach command, and exits.
 
@@ -131,6 +143,7 @@ Options:
 - `--allow`: permission mode, either `read-only` or `yolo`.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.
+- `--debug`: stream the raw agent JSON trace and append the extracted final message.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
 - `--check`: check which supported agent binaries are installed and print their versions.
 - `--list`: list active tmux sessions created by Headless.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ interface ParsedArgs {
   allow?: AllowMode;
   workDir?: string;
   json: boolean;
+  debug: boolean;
   printCommand: boolean;
   showConfig: boolean;
   check: boolean;
@@ -70,7 +71,8 @@ function usage(): string {
     "  --prompt, -p <text>   Prompt text.",
     "  --prompt-file <path>  Read prompt from a file.",
     "  --work-dir, -C <path> Run from this directory.",
-    "  --json               Print raw agent JSON trace output.",
+    "  --json               Stream raw agent JSON trace output.",
+    "  --debug              Stream raw trace and print extracted final message.",
     "  --tmux               Launch an interactive agent in a tmux session.",
     "  --check              Check installed agent binaries and versions.",
     "  --list               List active headless tmux sessions.",
@@ -86,6 +88,7 @@ function usage(): string {
 function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     json: false,
+    debug: false,
     printCommand: false,
     showConfig: false,
     check: false,
@@ -140,6 +143,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--json":
         parsed.json = true;
+        break;
+      case "--debug":
+        parsed.debug = true;
         break;
       case "--tmux":
         parsed.tmux = true;
@@ -634,6 +640,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.tmux && parsed.json) {
       throw new CliError("--json cannot be used with --tmux");
     }
+    if (parsed.debug && parsed.json) {
+      throw new CliError("--debug cannot be used with --json");
+    }
+    if (parsed.debug && parsed.tmux) {
+      throw new CliError("--debug cannot be used with --tmux");
+    }
     if (parsed.showConfig) {
       stdout(renderConfig(parsed.agent));
       return 0;
@@ -693,14 +705,28 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return 0;
     }
 
-    const result = await executeCommand(parsed.agent, command, cwd, env, stderr, parsed.json ? stdout : undefined);
+    const result = await executeCommand(
+      parsed.agent,
+      command,
+      cwd,
+      env,
+      stderr,
+      parsed.json || parsed.debug ? stdout : undefined,
+    );
     if (parsed.json) {
       return result.code;
     }
 
     const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
     if (finalMessage) {
-      stdout(`${finalMessage}\n`);
+      if (parsed.debug) {
+        if (!result.stdout.endsWith("\n")) {
+          stdout("\n");
+        }
+        stdout(`--- final message ---\n${finalMessage}\n`);
+      } else {
+        stdout(`${finalMessage}\n`);
+      }
       return result.code;
     }
     if (result.code === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -303,6 +303,13 @@ interface HeadlessTmuxSession {
   agent: AgentName;
 }
 
+type StdoutHandling = "capture" | "stream" | "capture-and-stream";
+
+interface ExecuteCommandOptions {
+  stdoutHandling: StdoutHandling;
+  stdout: (text: string) => void;
+}
+
 function suppressKnownStderr(agent: AgentName, text: string): string {
   if (agent !== "gemini") {
     return text;
@@ -329,7 +336,7 @@ async function executeCommand(
   cwd: string | undefined,
   env: Env,
   stderr: (text: string) => void,
-  stdout?: (text: string) => void,
+  options: ExecuteCommandOptions,
 ): Promise<ExecuteResult> {
   let stdinFd: number | undefined;
   const stdio: ["ignore" | "pipe" | number, "pipe", "pipe"] = [
@@ -357,8 +364,12 @@ async function executeCommand(
       }
       child.stdout?.setEncoding("utf8");
       child.stdout?.on("data", (chunk: string) => {
-        capturedStdout += chunk;
-        stdout?.(chunk);
+        if (options.stdoutHandling !== "stream") {
+          capturedStdout += chunk;
+        }
+        if (options.stdoutHandling !== "capture") {
+          options.stdout(chunk);
+        }
       });
       child.stderr?.setEncoding("utf8");
       child.stderr?.on("data", (chunk: string) => {
@@ -705,14 +716,15 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return 0;
     }
 
-    const result = await executeCommand(
-      parsed.agent,
-      command,
-      cwd,
-      env,
-      stderr,
-      parsed.json || parsed.debug ? stdout : undefined,
-    );
+    const stdoutHandling: StdoutHandling = parsed.json
+      ? "stream"
+      : parsed.debug
+        ? "capture-and-stream"
+        : "capture";
+    const result = await executeCommand(parsed.agent, command, cwd, env, stderr, {
+      stdout,
+      stdoutHandling,
+    });
     if (parsed.json) {
       return result.code;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -323,6 +323,7 @@ async function executeCommand(
   cwd: string | undefined,
   env: Env,
   stderr: (text: string) => void,
+  stdout?: (text: string) => void,
 ): Promise<ExecuteResult> {
   let stdinFd: number | undefined;
   const stdio: ["ignore" | "pipe" | number, "pipe", "pipe"] = [
@@ -351,6 +352,7 @@ async function executeCommand(
       child.stdout?.setEncoding("utf8");
       child.stdout?.on("data", (chunk: string) => {
         capturedStdout += chunk;
+        stdout?.(chunk);
       });
       child.stderr?.setEncoding("utf8");
       child.stderr?.on("data", (chunk: string) => {
@@ -691,9 +693,8 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return 0;
     }
 
-    const result = await executeCommand(parsed.agent, command, cwd, env, stderr);
+    const result = await executeCommand(parsed.agent, command, cwd, env, stderr, parsed.json ? stdout : undefined);
     if (parsed.json) {
-      stdout(result.stdout);
       return result.code;
     }
 

--- a/tests/debug.test.ts
+++ b/tests/debug.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { runCli } from "../src/cli.ts";
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    if (assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(assertion(), true);
+}
+
+test("CLI --debug streams raw trace and appends extracted final message", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const firstChunk = `${JSON.stringify({
+      type: "message",
+      message: { role: "toolresult", content: [{ type: "text", text: "tool output" }] },
+    })}\n`;
+    const secondChunk = `${JSON.stringify({
+      type: "message",
+      message: { role: "assistant", content: [{ type: "text", text: "final answer" }] },
+    })}\n`;
+    await mkdir(binDir);
+    const binary = join(binDir, "pi");
+    await writeFile(
+      binary,
+      [
+        "#!/usr/bin/env node",
+        `process.stdout.write(${JSON.stringify(firstChunk)});`,
+        `setTimeout(() => { process.stdout.write(${JSON.stringify(secondChunk)}); }, 500);`,
+        "",
+      ].join("\n"),
+    );
+    await chmod(binary, 0o755);
+
+    const stdout: string[] = [];
+    let completed = false;
+    const result = runCli(["pi", "--prompt", "hello", "--debug"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    }).finally(() => {
+      completed = true;
+    });
+
+    await waitFor(() => stdout.join("").startsWith(firstChunk) && !completed);
+
+    const code = await result;
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), `${firstChunk}${secondChunk}--- final message ---\nfinal answer\n`);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --debug separates final message label from traces without trailing newlines", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const trace = JSON.stringify({
+      type: "message",
+      message: { role: "assistant", content: [{ type: "text", text: "final answer" }] },
+    });
+    await mkdir(binDir);
+    const binary = join(binDir, "pi");
+    await writeFile(
+      binary,
+      [
+        "#!/usr/bin/env node",
+        `process.stdout.write(${JSON.stringify(trace)});`,
+        "",
+      ].join("\n"),
+    );
+    await chmod(binary, 0o755);
+
+    const stdout: string[] = [];
+    const code = await runCli(["pi", "--prompt", "hello", "--debug"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), `${trace}\n--- final message ---\nfinal answer\n`);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI rejects --debug with conflicting output modes", async () => {
+  const stderr: string[] = [];
+  assert.equal(
+    await runCli(["codex", "--prompt", "hello", "--debug", "--json"], {
+      stderr: (text) => stderr.push(text),
+    }),
+    2,
+  );
+  assert.match(stderr.join(""), /--debug cannot be used with --json/);
+
+  stderr.length = 0;
+  assert.equal(
+    await runCli(["codex", "--prompt", "hello", "--debug", "--tmux"], {
+      stderr: (text) => stderr.push(text),
+    }),
+    2,
+  );
+  assert.match(stderr.join(""), /--debug cannot be used with --tmux/);
+});

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -9,8 +9,18 @@ import { fileURLToPath } from "node:url";
 import { buildAgentCommand, buildInteractiveAgentCommand, getAgentConfig, listAgents } from "../src/agents.ts";
 import { runCli } from "../src/cli.ts";
 import { quoteCommand } from "../src/shell.ts";
+import type { AgentName } from "../src/types.ts";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(assertion(), true);
+}
 
 test("lists all supported agents", () => {
   assert.deepEqual(listAgents(), ["claude", "codex", "cursor", "gemini", "opencode", "pi"]);
@@ -412,6 +422,58 @@ test("CLI --json prints raw trace output", async () => {
     assert.equal(stdout.join(""), trace);
   } finally {
     rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --json streams raw trace output for every provider", async () => {
+  const providerBinaries: Record<AgentName, string> = {
+    claude: "claude",
+    codex: "codex",
+    cursor: "agent",
+    gemini: "gemini",
+    opencode: "opencode",
+    pi: "pi",
+  };
+
+  for (const [agent, binaryName] of Object.entries(providerBinaries) as [AgentName, string][]) {
+    const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+    try {
+      const binDir = join(dir, "bin");
+      const firstChunk = `${agent}:first\n`;
+      const secondChunk = `${agent}:second\n`;
+      await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+        await mkdir(binDir);
+        const binary = join(binDir, binaryName);
+        await writeFile(
+          binary,
+          [
+            "#!/usr/bin/env node",
+            `process.stdout.write(${JSON.stringify(firstChunk)});`,
+            `setTimeout(() => { process.stdout.write(${JSON.stringify(secondChunk)}); }, 120);`,
+            "",
+          ].join("\n"),
+        );
+        await chmod(binary, 0o755);
+      });
+
+      const stdout: string[] = [];
+      let completed = false;
+      const result = runCli([agent, "--prompt", "hello", "--json"], {
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+        stdout: (text) => stdout.push(text),
+      }).finally(() => {
+        completed = true;
+      });
+
+      await waitFor(() => stdout.join("") === firstChunk);
+      assert.equal(completed, false);
+
+      const code = await result;
+      assert.equal(code, 0);
+      assert.equal(stdout.join(""), `${firstChunk}${secondChunk}`);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   }
 });
 

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -465,7 +465,7 @@ test("CLI --json streams raw trace output for every provider", async () => {
         completed = true;
       });
 
-      await waitFor(() => stdout.join("") === firstChunk);
+      await waitFor(() => stdout.join("").startsWith(firstChunk) && !completed);
       assert.equal(completed, false);
 
       const code = await result;


### PR DESCRIPTION
## What changed
- Stream `--json` raw agent trace output in real time instead of buffering until process exit.
- Add `--debug` mode that streams the raw trace and appends the extracted final assistant message.
- Document the new streaming/debug behavior and update the changelog for the next release.

## Why
- Makes long-running provider traces observable while still preserving final-message extraction when needed.

## How to test
- `npm run check`
- Global smoke-tested `headless pi --prompt hello --debug` with a fake provider binary.

## Context
- `--debug` is mutually exclusive with `--json` and `--tmux`.
- Existing default mode remains final-message-only.