### PR TITLE
feat: add Docker execution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added Docker execution mode, Docker setup checks, local image builds, and packaged Docker image support. Thanks @RobertTLange for PR #3.
+
 ## 0.1.1 - 2026-04-24
 
 - Added `--debug` mode to stream the raw agent trace and append the extracted final assistant message.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,33 @@
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash ca-certificates curl git ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g \
-  @anthropic-ai/claude-code \
-  @google/gemini-cli \
-  @mariozechner/pi-coding-agent \
-  @openai/codex \
-  opencode-ai
+  @anthropic-ai/claude-code@2.1.119 \
+  @google/gemini-cli@0.39.1 \
+  @mariozechner/pi-coding-agent@0.70.2 \
+  @openai/codex@0.125.0 \
+  opencode-ai@1.14.25
 
-RUN curl https://cursor.com/install -fsS | bash \
-  && cursor_agent_dir="$(dirname "$(readlink -f /root/.local/bin/cursor-agent)")" \
-  && mkdir -p /opt/cursor-agent \
-  && cp -R "${cursor_agent_dir}/." /opt/cursor-agent/ \
+ARG TARGETARCH
+ARG CURSOR_AGENT_VERSION=2026.04.17-787b533
+ARG CURSOR_AGENT_SHA256_AMD64=942b2b583239497715f2390336eb8e2df3673703bd167bd59f7be33a27e15c5a
+ARG CURSOR_AGENT_SHA256_ARM64=985191ffc606da1317e1399f99306481f58643f345ed2252033b011504c780ce
+
+RUN set -eu; \
+  case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+    amd64) cursor_arch="x64"; cursor_sha256="${CURSOR_AGENT_SHA256_AMD64}" ;; \
+    arm64) cursor_arch="arm64"; cursor_sha256="${CURSOR_AGENT_SHA256_ARM64}" ;; \
+    *) echo "unsupported Cursor Agent architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
+  esac; \
+  cursor_tarball="/tmp/cursor-agent.tar.gz"; \
+  curl "https://downloads.cursor.com/lab/${CURSOR_AGENT_VERSION}/linux/${cursor_arch}/agent-cli-package.tar.gz" -fsSL -o "${cursor_tarball}"; \
+  echo "${cursor_sha256}  ${cursor_tarball}" | sha256sum -c -; \
+  mkdir -p /opt/cursor-agent \
+  && tar --strip-components=1 -xzf "${cursor_tarball}" -C /opt/cursor-agent \
+  && rm -f "${cursor_tarball}" \
   && ln -sf /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent \
   && ln -sf /usr/local/bin/cursor-agent /usr/local/bin/agent
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN npm install -g \
   opencode-ai
 
 RUN curl https://cursor.com/install -fsS | bash \
-  && if command -v cursor-agent >/dev/null 2>&1 && ! command -v agent >/dev/null 2>&1; then \
-    ln -s "$(command -v cursor-agent)" /usr/local/bin/agent; \
-  fi
+  && cursor_agent_dir="$(dirname "$(readlink -f /root/.local/bin/cursor-agent)")" \
+  && mkdir -p /opt/cursor-agent \
+  && cp -R "${cursor_agent_dir}/." /opt/cursor-agent/ \
+  && ln -sf /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent \
+  && ln -sf /usr/local/bin/cursor-agent /usr/local/bin/agent
 
 ENV PATH="/root/.local/bin:/root/.cursor/bin:/root/.cursor/cli/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl git ripgrep \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g \
+  @anthropic-ai/claude-code \
+  @google/gemini-cli \
+  @mariozechner/pi-coding-agent \
+  @openai/codex \
+  opencode-ai
+
+RUN curl https://cursor.com/install -fsS | bash \
+  && if command -v cursor-agent >/dev/null 2>&1 && ! command -v agent >/dev/null 2>&1; then \
+    ln -s "$(command -v cursor-agent)" /usr/local/bin/agent; \
+  fi
+
+ENV PATH="/root/.local/bin:/root/.cursor/bin:/root/.cursor/cli/bin:${PATH}"
+
+WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ headless codex --prompt "Fix the failing tests" --debug
 
 ### 4) Docker mode (`--docker`)
 
-Docker mode wraps one-shot headless execution in `docker run --rm`. It mounts the target workdir at the same absolute path inside the container, mounts existing agent config/auth seed paths read-only, passes a curated set of credential environment variables, and runs the selected agent from `ghcr.io/RobertTLange/headless:latest` by default.
+Docker mode wraps one-shot headless execution in `docker run --rm`. It mounts the target workdir at the same absolute path inside the container, mounts existing agent config/auth seed paths read-only, passes a curated set of credential environment variables, and runs the selected agent from `ghcr.io/roberttlange/headless:latest` by default.
 
 ```bash
 headless codex --prompt "Fix the failing tests" --docker
@@ -136,7 +136,7 @@ headless gemini --prompt "Inspect this repo" --docker --docker-arg --network=hos
 
 Docker mode is only for headless execution. It cannot be combined with `--tmux`, `send`, `rename`, or `--list`.
 
-The default image contract is simple: every supported agent binary is available on `PATH`, and the image has no required entrypoint. Plain `--docker` uses `ghcr.io/RobertTLange/headless:latest`; Docker will pull it automatically if it is not local. Headless never auto-builds images during agent execution.
+The default image contract is simple: every supported agent binary is available on `PATH`, and the image has no required entrypoint. Plain `--docker` uses `ghcr.io/roberttlange/headless:latest`; Docker will pull it automatically if it is not local. Headless never auto-builds images during agent execution.
 
 For local development or when the default image has not been published yet, build the packaged Dockerfile explicitly:
 
@@ -191,7 +191,7 @@ Options:
 - `--allow`: permission mode, either `read-only` or `yolo`.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--docker`: run the agent inside Docker for one-shot headless execution.
-- `--docker-image`: Docker image override. Defaults to `ghcr.io/RobertTLange/headless:latest`.
+- `--docker-image`: Docker image override. Defaults to `ghcr.io/roberttlange/headless:latest`.
 - `--docker-arg`: extra `docker run` argument. Repeat for multiple args.
 - `--docker-env`: pass env into Docker as `NAME` or `NAME=value`. Repeatable.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ headless pi --prompt "Summarize this repo" --json
 headless codex --prompt "Fix the failing tests" --debug
 # Launch in tmux for persistent interactive sessions.
 headless codex --prompt "Fix the failing tests" --tmux
+# Run the agent inside the default Docker image.
+headless codex --prompt "Fix the failing tests" --docker
+# Check Docker setup and image availability.
+headless docker doctor
 # Restrict tool permissions to read-only actions.
 headless codex --allow read-only --prompt "Review this repo"
 # Allow all tools for autonomous execution.
@@ -83,7 +87,7 @@ By default, Headless uses each agent's native auto-approve/bypass mode. Pass `--
 By default, Headless prints the agent's final assistant message. Pass `--json` to stream the raw native JSON trace, or `--debug` to stream the trace and append the extracted final message.
 When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`.
 
-## 4 Execution Modes
+## 5 Execution Modes
 
 ### 1) Raw mode (default)
 
@@ -113,7 +117,38 @@ headless codex --prompt "Fix the failing tests" --debug
 
 `--debug` only applies to headless execution and cannot be combined with `--json` or `--tmux`.
 
-### 4) tmux mode (`--tmux`)
+### 4) Docker mode (`--docker`)
+
+Docker mode wraps one-shot headless execution in `docker run --rm`. It mounts the target workdir at the same absolute path inside the container, mounts existing agent config/auth seed paths read-only, passes a curated set of credential environment variables, and runs the selected agent from `ghcr.io/RobertTLange/headless:latest` by default.
+
+```bash
+headless codex --prompt "Fix the failing tests" --docker
+headless claude --prompt-file task.md --work-dir /path/to/project --docker
+headless pi --prompt "Summarize this repo" --docker --docker-image custom/headless:dev
+```
+
+Use `--docker-env NAME` to pass one extra host environment variable, `--docker-env NAME=value` to set one inline value, and repeat `--docker-arg <arg>` for additional `docker run` arguments.
+
+```bash
+headless codex --prompt "Use the private provider" --docker --docker-env OPENROUTER_API_KEY
+headless gemini --prompt "Inspect this repo" --docker --docker-arg --network=host
+```
+
+Docker mode is only for headless execution. It cannot be combined with `--tmux`, `send`, `rename`, or `--list`.
+
+The default image contract is simple: every supported agent binary is available on `PATH`, and the image has no required entrypoint. Plain `--docker` uses `ghcr.io/RobertTLange/headless:latest`; Docker will pull it automatically if it is not local. Headless never auto-builds images during agent execution.
+
+For local development or when the default image has not been published yet, build the packaged Dockerfile explicitly:
+
+```bash
+headless docker doctor
+headless docker build
+headless codex --prompt "Fix the failing tests" --docker --docker-image headless-local:dev
+```
+
+Use `headless docker build --docker-image <image>` to choose a different local tag.
+
+### 5) tmux mode (`--tmux`)
 
 tmux mode creates a detached session named `headless-<agent>-<pid>`, starts the selected agent in interactive mode with the prompt as its initial message, prints an attach command, and exits. Pass `--name <name>` to create a stable managed session name like `headless-codex-work`.
 
@@ -142,6 +177,8 @@ headless send headless-codex-work --prompt "Run the focused tests now"
 
 ```bash
 headless [agent] (--prompt <text> | --prompt-file <path> | --check | --list | --show-config) [options]
+headless docker doctor [options]
+headless docker build [options]
 headless send <session-name> (--prompt <text> | --prompt-file <path>) [options]
 headless rename <session-name> <new-name> [options]
 ```
@@ -153,12 +190,18 @@ Options:
 - `--model`, `--agent-model`: model override passed to the agent CLI.
 - `--allow`: permission mode, either `read-only` or `yolo`.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
+- `--docker`: run the agent inside Docker for one-shot headless execution.
+- `--docker-image`: Docker image override. Defaults to `ghcr.io/RobertTLange/headless:latest`.
+- `--docker-arg`: extra `docker run` argument. Repeat for multiple args.
+- `--docker-env`: pass env into Docker as `NAME` or `NAME=value`. Repeatable.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.
 - `--debug`: stream the raw agent JSON trace and append the extracted final message.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
 - `--name`: use a stable managed session name with `--tmux`.
 - `send <session-name>`: send a message to an existing Headless tmux session.
 - `rename <session-name> <new-name>`: rename an existing Headless tmux session.
+- `docker doctor`: check Docker setup and image availability.
+- `docker build`: build the packaged Dockerfile as `headless-local:dev`, or `--docker-image <image>`.
 - `--check`: check which supported agent binaries are installed and print their versions.
 - `--list`: list active tmux sessions created by Headless, including state and timestamps.
 - `--print-command`: print the shell command without executing it.
@@ -176,6 +219,8 @@ If no prompt or prompt file is supplied, Headless reads from piped stdin.
 - `PI_CODING_AGENT_PROVIDER`: passed to Pi as `--provider`.
 - `PI_CODING_AGENT_MODEL`: default Pi model when `--model` is omitted.
 - `PI_CODING_AGENT_MODELS`: passed to Pi as `--models`.
+
+Docker mode also passes common agent/provider credential variables when present, including `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, Cursor/Pi credential variables, common AWS variables, and OpenAI-compatible endpoint variables. Use `--docker-env` for anything else.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "files": [
+    "Dockerfile",
     "dist"
   ],
   "scripts": {

--- a/src/check.ts
+++ b/src/check.ts
@@ -18,6 +18,14 @@ interface AgentCheck {
   version: string;
 }
 
+interface DockerCheck {
+  command: string;
+  available: boolean;
+  version: string;
+  image: string;
+  imageAvailable: boolean;
+}
+
 export function commandForAgent(agent: AgentName, env: Env): string {
   if (agent === "cursor") {
     return env.CURSOR_CLI_BIN || "agent";
@@ -72,11 +80,26 @@ async function captureVersion(executable: string, env: Env): Promise<string> {
 }
 
 async function captureVersionOnce(executable: string, env: Env): Promise<string> {
-  const result = await new Promise<CaptureResult>((resolve) => {
+  const result = await captureCommand(executable, ["--version"], env, versionTimeoutMs);
+
+  if (result.code !== 0) {
+    return "unknown";
+  }
+  const stdoutVersion = normalizeVersion(result.stdout);
+  return stdoutVersion === "unknown" ? normalizeVersion(result.stderr) : stdoutVersion;
+}
+
+async function captureCommand(
+  executable: string,
+  args: string[],
+  env: Env,
+  timeoutMs: number,
+): Promise<CaptureResult> {
+  return await new Promise<CaptureResult>((resolve) => {
     let stdout = "";
     let stderr = "";
     let settled = false;
-    const child = spawn(executable, ["--version"], {
+    const child = spawn(executable, args, {
       env: env as NodeJS.ProcessEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -85,7 +108,7 @@ async function captureVersionOnce(executable: string, env: Env): Promise<string>
       settled = true;
       child.kill();
       resolve({ code: 124, stdout, stderr });
-    }, versionTimeoutMs);
+    }, timeoutMs);
     const finish = (result: CaptureResult) => {
       if (settled) return;
       settled = true;
@@ -109,12 +132,6 @@ async function captureVersionOnce(executable: string, env: Env): Promise<string>
       finish({ code: signal ? 1 : (code ?? 1), stdout, stderr });
     });
   });
-
-  if (result.code !== 0) {
-    return "unknown";
-  }
-  const stdoutVersion = normalizeVersion(result.stdout);
-  return stdoutVersion === "unknown" ? normalizeVersion(result.stderr) : stdoutVersion;
 }
 
 function normalizeVersion(output: string): string {
@@ -144,6 +161,24 @@ export async function checkAgents(env: Env): Promise<AgentCheck[]> {
   );
 }
 
+export async function checkDocker(env: Env, image: string): Promise<DockerCheck> {
+  const command = "docker";
+  const executable = findExecutable(command, env);
+  if (!executable) {
+    return { command, available: false, version: "-", image, imageAvailable: false };
+  }
+
+  const version = await captureVersion(executable, env);
+  const imageInspect = await captureCommand(executable, ["image", "inspect", image], env, versionTimeoutMs);
+  return {
+    command,
+    available: true,
+    version,
+    image,
+    imageAvailable: imageInspect.code === 0,
+  };
+}
+
 export function renderAgentChecks(checks: AgentCheck[]): string {
   const rows = [
     ["Agent", "Status", "Version", "Binary"],
@@ -154,6 +189,26 @@ export function renderAgentChecks(checks: AgentCheck[]): string {
       check.command,
     ]),
   ];
+  const widths = rows[0].map((_, column) => Math.max(...rows.map((row) => row[column].length)));
+  return rows
+    .map((row) => row.map((cell, index) => cell.padEnd(widths[index])).join("  ").trimEnd())
+    .join("\n")
+    .concat("\n");
+}
+
+export function renderDockerCheck(check: DockerCheck): string {
+  return renderRows([
+    ["Docker", "Status", "Version", "Default image"],
+    [
+      check.command,
+      check.available ? "✓" : "✗",
+      check.version,
+      check.available ? `${check.image} (${check.imageAvailable ? "present" : "missing"})` : check.image,
+    ],
+  ]);
+}
+
+function renderRows(rows: string[][]): string {
   const widths = rows[0].map((_, column) => Math.max(...rows.map((row) => row[column].length)));
   return rows
     .map((row) => row.map((cell, index) => cell.padEnd(widths[index])).join("  ").trimEnd())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,7 +93,7 @@ function usage(): string {
     "  --prompt-file <path>  Read prompt from a file.",
     "  --work-dir, -C <path> Run from this directory.",
     "  --docker             Run the agent inside Docker.",
-    "  --docker-image <img> Docker image. Defaults to ghcr.io/RobertTLange/headless:latest.",
+    "  --docker-image <img> Docker image. Defaults to ghcr.io/roberttlange/headless:latest.",
     "  --docker-arg <arg>   Extra docker run argument. Repeat for multiple args.",
     "  --docker-env <env>   Pass env into Docker as NAME or NAME=value. Repeatable.",
     "  --json               Stream raw agent JSON trace output.",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { spawn } from "node:child_process";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -22,7 +22,13 @@ import {
   isAgentName,
   listAgents,
 } from "./agents.js";
-import { checkAgents, commandExists, commandForAgent, renderAgentChecks } from "./check.js";
+import { checkAgents, checkDocker, commandExists, commandForAgent, renderAgentChecks, renderDockerCheck } from "./check.js";
+import {
+  buildDockerAgentCommand,
+  DEFAULT_DOCKER_IMAGE,
+  LOCAL_DOCKER_IMAGE,
+  detectDockerHostUser,
+} from "./docker.js";
 import { extractFinalMessage } from "./output.js";
 import { quoteCommand } from "./shell.js";
 import type { AgentName, AllowMode, BuiltCommand, Env } from "./types.js";
@@ -33,6 +39,7 @@ interface ParsedArgs {
   rename: boolean;
   renameSession?: string;
   renameName?: string;
+  dockerCommand?: "build" | "doctor";
   agent?: AgentName;
   prompt?: string;
   promptFile?: string;
@@ -40,6 +47,10 @@ interface ParsedArgs {
   allow?: AllowMode;
   workDir?: string;
   tmuxName?: string;
+  docker: boolean;
+  dockerImage?: string;
+  dockerArgs: string[];
+  dockerEnv: string[];
   json: boolean;
   debug: boolean;
   printCommand: boolean;
@@ -68,6 +79,8 @@ class CliError extends Error {
 function usage(): string {
   return [
     "Usage: headless [agent] (--prompt <text> | --prompt-file <path> | --check | --list | --show-config) [options]",
+    "       headless docker doctor [options]",
+    "       headless docker build [options]",
     "       headless send <session-name> (--prompt <text> | --prompt-file <path>) [options]",
     "       headless rename <session-name> <new-name> [options]",
     "",
@@ -79,12 +92,18 @@ function usage(): string {
     "  --prompt, -p <text>   Prompt text.",
     "  --prompt-file <path>  Read prompt from a file.",
     "  --work-dir, -C <path> Run from this directory.",
+    "  --docker             Run the agent inside Docker.",
+    "  --docker-image <img> Docker image. Defaults to ghcr.io/RobertTLange/headless:latest.",
+    "  --docker-arg <arg>   Extra docker run argument. Repeat for multiple args.",
+    "  --docker-env <env>   Pass env into Docker as NAME or NAME=value. Repeatable.",
     "  --json               Stream raw agent JSON trace output.",
     "  --debug              Stream raw trace and print extracted final message.",
     "  --tmux               Launch an interactive agent in a tmux session.",
     "  --name <name>        Use a managed tmux session name with --tmux.",
     "  send <session-name>  Send a message to an existing headless tmux session.",
     "  rename <session> <name> Rename an existing headless tmux session.",
+    "  docker doctor       Check Docker setup and image availability.",
+    "  docker build        Build the local Docker image tag headless-local:dev.",
     "  --check              Check installed agent binaries and versions.",
     "  --list               List active headless tmux sessions.",
     "  --print-command      Print the command without executing it.",
@@ -100,6 +119,9 @@ function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     send: false,
     rename: false,
+    docker: false,
+    dockerArgs: [],
+    dockerEnv: [],
     json: false,
     debug: false,
     printCommand: false,
@@ -129,6 +151,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     parsed.send = true;
   } else if (first === "rename") {
     parsed.rename = true;
+  } else if (first === "docker") {
+    parsed.dockerCommand = parseDockerCommand(args.shift());
   } else if (isAgentName(first)) {
     parsed.agent = first;
   } else if (first.startsWith("-")) {
@@ -157,6 +181,18 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--work-dir":
       case "-C":
         parsed.workDir = takeValue(args, arg);
+        break;
+      case "--docker":
+        parsed.docker = true;
+        break;
+      case "--docker-image":
+        parsed.dockerImage = takeValue(args, arg);
+        break;
+      case "--docker-arg":
+        parsed.dockerArgs.push(takeValue(args, arg));
+        break;
+      case "--docker-env":
+        parsed.dockerEnv.push(parseDockerEnv(takeValue(args, arg)));
         break;
       case "--name":
         parsed.tmuxName = takeValue(args, arg);
@@ -229,6 +265,21 @@ function parseAllowMode(value: string): AllowMode {
   throw new CliError(`unsupported allow mode: ${value}`);
 }
 
+function parseDockerEnv(value: string): string {
+  const name = value.includes("=") ? value.slice(0, value.indexOf("=")) : value;
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new CliError(`invalid docker env: ${value}`);
+  }
+  return value;
+}
+
+function parseDockerCommand(value: string | undefined): "build" | "doctor" {
+  if (value === "build" || value === "doctor") {
+    return value;
+  }
+  throw new CliError("missing docker command; use docker doctor or docker build");
+}
+
 function renderConfig(agent: AgentName): string {
   const config = getAgentConfig(agent);
   return [
@@ -239,6 +290,42 @@ function renderConfig(agent: AgentName): string {
     ...config.seedPaths.map((path) => `  ${path}`),
     "",
   ].join("\n");
+}
+
+function packageRoot(): string {
+  return dirname(dirname(fileURLToPath(import.meta.url)));
+}
+
+function dockerfilePath(): string {
+  return join(packageRoot(), "Dockerfile");
+}
+
+function buildDockerImageCommand(image: string): BuiltCommand {
+  return { command: "docker", args: ["build", "-t", image, "-f", dockerfilePath(), packageRoot()] };
+}
+
+function renderDockerDoctor(check: Awaited<ReturnType<typeof checkDocker>>, image: string): string {
+  const lines = [
+    renderDockerCheck(check).trimEnd(),
+    "",
+    `Default run image: ${DEFAULT_DOCKER_IMAGE}`,
+    `Local build image: ${LOCAL_DOCKER_IMAGE}`,
+    `Dockerfile: ${dockerfilePath()}`,
+  ];
+  if (!check.available) {
+    lines.push("", "Docker is not on PATH. Install/start Docker, then rerun `headless docker doctor`.");
+  } else if (!check.imageAvailable) {
+    lines.push(
+      "",
+      `Image not present locally: ${image}`,
+      "Plain `headless --docker` will let Docker pull the default image automatically.",
+      `For local development, run: headless docker build`,
+      `Then run with: headless codex --docker --docker-image ${LOCAL_DOCKER_IMAGE} --prompt "..."`,
+    );
+  } else {
+    lines.push("", "Docker is ready.");
+  }
+  return `${lines.join("\n")}\n`;
 }
 
 async function readStdin(): Promise<string> {
@@ -362,6 +449,20 @@ interface ExecuteCommandOptions {
 }
 
 function suppressKnownStderr(agent: AgentName, text: string): string {
+  if (agent === "codex") {
+    return text
+      .split(/\r?\n/)
+      .filter((line) => {
+        const trimmed = line.trim();
+        if (!trimmed) return false;
+        if (/ERROR codex_core::session: failed to record rollout items: thread .* not found$/.test(trimmed)) {
+          return false;
+        }
+        return true;
+      })
+      .map((line) => `${line}\n`)
+      .join("");
+  }
   if (agent !== "gemini") {
     return text;
   }
@@ -737,6 +838,7 @@ async function executeSimpleCommand(
   cwd: string | undefined,
   env: Env,
   stderr: (text: string) => void,
+  stdout?: (text: string) => void,
 ): Promise<number> {
   return await new Promise<number>((resolve) => {
     const child = spawn(command.command, command.args, {
@@ -746,7 +848,7 @@ async function executeSimpleCommand(
     });
 
     child.stdout?.setEncoding("utf8");
-    child.stdout?.on("data", () => undefined);
+    child.stdout?.on("data", (chunk: string) => stdout?.(chunk));
     child.stderr?.setEncoding("utf8");
     child.stderr?.on("data", (chunk: string) => stderr(chunk));
     child.on("error", (error) => {
@@ -821,7 +923,40 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       stdout(usage());
       return 0;
     }
+    if (parsed.dockerCommand) {
+      if (parsed.prompt !== undefined || parsed.promptFile !== undefined) {
+        throw new CliError(`--prompt and --prompt-file cannot be used with docker ${parsed.dockerCommand}`);
+      }
+      if (parsed.docker || parsed.dockerArgs.length > 0 || parsed.dockerEnv.length > 0) {
+        throw new CliError(`--docker, --docker-arg, and --docker-env cannot be used with docker ${parsed.dockerCommand}`);
+      }
+      if (parsed.tmux || parsed.json || parsed.debug || parsed.list || parsed.check || parsed.showConfig) {
+        throw new CliError(`unsupported option for docker ${parsed.dockerCommand}`);
+      }
+      if (parsed.dockerCommand === "doctor") {
+        const image = parsed.dockerImage ?? DEFAULT_DOCKER_IMAGE;
+        stdout(renderDockerDoctor(await checkDocker(env, image), image));
+        return 0;
+      }
+
+      const image = parsed.dockerImage ?? LOCAL_DOCKER_IMAGE;
+      const command = buildDockerImageCommand(image);
+      if (!existsSync(dockerfilePath())) {
+        throw new CliError(`Dockerfile not found: ${dockerfilePath()}`);
+      }
+      if (parsed.printCommand) {
+        stdout(`${quoteCommand(command)}\n`);
+        return 0;
+      }
+      if (!commandExists("docker", env)) {
+        throw new CliError("docker not found on PATH");
+      }
+      return await executeSimpleCommand(command, undefined, env, stderr, stdout);
+    }
     if (parsed.rename) {
+      if (parsed.docker) {
+        throw new CliError("--docker cannot be used with rename");
+      }
       if (parsed.tmux) {
         throw new CliError("--tmux cannot be used with rename");
       }
@@ -853,6 +988,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return code;
     }
     if (parsed.send) {
+      if (parsed.docker) {
+        throw new CliError("--docker cannot be used with send");
+      }
       if (parsed.tmux) {
         throw new CliError("--tmux cannot be used with send");
       }
@@ -885,14 +1023,27 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     if (parsed.check) {
       stdout(renderAgentChecks(await checkAgents(env)));
+      stdout(renderDockerCheck(await checkDocker(env, parsed.dockerImage ?? DEFAULT_DOCKER_IMAGE)));
       return 0;
+    }
+    if (parsed.list && parsed.docker) {
+      throw new CliError("--docker cannot be used with --list");
     }
     if (parsed.list) {
       stdout(await listHeadlessTmuxSessions(parsed.agent, env));
       return 0;
     }
+    if (
+      !parsed.docker &&
+      (parsed.dockerImage !== undefined || parsed.dockerArgs.length > 0 || parsed.dockerEnv.length > 0)
+    ) {
+      throw new CliError("--docker-image, --docker-arg, and --docker-env require --docker");
+    }
     if (!parsed.agent) {
-      parsed.agent = selectDefaultAgent(env);
+      parsed.agent = parsed.docker ? autoAgentPreference[0] : selectDefaultAgent(env);
+    }
+    if (parsed.tmux && parsed.docker) {
+      throw new CliError("--docker cannot be used with --tmux");
     }
     if (parsed.tmux && parsed.json) {
       throw new CliError("--json cannot be used with --tmux");
@@ -949,7 +1100,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return code;
     }
 
-    const command = buildAgentCommand(
+    let command = buildAgentCommand(
       parsed.agent,
       {
         prompt: prompt.prompt,
@@ -959,10 +1110,25 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       },
       env,
     );
+    if (parsed.docker) {
+      command = buildDockerAgentCommand({
+        agent: parsed.agent,
+        command,
+        dockerArgs: parsed.dockerArgs,
+        dockerEnv: parsed.dockerEnv,
+        env,
+        hostUser: detectDockerHostUser(),
+        image: parsed.dockerImage ?? DEFAULT_DOCKER_IMAGE,
+        workDir: cwd ?? process.cwd(),
+      });
+    }
 
     if (parsed.printCommand) {
       stdout(`${quoteCommand(command)}\n`);
       return 0;
+    }
+    if (parsed.docker && !commandExists("docker", env)) {
+      throw new CliError("docker not found on PATH");
     }
 
     const stdoutHandling: StdoutHandling = parsed.json

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { getAgentConfig } from "./agents.js";
 import type { AgentName, BuiltCommand, Env } from "./types.js";
 
-export const DEFAULT_DOCKER_IMAGE = "ghcr.io/RobertTLange/headless:latest";
+export const DEFAULT_DOCKER_IMAGE = "ghcr.io/roberttlange/headless:latest";
 export const LOCAL_DOCKER_IMAGE = "headless-local:dev";
 const containerHome = "/headless-home";
 const hostHomeMountRoot = "/tmp/headless-host-home";

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,0 +1,140 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { getAgentConfig } from "./agents.js";
+import type { AgentName, BuiltCommand, Env } from "./types.js";
+
+export const DEFAULT_DOCKER_IMAGE = "ghcr.io/RobertTLange/headless:latest";
+export const LOCAL_DOCKER_IMAGE = "headless-local:dev";
+const containerHome = "/headless-home";
+const hostHomeMountRoot = "/tmp/headless-host-home";
+const bootstrapScript = [
+  "set -eu",
+  `mkdir -p "${containerHome}"`,
+  `if [ -d "${hostHomeMountRoot}" ]; then cp -R "${hostHomeMountRoot}/." "$HOME"/; fi`,
+  'exec "$@"',
+].join("; ");
+
+const defaultDockerEnvNames = [
+  "ANTHROPIC_API_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_DEFAULT_REGION",
+  "AWS_PROFILE",
+  "AWS_REGION",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AZURE_OPENAI_API_KEY",
+  "AZURE_OPENAI_ENDPOINT",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CODEX_API_KEY",
+  "CURSOR_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENROUTER_API_KEY",
+  "PI_CODING_AGENT_API_KEY",
+  "PI_CODING_AGENT_MODEL",
+  "PI_CODING_AGENT_MODELS",
+  "PI_CODING_AGENT_PROVIDER",
+];
+
+export interface DockerAgentCommandOptions {
+  agent: AgentName;
+  command: BuiltCommand;
+  dockerArgs: string[];
+  dockerEnv: string[];
+  env: Env;
+  hostUser?: string;
+  image: string;
+  workDir: string;
+}
+
+export function detectDockerHostUser(): string | undefined {
+  if (typeof process.getuid !== "function" || typeof process.getgid !== "function") {
+    return undefined;
+  }
+  return `${process.getuid()}:${process.getgid()}`;
+}
+
+export function buildDockerAgentCommand(options: DockerAgentCommandOptions): BuiltCommand {
+  const args = ["run", "--rm"];
+  if (options.command.stdinText !== undefined || options.command.stdinFile !== undefined) {
+    args.push("--interactive");
+  }
+  args.push("--tmpfs", `${containerHome}:rw,mode=1777`);
+  if (options.hostUser) {
+    args.push("--user", options.hostUser);
+  }
+
+  const workDir = realpathSync(options.workDir);
+  args.push("--workdir", workDir, "--volume", `${workDir}:${workDir}`);
+  args.push(...agentConfigMountArgs(options.agent, options.env));
+  args.push(...dockerEnvArgs(options.env, options.command.env, options.dockerEnv));
+  args.push(...options.dockerArgs);
+  args.push(options.image, "sh", "-lc", bootstrapScript, "headless-agent", options.command.command, ...options.command.args);
+
+  const dockerCommand: BuiltCommand = { command: "docker", args };
+  if (options.command.env) {
+    dockerCommand.env = options.command.env;
+  }
+  if (options.command.stdinFile) {
+    dockerCommand.stdinFile = options.command.stdinFile;
+  }
+  if (options.command.stdinText !== undefined) {
+    dockerCommand.stdinText = options.command.stdinText;
+  }
+  return dockerCommand;
+}
+
+function agentConfigMountArgs(agent: AgentName, env: Env): string[] {
+  const home = env.HOME;
+  if (!home) {
+    return [];
+  }
+
+  const mounted = new Set<string>();
+  const args: string[] = [];
+  for (const relPath of getAgentConfig(agent).seedPaths) {
+    const hostPath = join(home, relPath);
+    if (!existsSync(hostPath) || mounted.has(hostPath)) {
+      continue;
+    }
+    mounted.add(hostPath);
+    args.push("--volume", `${hostPath}:${join(hostHomeMountRoot, relPath)}:ro`);
+    if (statSync(hostPath).isDirectory()) {
+      break;
+    }
+  }
+  return args;
+}
+
+function dockerEnvArgs(env: Env, commandEnv: Env | undefined, explicitDockerEnv: string[]): string[] {
+  const values = new Map<string, string | undefined>();
+  for (const name of defaultDockerEnvNames) {
+    if (env[name] !== undefined) {
+      values.set(name, undefined);
+    }
+  }
+  for (const [name, value] of Object.entries(commandEnv ?? {})) {
+    if (value !== undefined) {
+      values.set(name, value);
+    }
+  }
+  for (const item of explicitDockerEnv) {
+    const equals = item.indexOf("=");
+    if (equals === -1) {
+      values.set(item, undefined);
+    } else {
+      values.set(item.slice(0, equals), item);
+    }
+  }
+  values.set("HOME", `HOME=${containerHome}`);
+
+  const args: string[] = [];
+  for (const [name, value] of values) {
+    args.push("--env", value ?? name);
+  }
+  return args;
+}

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { getAgentConfig } from "./agents.js";
 import type { AgentName, BuiltCommand, Env } from "./types.js";
@@ -40,6 +40,12 @@ const defaultDockerEnvNames = [
   "PI_CODING_AGENT_PROVIDER",
 ];
 
+interface DockerEnvEntry {
+  name: string;
+  value?: string;
+  actualValue?: string;
+}
+
 export interface DockerAgentCommandOptions {
   agent: AgentName;
   command: BuiltCommand;
@@ -69,9 +75,11 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
   }
 
   const workDir = realpathSync(options.workDir);
+  const dockerEnvEntries = collectDockerEnvEntries(options.env, options.command.env, options.dockerEnv);
   args.push("--workdir", workDir, "--volume", `${workDir}:${workDir}`);
   args.push(...agentConfigMountArgs(options.agent, options.env));
-  args.push(...dockerEnvArgs(options.env, options.command.env, options.dockerEnv));
+  args.push(...credentialMountArgs(options.env, dockerEnvEntries, workDir));
+  args.push(...dockerEnvArgs(dockerEnvEntries));
   args.push(...options.dockerArgs);
   args.push(options.image, "sh", "-lc", bootstrapScript, "headless-agent", options.command.command, ...options.command.args);
 
@@ -110,31 +118,54 @@ function agentConfigMountArgs(agent: AgentName, env: Env): string[] {
   return args;
 }
 
-function dockerEnvArgs(env: Env, commandEnv: Env | undefined, explicitDockerEnv: string[]): string[] {
-  const values = new Map<string, string | undefined>();
+function collectDockerEnvEntries(env: Env, commandEnv: Env | undefined, explicitDockerEnv: string[]): DockerEnvEntry[] {
+  const entries = new Map<string, DockerEnvEntry>();
   for (const name of defaultDockerEnvNames) {
     if (env[name] !== undefined) {
-      values.set(name, undefined);
+      entries.set(name, { name, actualValue: env[name] });
     }
   }
   for (const [name, value] of Object.entries(commandEnv ?? {})) {
     if (value !== undefined) {
-      values.set(name, value);
+      entries.set(name, { name, value: `${name}=${value}`, actualValue: value });
     }
   }
   for (const item of explicitDockerEnv) {
     const equals = item.indexOf("=");
     if (equals === -1) {
-      values.set(item, undefined);
+      entries.set(item, { name: item, actualValue: env[item] });
     } else {
-      values.set(item.slice(0, equals), item);
+      entries.set(item.slice(0, equals), { name: item.slice(0, equals), value: item, actualValue: item.slice(equals + 1) });
     }
   }
-  values.set("HOME", `HOME=${containerHome}`);
+  entries.set("HOME", { name: "HOME", value: `HOME=${containerHome}`, actualValue: containerHome });
 
+  return [...entries.values()];
+}
+
+function credentialMountArgs(env: Env, entries: DockerEnvEntry[], workDir: string): string[] {
   const args: string[] = [];
-  for (const [name, value] of values) {
-    args.push("--env", value ?? name);
+  const googleCredentials = entries.find((entry) => entry.name === "GOOGLE_APPLICATION_CREDENTIALS")?.actualValue;
+  if (googleCredentials) {
+    const hostPath = resolve(workDir, googleCredentials);
+    if (existsSync(hostPath) && statSync(hostPath).isFile()) {
+      args.push("--volume", `${hostPath}:${hostPath}:ro`);
+    }
+  }
+
+  const awsProfile = entries.find((entry) => entry.name === "AWS_PROFILE")?.actualValue;
+  const awsDir = env.HOME ? join(env.HOME, ".aws") : undefined;
+  if (awsProfile && awsDir && existsSync(awsDir) && statSync(awsDir).isDirectory()) {
+    args.push("--volume", `${awsDir}:${join(hostHomeMountRoot, ".aws")}:ro`);
+  }
+
+  return args;
+}
+
+function dockerEnvArgs(entries: DockerEnvEntry[]): string[] {
+  const args: string[] = [];
+  for (const entry of entries) {
+    args.push("--env", entry.value ?? entry.name);
   }
   return args;
 }

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -162,3 +162,33 @@ test("CLI --check retries transient empty version output", async () => {
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("CLI --check reports docker and default image status", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir);
+    await writeExecutable(
+      join(binDir, "docker"),
+      [
+        "#!/bin/sh",
+        "if [ \"$1\" = \"--version\" ]; then echo 'Docker version 27.1.2, build abc'; exit 0; fi",
+        "if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ]; then exit 0; fi",
+        "exit 1",
+        "",
+      ].join("\n"),
+    );
+
+    const stdout: string[] = [];
+    const code = await runCli(["--check"], {
+      env: { PATH: binDir },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^Docker\s+Status\s+Version\s+Default image$/m);
+    assert.match(stdout.join(""), /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/RobertTLange\/headless:latest \(present\)$/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -187,7 +187,7 @@ test("CLI --check reports docker and default image status", async () => {
 
     assert.equal(code, 0);
     assert.match(stdout.join(""), /^Docker\s+Status\s+Version\s+Default image$/m);
-    assert.match(stdout.join(""), /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/RobertTLange\/headless:latest \(present\)$/m);
+    assert.match(stdout.join(""), /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/roberttlange\/headless:latest \(present\)$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -1,11 +1,19 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import { buildDockerAgentCommand, DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
+
+test("Dockerfile exposes Cursor agent from a non-root path", () => {
+  const dockerfile = readFileSync("Dockerfile", "utf8");
+
+  assert.match(dockerfile, /cp -R "\$\{cursor_agent_dir\}\/\." \/opt\/cursor-agent\//);
+  assert.match(dockerfile, /ln -sf \/opt\/cursor-agent\/cursor-agent \/usr\/local\/bin\/cursor-agent/);
+  assert.match(dockerfile, /ln -sf \/usr\/local\/bin\/cursor-agent \/usr\/local\/bin\/agent/);
+});
 
 test("wraps stdin-based agent command in docker with workdir, user, env, and config mounts", () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -191,3 +191,44 @@ test("preserves prompt-file stdin through docker for print-command output", () =
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("mounts provider credential files needed by forwarded env vars", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "project");
+    const googleCredentials = join(dir, "google", "service-account.json");
+    mkdirSync(join(home, ".aws"), { recursive: true });
+    mkdirSync(join(dir, "google"), { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(join(home, ".aws", "config"), "[profile dev]\nregion = us-west-2\n");
+    writeFileSync(join(home, ".aws", "credentials"), "[dev]\naws_access_key_id = test\n");
+    writeFileSync(googleCredentials, "{}");
+
+    const command = buildDockerAgentCommand({
+      agent: "codex",
+      command: {
+        command: "codex",
+        args: ["exec", "-"],
+        stdinText: "hello",
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: {
+        AWS_PROFILE: "dev",
+        GOOGLE_APPLICATION_CREDENTIALS: googleCredentials,
+        HOME: home,
+      },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      workDir,
+    });
+
+    assert.ok(command.args.includes(`${googleCredentials}:${googleCredentials}:ro`));
+    assert.ok(command.args.includes(`${join(home, ".aws")}:/tmp/headless-host-home/.aws:ro`));
+    assert.ok(command.args.includes("AWS_PROFILE"));
+    assert.ok(command.args.includes("GOOGLE_APPLICATION_CREDENTIALS"));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -10,7 +10,16 @@ import { quoteCommand } from "../src/shell.ts";
 test("Dockerfile exposes Cursor agent from a non-root path", () => {
   const dockerfile = readFileSync("Dockerfile", "utf8");
 
-  assert.match(dockerfile, /cp -R "\$\{cursor_agent_dir\}\/\." \/opt\/cursor-agent\//);
+  assert.match(dockerfile, /^FROM node:22-bookworm-slim@sha256:[a-f0-9]{64}$/m);
+  assert.match(dockerfile, /@anthropic-ai\/claude-code@\d+\.\d+\.\d+/);
+  assert.match(dockerfile, /@google\/gemini-cli@\d+\.\d+\.\d+/);
+  assert.match(dockerfile, /@mariozechner\/pi-coding-agent@\d+\.\d+\.\d+/);
+  assert.match(dockerfile, /@openai\/codex@\d+\.\d+\.\d+/);
+  assert.match(dockerfile, /opencode-ai@\d+\.\d+\.\d+/);
+  assert.match(dockerfile, /ARG CURSOR_AGENT_VERSION=\d{4}\.\d{2}\.\d{2}-[a-f0-9]+/);
+  assert.match(dockerfile, /ARG CURSOR_AGENT_SHA256_AMD64=[a-f0-9]{64}/);
+  assert.match(dockerfile, /ARG CURSOR_AGENT_SHA256_ARM64=[a-f0-9]{64}/);
+  assert.match(dockerfile, /sha256sum -c -/);
   assert.match(dockerfile, /ln -sf \/opt\/cursor-agent\/cursor-agent \/usr\/local\/bin\/cursor-agent/);
   assert.match(dockerfile, /ln -sf \/usr\/local\/bin\/cursor-agent \/usr\/local\/bin\/agent/);
 });

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { buildDockerAgentCommand, DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
+import { quoteCommand } from "../src/shell.ts";
+
+test("wraps stdin-based agent command in docker with workdir, user, env, and config mounts", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "project");
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(join(home, ".codex", "auth.json"), "{}");
+    const resolvedWorkDir = realpathSync(workDir);
+
+    const command = buildDockerAgentCommand({
+      agent: "codex",
+      command: {
+        command: "codex",
+        args: ["exec", "--json", "-"],
+        stdinText: "hello",
+      },
+      dockerArgs: ["--network=host"],
+      dockerEnv: ["EXTRA_TOKEN", "INLINE_TOKEN=value"],
+      env: {
+        HOME: home,
+        OPENAI_API_KEY: "sk-test",
+        EXTRA_TOKEN: "extra",
+        UNRELATED_SECRET: "nope",
+      },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      workDir,
+    });
+
+    assert.equal(command.command, "docker");
+    assert.deepEqual(command.args.slice(0, 17), [
+      "run",
+      "--rm",
+      "--interactive",
+      "--tmpfs",
+      "/headless-home:rw,mode=1777",
+      "--user",
+      "501:20",
+      "--workdir",
+      resolvedWorkDir,
+      "--volume",
+      `${resolvedWorkDir}:${resolvedWorkDir}`,
+      "--volume",
+      `${join(home, ".codex", "auth.json")}:/tmp/headless-host-home/.codex/auth.json:ro`,
+      "--env",
+      "OPENAI_API_KEY",
+      "--env",
+      "EXTRA_TOKEN",
+    ]);
+    assert.deepEqual(command.args.slice(17, 25), [
+      "--env",
+      "INLINE_TOKEN=value",
+      "--env",
+      "HOME=/headless-home",
+      "--network=host",
+      DEFAULT_DOCKER_IMAGE,
+      "sh",
+      "-lc",
+    ]);
+    assert.match(command.args[25] ?? "", /cp -R "\/tmp\/headless-host-home\/\." "\$HOME"/);
+    assert.deepEqual(command.args.slice(26), ["headless-agent", "codex", "exec", "--json", "-"]);
+    assert.equal(command.stdinText, "hello");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("wraps argument-mode commands without stdin or unrelated env", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "project");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    const resolvedWorkDir = realpathSync(workDir);
+
+    const command = buildDockerAgentCommand({
+      agent: "pi",
+      command: {
+        command: "pi",
+        args: ["--no-session", "--mode", "json", "hello"],
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: { HOME: home, UNRELATED_SECRET: "nope" },
+      hostUser: undefined,
+      image: "custom/headless:dev",
+      workDir,
+    });
+
+    assert.equal(command.command, "docker");
+    assert.deepEqual(command.args.slice(0, 11), [
+      "run",
+      "--rm",
+      "--tmpfs",
+      "/headless-home:rw,mode=1777",
+      "--workdir",
+      resolvedWorkDir,
+      "--volume",
+      `${resolvedWorkDir}:${resolvedWorkDir}`,
+      "--env",
+      "HOME=/headless-home",
+      "custom/headless:dev",
+    ]);
+    assert.deepEqual(command.args.slice(11, 15), ["sh", "-lc", command.args[13], "headless-agent"]);
+    assert.deepEqual(command.args.slice(15), ["pi", "--no-session", "--mode", "json", "hello"]);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("uses a writable container home while keeping host agent config read-only", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "project");
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(join(home, ".codex", "auth.json"), "{}");
+
+    const command = buildDockerAgentCommand({
+      agent: "codex",
+      command: {
+        command: "codex",
+        args: ["exec", "-"],
+        stdinText: "hello",
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: { HOME: home },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      workDir,
+    });
+
+    assert.ok(command.args.includes(`${join(home, ".codex", "auth.json")}:/tmp/headless-host-home/.codex/auth.json:ro`));
+    assert.ok(command.args.includes("/headless-home:rw,mode=1777"));
+    assert.ok(command.args.includes("HOME=/headless-home"));
+    assert.ok(!command.args.includes(`${join(home, ".codex")}:${join(home, ".codex")}:ro`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("preserves prompt-file stdin through docker for print-command output", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "project");
+    const promptFile = join(dir, "prompt.md");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(promptFile, "hello");
+
+    const command = buildDockerAgentCommand({
+      agent: "claude",
+      command: {
+        command: "claude",
+        args: ["-p"],
+        stdinFile: promptFile,
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: { HOME: home },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      workDir,
+    });
+
+    assert.match(quoteCommand(command), /^docker run --rm --interactive --tmpfs '\/headless-home:rw,mode=1777' --user 501:20 /);
+    assert.match(quoteCommand(command), new RegExp(`< ${promptFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import { buildAgentCommand, buildInteractiveAgentCommand, getAgentConfig, listAgents } from "../src/agents.ts";
 import { runCli } from "../src/cli.ts";
+import { DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
 import type { AgentName } from "../src/types.ts";
 
@@ -24,6 +25,11 @@ async function waitFor(assertion: () => boolean): Promise<void> {
 
 test("lists all supported agents", () => {
   assert.deepEqual(listAgents(), ["claude", "codex", "cursor", "gemini", "opencode", "pi"]);
+});
+
+test("default Docker image reference is accepted by Docker", () => {
+  assert.equal(DEFAULT_DOCKER_IMAGE, DEFAULT_DOCKER_IMAGE.toLowerCase());
+  assert.equal(DEFAULT_DOCKER_IMAGE, "ghcr.io/roberttlange/headless:latest");
 });
 
 test("builds codex command with default model and prompt stdin", () => {
@@ -356,7 +362,7 @@ test("CLI --docker executes through docker and preserves stdin prompt", async ()
     assert.equal(stdout.join(""), "docker final\n");
     assert.equal(capture.stdin, "hello");
     assert.equal(capture.args[0], "run");
-    assert.ok(capture.args.includes("ghcr.io/RobertTLange/headless:latest"));
+    assert.ok(capture.args.includes("ghcr.io/roberttlange/headless:latest"));
     assert.deepEqual(capture.args.slice(-8), [
       "codex",
       "--dangerously-bypass-approvals-and-sandbox",
@@ -400,7 +406,7 @@ test("CLI docker doctor reports image status and local build guidance", async ()
 
     const output = stdout.join("");
     assert.equal(code, 0);
-    assert.match(output, /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/RobertTLange\/headless:latest \(missing\)$/m);
+    assert.match(output, /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/roberttlange\/headless:latest \(missing\)$/m);
     assert.match(output, /Plain `headless --docker` will let Docker pull the default image automatically\./);
     assert.match(output, /For local development, run: headless docker build/);
   } finally {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -270,6 +270,191 @@ test("CLI accepts stdin fallback", async () => {
   assert.equal(stdout.join(""), "pi --no-session --mode json --tools 'read,bash,edit,write' 'stdin prompt'\n");
 });
 
+test("CLI --docker print-command wraps the selected agent command", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    mkdirSync(join(homeDir, ".codex"), { recursive: true });
+    mkdirSync(projectDir);
+    writeFileSync(join(homeDir, ".codex", "config.toml"), "model = 'test'\n");
+
+    const stdout: string[] = [];
+    const code = await runCli(
+      [
+        "codex",
+        "--prompt",
+        "hello",
+        "--work-dir",
+        projectDir,
+        "--docker",
+        "--docker-image",
+        "custom/headless:dev",
+        "--docker-env",
+        "EXTRA_TOKEN=value",
+        "--docker-arg",
+        "--network=host",
+        "--print-command",
+      ],
+      {
+        env: { ...process.env, HOME: homeDir },
+        stdout: (text) => stdout.push(text),
+      },
+    );
+
+    const output = stdout.join("");
+    assert.equal(code, 0);
+    assert.match(output, /^printf %s hello \| docker run --rm --interactive --tmpfs '\/headless-home:rw,mode=1777' --user \d+:\d+ /);
+    assert.match(output, new RegExp(`--workdir ${quoteCommand({ command: realpathSync(projectDir), args: [] })}`));
+    assert.match(output, /--env EXTRA_TOKEN=value --env HOME=\/headless-home --network=host custom\/headless:dev sh -lc/);
+    assert.match(output, /headless-agent codex/);
+    assert.match(output, /exec --model gpt-5\.2 --json --skip-git-repo-check -/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --docker executes through docker and preserves stdin prompt", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    const captureFile = join(dir, "docker.json");
+    mkdirSync(binDir);
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    await import("node:fs/promises").then(async ({ chmod, writeFile }) => {
+      const docker = join(binDir, "docker");
+      await writeFile(
+        docker,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const stdin = fs.readFileSync(0, 'utf8');",
+          "fs.writeFileSync(process.env.HEADLESS_DOCKER_CAPTURE, JSON.stringify({ args: process.argv.slice(2), stdin }));",
+          "console.log(JSON.stringify({ type: 'agent_message', text: 'docker final' }));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(docker, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--work-dir", projectDir, "--docker"], {
+      env: {
+        ...process.env,
+        HEADLESS_DOCKER_CAPTURE: captureFile,
+        HOME: homeDir,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    const capture = JSON.parse(readFileSync(captureFile, "utf8"));
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "docker final\n");
+    assert.equal(capture.stdin, "hello");
+    assert.equal(capture.args[0], "run");
+    assert.ok(capture.args.includes("ghcr.io/RobertTLange/headless:latest"));
+    assert.deepEqual(capture.args.slice(-8), [
+      "codex",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "exec",
+      "--model",
+      "gpt-5.2",
+      "--json",
+      "--skip-git-repo-check",
+      "-",
+    ]);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI docker doctor reports image status and local build guidance", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir);
+    await import("node:fs/promises").then(async ({ chmod, writeFile }) => {
+      const docker = join(binDir, "docker");
+      await writeFile(
+        docker,
+        [
+          "#!/bin/sh",
+          "if [ \"$1\" = \"--version\" ]; then echo 'Docker version 27.1.2, build abc'; exit 0; fi",
+          "if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ]; then exit 1; fi",
+          "exit 2",
+          "",
+        ].join("\n"),
+      );
+      await chmod(docker, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["docker", "doctor"], {
+      env: { PATH: binDir },
+      stdout: (text) => stdout.push(text),
+    });
+
+    const output = stdout.join("");
+    assert.equal(code, 0);
+    assert.match(output, /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/RobertTLange\/headless:latest \(missing\)$/m);
+    assert.match(output, /Plain `headless --docker` will let Docker pull the default image automatically\./);
+    assert.match(output, /For local development, run: headless docker build/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI docker build prints the packaged Dockerfile build command", async () => {
+  const stdout: string[] = [];
+  const code = await runCli(["docker", "build", "--print-command"], {
+    stdout: (text) => stdout.push(text),
+  });
+
+  assert.equal(code, 0);
+  assert.match(stdout.join(""), /^docker build -t headless-local:dev -f .*Dockerfile /);
+});
+
+test("CLI docker build runs docker with a custom image tag", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "docker-args.json");
+    mkdirSync(binDir);
+    await import("node:fs/promises").then(async ({ chmod, writeFile }) => {
+      const docker = join(binDir, "docker");
+      await writeFile(
+        docker,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "fs.writeFileSync(process.env.HEADLESS_DOCKER_CAPTURE, JSON.stringify(process.argv.slice(2)));",
+          "process.stdout.write('built\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(docker, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["docker", "build", "--docker-image", "custom/headless:dev"], {
+      env: { ...process.env, HEADLESS_DOCKER_CAPTURE: captureFile, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    const args = JSON.parse(readFileSync(captureFile, "utf8"));
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "built\n");
+    assert.deepEqual(args.slice(0, 4), ["build", "-t", "custom/headless:dev", "-f"]);
+    assert.match(args[4], /Dockerfile$/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI auto-selects the preferred installed agent when omitted", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
@@ -998,6 +1183,62 @@ test("CLI rejects --json with --tmux", async () => {
   assert.match(stderr.join(""), /--json cannot be used with --tmux/);
 });
 
+test("CLI rejects docker for tmux and session-management commands", async () => {
+  const stderr: string[] = [];
+  assert.equal(
+    await runCli(["codex", "--prompt", "hello", "--docker", "--tmux"], { stderr: (text) => stderr.push(text) }),
+    2,
+  );
+  assert.match(stderr.join(""), /--docker cannot be used with --tmux/);
+
+  stderr.length = 0;
+  assert.equal(
+    await runCli(["send", "headless-codex-work", "--prompt", "hello", "--docker"], {
+      stderr: (text) => stderr.push(text),
+    }),
+    2,
+  );
+  assert.match(stderr.join(""), /--docker cannot be used with send/);
+
+  stderr.length = 0;
+  assert.equal(
+    await runCli(["rename", "headless-codex-work", "next", "--docker"], { stderr: (text) => stderr.push(text) }),
+    2,
+  );
+  assert.match(stderr.join(""), /--docker cannot be used with rename/);
+});
+
+test("CLI validates docker env names", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["codex", "--prompt", "hello", "--docker", "--docker-env", "BAD-NAME"], {
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /invalid docker env/);
+});
+
+test("CLI reports missing docker at execution time", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["codex", "--prompt", "hello", "--docker"], {
+    env: { ...process.env, PATH: "" },
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /docker not found on PATH/);
+});
+
+test("CLI requires --docker for docker execution options", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["codex", "--prompt", "hello", "--docker-image", "custom/headless:dev"], {
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /require --docker/);
+});
+
 test("CLI suppresses known Gemini startup warnings", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
@@ -1032,6 +1273,41 @@ test("CLI suppresses known Gemini startup warnings", async () => {
     assert.equal(code, 0);
     assert.equal(stdout.join(""), "final answer\n");
     assert.equal(stderr.join(""), "real gemini error\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI suppresses known Codex rollout recording warning", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "process.stderr.write('2026-04-25T16:54:20.076657Z ERROR codex_core::session: failed to record rollout items: thread 019dc590-3a4c-78d1-a11a-8c28174c8902 not found\\n');",
+          "console.log(JSON.stringify({ type: 'agent_message', text: 'final answer' }));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "final answer\n");
+    assert.equal(stderr.join(""), "");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }


### PR DESCRIPTION
## What changed
- Add `--docker` execution for one-shot agent runs using `ghcr.io/RobertTLange/headless:latest` by default.
- Mount workdirs and agent seed config safely, with a writable ephemeral container home.
- Add `headless docker doctor` and explicit `headless docker build` for local/npx-friendly image workflows.
- Package the Dockerfile and document the Docker workflow.

## Why
Docker mode should be smooth for normal use without surprising users with automatic local image builds. Plain `--docker` lets Docker pull the default image; local builds are explicit.

## How to test
- `npm run check`
- `npm run pack:check`
- `headless docker doctor`
- `headless docker build --print-command`
- `headless codex --prompt "Reply exactly: docker-ok" --docker --docker-image headless-local:dev`