### PR TITLE
Add tracked local integration pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -u
+
+if [ "${HEADLESS_SKIP_INTEGRATION_HOOK:-}" = "1" ]; then
+  echo "headless pre-push: skipped by HEADLESS_SKIP_INTEGRATION_HOOK=1"
+  exit 0
+fi
+
+if ! command -v headless >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+headless pre-push: global `headless` not found.
+
+Install or link the CLI first, for example:
+  npm link
+  # or: npm install -g @roberttlange/headless
+
+Then enable this tracked hook locally:
+  npm run hooks:install
+
+Bypass once with:
+  HEADLESS_SKIP_INTEGRATION_HOOK=1 git push
+EOF
+  exit 1
+fi
+
+if ! headless --help 2>/dev/null | grep -q -- "--session"; then
+  cat >&2 <<'EOF'
+headless pre-push: global `headless` does not support --session.
+
+Refresh the global CLI from this repo before pushing:
+  npm link
+
+Bypass once with:
+  HEADLESS_SKIP_INTEGRATION_HOOK=1 git push
+EOF
+  exit 1
+fi
+
+echo "headless pre-push: running local integration suite"
+if ! npm run test:integration:local; then
+  cat >&2 <<'EOF'
+headless pre-push: local integration suite failed.
+
+Expected local prerequisites:
+  - all six Headless backends installed and authenticated
+  - Docker installed, running, and able to pull/run the default image
+  - Modal configured with MODAL_TOKEN_ID/MODAL_TOKEN_SECRET or ~/.modal.toml
+  - tmux installed
+
+Bypass once with:
+  HEADLESS_SKIP_INTEGRATION_HOOK=1 git push
+EOF
+  exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,29 +6,16 @@ if [ "${HEADLESS_SKIP_INTEGRATION_HOOK:-}" = "1" ]; then
   exit 0
 fi
 
-if ! command -v headless >/dev/null 2>&1; then
+hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$hook_dir/.." && pwd)
+headless_bin="$repo_root/dist/cli.js"
+
+cd "$repo_root"
+
+echo "headless pre-push: building local CLI"
+if ! npm run build; then
   cat >&2 <<'EOF'
-headless pre-push: global `headless` not found.
-
-Install or link the CLI first, for example:
-  npm link
-  # or: npm install -g @roberttlange/headless
-
-Then enable this tracked hook locally:
-  npm run hooks:install
-
-Bypass once with:
-  HEADLESS_SKIP_INTEGRATION_HOOK=1 git push
-EOF
-  exit 1
-fi
-
-if ! headless --help 2>/dev/null | grep -q -- "--session"; then
-  cat >&2 <<'EOF'
-headless pre-push: global `headless` does not support --session.
-
-Refresh the global CLI from this repo before pushing:
-  npm link
+headless pre-push: local build failed.
 
 Bypass once with:
   HEADLESS_SKIP_INTEGRATION_HOOK=1 git push
@@ -37,7 +24,7 @@ EOF
 fi
 
 echo "headless pre-push: running local integration suite"
-if ! npm run test:integration:local; then
+if ! HEADLESS_BIN="$headless_bin" npm run test:integration:local; then
   cat >&2 <<'EOF'
 headless pre-push: local integration suite failed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.1 - 2026-04-27
 
+- Added named native session aliases and a tracked local integration pre-push hook. Thanks @RobertTLange for PR #7.
 - Added `~/.headless/config.toml` support for per-agent default `model` and `reasoning_effort` values, plus a packaged `config.toml.example` template and README setup docs. Thanks @RobertTLange for PR #6.
 - Added provider-specific default models for Cursor, Gemini, OpenCode, and Pi, including Gemini `gemini-3.1-pro-preview` and Pi `openai-codex/gpt-5.5`.
 - Changed Pi model overrides to accept `provider/model` specs such as `openai-codex/gpt-5.4`, splitting them into native Pi provider and model flags.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ headless codex --prompt "Fix the failing tests" --debug
 headless codex --prompt "Summarize this repo" --model gpt-5 --usage
 # Launch in tmux for persistent interactive sessions.
 headless codex --prompt "Fix the failing tests" --tmux
+# Start or resume a named native session.
+headless codex --prompt "Continue the fix" --session bughunt
 # Run the agent inside the default Docker image.
 headless codex --prompt "Fix the failing tests" --docker
 # Run the agent in a Modal CPU sandbox and sync edits back.
@@ -93,6 +95,8 @@ Pass `--reasoning-effort low|medium|high|xhigh` to request a normalized reasonin
 
 By default, Headless prints the agent's final assistant message. Pass `--json` to stream the raw native JSON trace, or `--debug` to stream the trace and append the extracted final message. Pass `--usage` to append normalized token usage and cost JSON for one-shot runs. Headless uses native agent costs when available and fetches live fallback pricing from `https://models.dev/api.json`; if a model cannot be priced, token counts are still returned with `cost: null`. When `--model` is omitted, Headless defaults Codex to `gpt-5.5`, Claude to `claude-opus-4-6`, Cursor to the `gpt-5.5` family with medium effort, Gemini to `gemini-3.1-pro-preview`, OpenCode to `openai/gpt-5.4`, and Pi to `openai-codex/gpt-5.5`.
 When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`.
+
+Pass `--session <name>` to start or resume a named session. Headless stores per-agent aliases in `~/.headless/sessions.json`, separate from `config.toml`, and maps each alias to the selected backend's native session id or session file. A missing alias starts a new session and records it after the run succeeds; an existing alias resumes that native session. In tmux mode, `--session <name>` maps to `headless-<agent>-<name>`: an active tmux session receives the prompt, otherwise Headless starts a new named tmux session. `--session` cannot be combined with `--name`, `--docker`, or `--modal`.
 
 ## User Defaults
 
@@ -203,12 +207,13 @@ Use `headless docker build --docker-image <image>` to choose a different local t
 
 ### 5) tmux mode (`--tmux`)
 
-tmux mode creates a detached session named `headless-<agent>-<pid>`, starts the selected agent in interactive mode with the prompt as its initial message, prints an attach command, and exits. Pass `--name <name>` to create a stable managed session name like `headless-codex-work`.
+tmux mode creates a detached session named `headless-<agent>-<pid>`, starts the selected agent in interactive mode with the prompt as its initial message, prints an attach command, and exits. Pass `--name <name>` to create a stable managed session name like `headless-codex-work`. Pass `--session <name>` instead when you want start-or-send behavior: if `headless-<agent>-<name>` is active, Headless sends the prompt there; otherwise it starts that named session.
 
 ```bash
 headless claude --prompt-file task.md --work-dir /path/to/project --tmux
 tmux attach-session -t headless-claude-12345
 headless codex --prompt "Fix the tests" --tmux --name work
+headless codex --prompt "Run the focused tests now" --tmux --session work
 ```
 
 Use `--print-command --tmux` to preview the tmux launch command without starting a session.
@@ -284,6 +289,7 @@ Options:
 - `--usage`: append normalized token usage and cost JSON after the final message.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
 - `--name`: use a stable managed session name with `--tmux`.
+- `--session`: start or resume a named Headless session. Uses `~/.headless/sessions.json`; in tmux mode starts or sends to `headless-<agent>-<name>`.
 - `send <session-name>`: send a message to an existing Headless tmux session.
 - `rename <session-name> <new-name>`: rename an existing Headless tmux session.
 - `docker doctor`: check Docker setup and image availability.

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
   ],
   "scripts": {
     "build": "tsc && chmod +x dist/cli.js",
-    "test": "node --import tsx --test tests/*.test.ts",
+    "test": "node --import tsx --test $(find tests -name '*.test.ts' ! -name 'integration-local.test.ts' -print)",
+    "test:integration:local": "node --import tsx --test tests/integration-local.test.ts",
     "test:agents": "tsx --test tests/agents-smoke.ts",
     "check": "npm run build && npm test",
+    "hooks:install": "git config core.hooksPath .githooks",
     "pack:check": "npm pack --dry-run",
     "prepack": "npm run build"
   },

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -125,6 +125,14 @@ function commandWithOptionalEnv(command: string, args: string[], env: Env | unde
 function buildClaude(options: BuildOptions): BuiltCommand {
   const args = withModel([], options.model ?? defaultClaudeModel);
   args.push("-p");
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--resume", options.sessionId);
+  } else if (options.sessionMode === "new" && options.sessionId) {
+    args.push("--session-id", options.sessionId);
+    if (options.sessionAlias) {
+      args.push("--name", options.sessionAlias);
+    }
+  }
 
   if (options.promptFile) {
     args.push("--output-format", "stream-json", "--verbose");
@@ -146,11 +154,15 @@ function buildCodex(options: BuildOptions, env: Env): BuiltCommand {
       ? ["--sandbox", "read-only", "--ask-for-approval", "never"]
       : ["--dangerously-bypass-approvals-and-sandbox"]),
     "exec",
+    ...(options.sessionMode === "resume" && options.sessionId ? ["resume"] : []),
     ...withModel([], model),
     ...(options.reasoningEffort ? ["-c", `model_reasoning_effort="${options.reasoningEffort}"`] : []),
     "--json",
     "--skip-git-repo-check",
   ];
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push(options.sessionId);
+  }
 
   if (options.promptFile) {
     args.push("-");
@@ -173,7 +185,11 @@ function buildInteractiveCodex(options: BuildOptions, env: Env): BuiltCommand {
   if (options.reasoningEffort) {
     args.push("-c", `model_reasoning_effort="${options.reasoningEffort}"`);
   }
-  args.push(options.prompt);
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("resume", options.sessionId, options.prompt);
+  } else {
+    args.push(options.prompt);
+  }
   return { command: "codex", args };
 }
 
@@ -184,6 +200,9 @@ function buildCursor(options: BuildOptions, env: Env): BuiltCommand {
 
   if (env.CURSOR_API_KEY) {
     args.unshift("--api-key", env.CURSOR_API_KEY);
+  }
+  if (options.sessionId && (options.sessionMode === "resume" || options.sessionMode === "new")) {
+    args.push("--resume", options.sessionId);
   }
   args.push("--model", model);
   if (options.allow === "read-only") {
@@ -202,6 +221,9 @@ function buildInteractiveCursor(options: BuildOptions, env: Env): BuiltCommand {
   if (env.CURSOR_API_KEY) {
     args.push("--api-key", env.CURSOR_API_KEY);
   }
+  if (options.sessionId && (options.sessionMode === "resume" || options.sessionMode === "new")) {
+    args.push("--resume", options.sessionId);
+  }
   args.push("--model", model);
   if (options.allow === "yolo" || options.allow === undefined) {
     args.push("--force");
@@ -217,6 +239,9 @@ function buildInteractiveCursor(options: BuildOptions, env: Env): BuiltCommand {
 function buildGemini(options: BuildOptions): BuiltCommand {
   const args = withModel([], options.model ?? DEFAULT_GEMINI_MODEL);
   args.push("--skip-trust");
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--resume", options.sessionId);
+  }
 
   if (options.promptFile) {
     args.push("--prompt", "", "--output-format", "stream-json", ...withGeminiAllow([], options.allow));
@@ -230,6 +255,9 @@ function buildGemini(options: BuildOptions): BuiltCommand {
 function buildInteractiveGemini(options: BuildOptions): BuiltCommand {
   const args = withModel([], options.model ?? DEFAULT_GEMINI_MODEL);
   args.push("--skip-trust");
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--resume", options.sessionId);
+  }
   args.push(...withGeminiAllow([], options.allow));
   args.push(options.prompt);
   return { command: "gemini", args };
@@ -246,6 +274,11 @@ function buildOpencode(options: BuildOptions): BuiltCommand {
   if (options.allow === "yolo" || options.allow === undefined) {
     args.push("--dangerously-skip-permissions");
   }
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--session", options.sessionId);
+  } else if (options.sessionMode === "new" && options.sessionAlias) {
+    args.push("--title", options.sessionAlias);
+  }
   args.push(options.prompt);
 
   return commandWithOptionalEnv("opencode", args, opencodeEnv(options.allow));
@@ -261,7 +294,7 @@ function buildInteractiveOpencode(options: BuildOptions): BuiltCommand {
 
 function buildPi(options: BuildOptions, env: Env): BuiltCommand {
   const command = env.PI_CODING_AGENT_BIN || "pi";
-  const args = ["--no-session", "--mode", "json"];
+  const args = options.sessionMode ? ["--mode", "json"] : ["--no-session", "--mode", "json"];
   const { provider, model } = piModelSpec(options.model, env);
 
   if (provider) {
@@ -273,6 +306,9 @@ function buildPi(options: BuildOptions, env: Env): BuiltCommand {
   }
   if (options.reasoningEffort) {
     args.push("--thinking", options.reasoningEffort);
+  }
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--session", options.sessionId);
   }
   if (options.allow === "read-only") {
     args.push("--tools", "read,grep,find,ls");
@@ -298,6 +334,9 @@ function buildInteractivePi(options: BuildOptions, env: Env): BuiltCommand {
   }
   if (options.reasoningEffort) {
     args.push("--thinking", options.reasoningEffort);
+  }
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--session", options.sessionId);
   }
   if (options.allow === "read-only") {
     args.push("--tools", "read,grep,find,ls");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -777,8 +777,8 @@ async function newestGeminiSessionId(cwd: string | undefined, env: Env): Promise
   if (result.code !== 0) {
     return "";
   }
-  const match = result.stdout.match(/\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/i);
-  return match?.[1] ?? "";
+  const matches = [...result.stdout.matchAll(/\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/gi)];
+  return matches.at(-1)?.[1] ?? "";
 }
 
 async function newestOpenCodeSessionId(cwd: string | undefined, env: Env): Promise<string> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,11 +6,13 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   statSync,
   writeFileSync,
 } from "node:fs";
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -43,7 +45,15 @@ import {
   DEFAULT_MODAL_TIMEOUT_SECONDS,
   executeModalAgent,
 } from "./modal.js";
-import { extractAgentError, extractFinalMessage, extractUsageSummary, fetchModelsDevPricing, priceUsageSummary } from "./output.js";
+import {
+  extractAgentError,
+  extractFinalMessage,
+  extractNativeSessionId,
+  extractUsageSummary,
+  fetchModelsDevPricing,
+  priceUsageSummary,
+} from "./output.js";
+import { readStoredSession, sessionStorePath, writeStoredSession } from "./sessions.js";
 import { quoteCommand } from "./shell.js";
 import type { AgentName, AllowMode, BuiltCommand, Env, ReasoningEffort } from "./types.js";
 
@@ -62,6 +72,7 @@ interface ParsedArgs {
   allow?: AllowMode;
   workDir?: string;
   tmuxName?: string;
+  sessionAlias?: string;
   docker: boolean;
   dockerImage?: string;
   dockerArgs: string[];
@@ -138,6 +149,7 @@ function usage(): string {
     "  --usage              Print final message plus normalized token and cost JSON.",
     "  --tmux               Launch an interactive agent in a tmux session.",
     "  --name <name>        Use a managed tmux session name with --tmux.",
+    "  --session <name>     Start or resume a named Headless session.",
     "  send <session-name>  Send a message to an existing headless tmux session.",
     "  rename <session> <name> Rename an existing headless tmux session.",
     "  docker doctor       Check Docker setup and image availability.",
@@ -272,6 +284,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--name":
         parsed.tmuxName = takeValue(args, arg);
+        break;
+      case "--session":
+        parsed.sessionAlias = takeValue(args, arg);
         break;
       case "--json":
         parsed.json = true;
@@ -631,6 +646,189 @@ interface ExecuteCommandOptions {
   stdout: (text: string) => void;
 }
 
+interface SessionPlan {
+  alias: string;
+  mode: "new" | "resume";
+  nativeId?: string;
+}
+
+function validateSessionAlias(alias: string | undefined): string | undefined {
+  if (alias === undefined) {
+    return undefined;
+  }
+  if (!/^[A-Za-z0-9_.-]+$/.test(alias)) {
+    throw new CliError("invalid session name; use letters, numbers, dots, dashes, or underscores");
+  }
+  return alias;
+}
+
+function buildSessionPlan(agent: AgentName, alias: string | undefined, env: Env): SessionPlan | undefined {
+  const validAlias = validateSessionAlias(alias);
+  if (!validAlias) {
+    return undefined;
+  }
+  if (!sessionStorePath(env)) {
+    throw new CliError("HOME is required for --session");
+  }
+  const stored = readStoredSession(env, agent, validAlias);
+  if (stored) {
+    return { alias: validAlias, mode: "resume", nativeId: stored.nativeId };
+  }
+  return {
+    alias: validAlias,
+    mode: "new",
+    nativeId: agent === "claude" ? randomUUID() : undefined,
+  };
+}
+
+async function prepareSessionPlan(
+  agent: AgentName,
+  plan: SessionPlan | undefined,
+  cwd: string | undefined,
+  env: Env,
+): Promise<SessionPlan | undefined> {
+  if (!plan || plan.mode !== "new" || agent !== "cursor" || plan.nativeId) {
+    return plan;
+  }
+  const command = { command: env.CURSOR_CLI_BIN || "agent", args: ["create-chat"] };
+  const result = await captureSimpleCommand(command, cwd, env);
+  if (result.code !== 0) {
+    throw new CliError(result.stderr.trim() || "could not create Cursor session");
+  }
+  const nativeId = result.stdout.trim();
+  if (!nativeId) {
+    throw new CliError("Cursor did not return a session id");
+  }
+  return { ...plan, nativeId };
+}
+
+function applySessionPlan(commandOptions: {
+  prompt: string;
+  promptFile?: string;
+  model?: string;
+  allow?: AllowMode;
+  reasoningEffort?: ReasoningEffort;
+}, plan: SessionPlan | undefined): typeof commandOptions & {
+  sessionAlias?: string;
+  sessionId?: string;
+  sessionMode?: "new" | "resume";
+} {
+  if (!plan) {
+    return commandOptions;
+  }
+  return {
+    ...commandOptions,
+    sessionAlias: plan.alias,
+    sessionId: plan.nativeId,
+    sessionMode: plan.mode,
+  };
+}
+
+async function persistSessionPlan(
+  agent: AgentName,
+  plan: SessionPlan | undefined,
+  stdout: string,
+  cwd: string | undefined,
+  env: Env,
+): Promise<void> {
+  if (!plan) {
+    return;
+  }
+  const nativeId = plan.nativeId || (await discoverNativeSessionId(agent, stdout, cwd, env));
+  if (!nativeId) {
+    throw new CliError(`could not determine ${agent} session id for --session ${plan.alias}`);
+  }
+  writeStoredSession(env, {
+    agent,
+    alias: plan.alias,
+    nativeId,
+    workDir: cwd ?? process.cwd(),
+  });
+}
+
+async function discoverNativeSessionId(
+  agent: AgentName,
+  stdout: string,
+  cwd: string | undefined,
+  env: Env,
+): Promise<string> {
+  const fromTrace = extractNativeSessionId(agent, stdout);
+  if (fromTrace) {
+    return fromTrace;
+  }
+  if (agent === "gemini") {
+    return await newestGeminiSessionId(cwd, env);
+  }
+  if (agent === "opencode") {
+    return await newestOpenCodeSessionId(cwd, env);
+  }
+  if (agent === "pi") {
+    return newestPiSessionFile(cwd, env);
+  }
+  return "";
+}
+
+async function newestGeminiSessionId(cwd: string | undefined, env: Env): Promise<string> {
+  const result = await captureSimpleCommand(
+    { command: "gemini", args: ["--list-sessions", "--skip-trust"] },
+    cwd,
+    env,
+  );
+  if (result.code !== 0) {
+    return "";
+  }
+  const match = result.stdout.match(/\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/i);
+  return match?.[1] ?? "";
+}
+
+async function newestOpenCodeSessionId(cwd: string | undefined, env: Env): Promise<string> {
+  const result = await captureSimpleCommand(
+    { command: "opencode", args: ["session", "list", "--format", "json", "--max-count", "20"] },
+    cwd,
+    env,
+  );
+  if (result.code !== 0) {
+    return "";
+  }
+  try {
+    const sessions = JSON.parse(result.stdout) as Array<{ id?: unknown; directory?: unknown }>;
+    const workspace = cwd ? realpathSync(cwd) : process.cwd();
+    const match = sessions.find((session) => session.directory === workspace) ?? sessions[0];
+    return typeof match?.id === "string" ? match.id : "";
+  } catch {
+    return "";
+  }
+}
+
+function newestPiSessionFile(cwd: string | undefined, env: Env): string {
+  const home = env.HOME;
+  if (!home) {
+    return "";
+  }
+  const sessionDir = join(home, ".pi", "agent", "sessions", piProjectSessionDir(cwd ?? process.cwd()));
+  if (!existsSync(sessionDir)) {
+    return "";
+  }
+  let newestPath = "";
+  let newestTime = -1;
+  for (const entry of readdirSync(sessionDir)) {
+    if (!entry.endsWith(".jsonl")) {
+      continue;
+    }
+    const path = join(sessionDir, entry);
+    const stats = statSync(path);
+    if (stats.mtimeMs > newestTime) {
+      newestTime = stats.mtimeMs;
+      newestPath = path;
+    }
+  }
+  return newestPath;
+}
+
+function piProjectSessionDir(workspace: string): string {
+  return `--${realpathSync(workspace).replace(/^\/+/, "").replace(/[\\/]+/g, "-")}--`;
+}
+
 function suppressKnownStderr(agent: AgentName, text: string): string {
   if (agent === "codex") {
     return text
@@ -976,6 +1174,11 @@ async function listHeadlessTmuxSessions(agent: AgentName | undefined, env: Env):
   return renderHeadlessTmuxSessions(sessions);
 }
 
+async function headlessTmuxSessionExists(sessionName: string, env: Env): Promise<boolean> {
+  const result = await captureSimpleCommand({ command: "tmux", args: ["has-session", "-t", sessionName] }, undefined, env);
+  return result.code === 0;
+}
+
 function trustClaudeWorkspace(cwd: string | undefined, env: Env): void {
   const homeDir = env.HOME;
   if (!homeDir) {
@@ -1118,6 +1321,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       }
       if (
         parsed.tmux ||
+        parsed.sessionAlias !== undefined ||
         parsed.json ||
         parsed.debug ||
         parsed.usage ||
@@ -1169,6 +1373,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (parsed.tmuxName !== undefined) {
         throw new CliError("--name cannot be used with rename");
       }
+      if (parsed.sessionAlias !== undefined) {
+        throw new CliError("--session cannot be used with rename");
+      }
 
       const session = validateHeadlessTmuxSession(parsed.renameSession);
       if (!parsed.renameName) {
@@ -1209,6 +1416,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (parsed.tmuxName !== undefined) {
         throw new CliError("--name cannot be used with send");
       }
+      if (parsed.sessionAlias !== undefined) {
+        throw new CliError("--session cannot be used with send");
+      }
 
       const sessionName = validateHeadlessTmuxSessionName(parsed.sendSession);
       const prompt = await resolvePrompt(parsed, deps, { forceText: true, requireAgent: false });
@@ -1228,6 +1438,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return code;
     }
     if (parsed.check) {
+      if (parsed.sessionAlias !== undefined) {
+        throw new CliError("--session cannot be used with --check");
+      }
       stdout(renderAgentChecks(await checkAgents(env)));
       stdout(renderDockerCheck(await checkDocker(env, parsed.dockerImage ?? DEFAULT_DOCKER_IMAGE)));
       return 0;
@@ -1239,6 +1452,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       throw new CliError("--modal cannot be used with --list");
     }
     if (parsed.list) {
+      if (parsed.sessionAlias !== undefined) {
+        throw new CliError("--session cannot be used with --list");
+      }
       stdout(await listHeadlessTmuxSessions(parsed.agent, env));
       return 0;
     }
@@ -1281,6 +1497,16 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.tmuxName !== undefined && !parsed.tmux) {
       throw new CliError("--name can only be used with --tmux");
     }
+    if (parsed.sessionAlias !== undefined && parsed.tmuxName !== undefined) {
+      throw new CliError("--session cannot be used with --name");
+    }
+    if (parsed.sessionAlias !== undefined && parsed.docker) {
+      throw new CliError("--session cannot be used with --docker");
+    }
+    if (parsed.sessionAlias !== undefined && parsed.modal) {
+      throw new CliError("--session cannot be used with --modal");
+    }
+    validateSessionAlias(parsed.sessionAlias);
     if (parsed.showConfig) {
       stdout(renderConfig(parsed.agent));
       return 0;
@@ -1301,6 +1527,23 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux });
 
     if (parsed.tmux) {
+      const sessionName = parsed.sessionAlias
+        ? buildHeadlessTmuxSessionName(parsed.agent, parsed.sessionAlias)
+        : undefined;
+      if (sessionName && (await headlessTmuxSessionExists(sessionName, env))) {
+        const tmuxCommands = buildTmuxSendCommands(sessionName, prompt.prompt);
+        if (parsed.printCommand) {
+          for (const command of tmuxCommands.commands) {
+            stdout(`${quoteCommand(command)}\n`);
+          }
+          return 0;
+        }
+        const code = await executeTmuxSendCommands(tmuxCommands, env, stderr);
+        if (code === 0) {
+          stdout(`sent: ${tmuxCommands.sessionName}\n`);
+        }
+        return code;
+      }
       const tmuxCommand = buildInteractiveAgentCommand(
         parsed.agent,
         {
@@ -1315,7 +1558,14 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (reasoningWarning) {
         stderr(reasoningWarning);
       }
-      const tmuxCommands = buildTmuxCommands(parsed.agent, tmuxCommand, prompt.prompt, cwd, env, parsed.tmuxName);
+      const tmuxCommands = buildTmuxCommands(
+        parsed.agent,
+        tmuxCommand,
+        prompt.prompt,
+        cwd,
+        env,
+        parsed.sessionAlias ?? parsed.tmuxName,
+      );
 
       if (parsed.printCommand) {
         stdout(`${quoteCommand(tmuxCommands.newSession)}\n`);
@@ -1340,15 +1590,19 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return code;
     }
 
+    let sessionPlan = buildSessionPlan(parsed.agent, parsed.sessionAlias, env);
+    if (!parsed.printCommand) {
+      sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env);
+    }
     let command = buildAgentCommand(
       parsed.agent,
-      {
+      applySessionPlan({
         prompt: prompt.prompt,
         promptFile: prompt.promptFile,
         model: configuredDefaults.model,
         allow: parsed.allow,
         reasoningEffort: configuredDefaults.reasoningEffort,
-      },
+      }, sessionPlan),
       env,
     );
     const reasoningWarning = unsupportedReasoningEffortWarning(parsed.agent, configuredDefaults.reasoningEffort, "headless");
@@ -1390,7 +1644,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
 
     const stdoutHandling: StdoutHandling = parsed.json
-      ? "stream"
+      ? parsed.sessionAlias
+        ? "capture-and-stream"
+        : "stream"
       : parsed.debug
         ? "capture-and-stream"
         : "capture";
@@ -1422,6 +1678,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
           stdout,
           stdoutHandling,
         });
+    if (result.code === 0 && sessionPlan) {
+      await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);
+    }
     if (parsed.json) {
       return result.code;
     }

--- a/src/output.ts
+++ b/src/output.ts
@@ -259,5 +259,26 @@ export function extractFinalMessage(agent: AgentName, stdout: string): string {
   return candidates.at(-1)?.trim() ?? "";
 }
 
+export function extractNativeSessionId(agent: AgentName, stdout: string): string {
+  const records = parseJsonValues(stdout).flatMap(flattenRecords);
+  for (const record of records) {
+    if (agent === "codex") {
+      const threadId = asString(record.thread_id).trim();
+      if (asString(record.type).trim().toLowerCase() === "thread.started" && threadId) {
+        return threadId;
+      }
+    }
+
+    if (agent === "opencode") {
+      const sessionId = asString(record.sessionID).trim() || asString(record.sessionId).trim();
+      if (sessionId) return sessionId;
+    }
+
+    const sessionId = asString(record.session_id).trim() || asString(record.sessionId).trim();
+    if (sessionId) return sessionId;
+  }
+  return "";
+}
+
 export { extractUsageSummary, fetchModelsDevPricing, priceUsageSummary } from "./usage.js";
 export type { UsageCostBreakdown, UsageSummary } from "./usage.js";

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,0 +1,76 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { AgentName, Env } from "./types.js";
+
+export interface StoredSession {
+  agent: AgentName;
+  alias: string;
+  nativeId: string;
+  workDir?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SessionStoreFile {
+  version: 1;
+  agents: Partial<Record<AgentName, Record<string, StoredSession>>>;
+}
+
+export function sessionStorePath(env: Env): string | undefined {
+  return env.HOME ? join(env.HOME, ".headless", "sessions.json") : undefined;
+}
+
+export function readStoredSession(env: Env, agent: AgentName, alias: string): StoredSession | undefined {
+  return readSessionStore(env).agents[agent]?.[alias];
+}
+
+export function writeStoredSession(
+  env: Env,
+  session: Pick<StoredSession, "agent" | "alias" | "nativeId" | "workDir">,
+): StoredSession {
+  const path = sessionStorePath(env);
+  if (!path) {
+    throw new Error("HOME is required for --session");
+  }
+
+  const store = readSessionStore(env);
+  const existing = store.agents[session.agent]?.[session.alias];
+  const now = new Date().toISOString();
+  const stored: StoredSession = {
+    agent: session.agent,
+    alias: session.alias,
+    nativeId: session.nativeId,
+    workDir: session.workDir,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  store.agents[session.agent] = { ...(store.agents[session.agent] ?? {}), [session.alias]: stored };
+  mkdirSync(dirname(path), { recursive: true });
+  const tmpPath = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmpPath, `${JSON.stringify(store, null, 2)}\n`);
+  renameSync(tmpPath, path);
+  return stored;
+}
+
+function readSessionStore(env: Env): SessionStoreFile {
+  const path = sessionStorePath(env);
+  if (!path || !existsSync(path)) {
+    return emptyStore();
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<SessionStoreFile>;
+    if (parsed.version !== 1 || !parsed.agents || typeof parsed.agents !== "object") {
+      return emptyStore();
+    }
+    return { version: 1, agents: parsed.agents };
+  } catch {
+    return emptyStore();
+  }
+}
+
+function emptyStore(): SessionStoreFile {
+  return { version: 1, agents: {} };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,9 @@ export interface BuildOptions {
   model?: string;
   allow?: AllowMode;
   reasoningEffort?: ReasoningEffort;
+  sessionAlias?: string;
+  sessionId?: string;
+  sessionMode?: "new" | "resume";
 }
 
 export interface BuiltCommand {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -793,6 +793,51 @@ test("CLI --session pre-creates and stores Cursor chats", async () => {
   }
 });
 
+test("CLI --session stores the newest Gemini session when list output is oldest first", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "gemini-args.jsonl");
+    mkdirSync(home);
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      await writeFile(
+        join(binDir, "gemini"),
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
+          "if (args.includes('--list-sessions')) {",
+          "  console.log('Available sessions for this project (2):');",
+          "  console.log('  1. older session (4 hours ago) [11111111-1111-4111-8111-111111111111]');",
+          "  console.log('  2. newest session (1 hour ago) [22222222-2222-4222-8222-222222222222]');",
+          "  process.exit(0);",
+          "}",
+          "console.log(JSON.stringify({ response: 'gemini done' }));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(join(binDir, "gemini"), 0o755);
+    });
+
+    const stdout: string[] = [];
+    const env = { ...process.env, HEADLESS_CAPTURE: captureFile, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` };
+    const code = await runCli(["gemini", "--session", "work", "--prompt", "hello"], {
+      env,
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "gemini done\n");
+    const store = JSON.parse(readFileSync(join(home, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.gemini.work.nativeId, "22222222-2222-4222-8222-222222222222");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI rejects invalid --session combinations", async () => {
   const stderr: string[] = [];
   assert.equal(await runCli(["codex", "--session", "bad/name", "--prompt", "hello"], { stderr: (text) => stderr.push(text) }), 2);

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -294,6 +294,95 @@ test("builds claude, cursor, gemini, opencode, and pi prompt commands", () => {
   });
 });
 
+test("builds native session commands for supported agents", () => {
+  assert.deepEqual(
+    buildAgentCommand("claude", {
+      prompt: "hello",
+      sessionAlias: "work",
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      sessionMode: "new",
+    }, {}).args,
+    [
+      "--model",
+      "claude-opus-4-6",
+      "-p",
+      "--session-id",
+      "11111111-1111-4111-8111-111111111111",
+      "--name",
+      "work",
+      "hello",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--dangerously-skip-permissions",
+    ],
+  );
+
+  assert.deepEqual(buildAgentCommand("codex", { prompt: "hello", sessionId: "thread-1", sessionMode: "resume" }, {}).args, [
+    "--dangerously-bypass-approvals-and-sandbox",
+    "exec",
+    "resume",
+    "--model",
+    "gpt-5.5",
+    "--json",
+    "--skip-git-repo-check",
+    "thread-1",
+    "-",
+  ]);
+
+  assert.deepEqual(buildAgentCommand("cursor", { prompt: "hello", sessionId: "chat-1", sessionMode: "resume" }, {}).args, [
+    "-p",
+    "--force",
+    "--output-format",
+    "stream-json",
+    "--resume",
+    "chat-1",
+    "--model",
+    "gpt-5.5-medium",
+    "hello",
+  ]);
+
+  assert.deepEqual(buildAgentCommand("gemini", { prompt: "hello", sessionId: "gem-1", sessionMode: "resume" }, {}).args, [
+    "--model",
+    "gemini-3.1-pro-preview",
+    "--skip-trust",
+    "--resume",
+    "gem-1",
+    "-p",
+    "hello",
+    "--output-format",
+    "stream-json",
+    "--approval-mode",
+    "yolo",
+  ]);
+
+  assert.deepEqual(buildAgentCommand("opencode", { prompt: "hello", sessionAlias: "work", sessionMode: "new" }, {}).args, [
+    "run",
+    "--format",
+    "json",
+    "--model",
+    "openai/gpt-5.4",
+    "--dangerously-skip-permissions",
+    "--title",
+    "work",
+    "hello",
+  ]);
+
+  assert.deepEqual(buildAgentCommand("pi", { prompt: "hello", sessionId: "pi-1", sessionMode: "resume" }, {}).args, [
+    "--mode",
+    "json",
+    "--provider",
+    "openai-codex",
+    "--model",
+    "gpt-5.5",
+    "--session",
+    "pi-1",
+    "--tools",
+    "read,bash,edit,write",
+    "hello",
+  ]);
+});
+
 test("builds interactive commands for tmux mode", () => {
   assert.deepEqual(buildInteractiveAgentCommand("codex", { prompt: "hello", model: "gpt-next" }, {}), {
     command: "codex",
@@ -616,6 +705,114 @@ test("CLI accepts stdin fallback", async () => {
     stdout.join(""),
     "pi --no-session --mode json --provider openai-codex --model gpt-5.5 --tools 'read,bash,edit,write' 'stdin prompt'\n",
   );
+});
+
+test("CLI --session creates and resumes a Codex alias", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "codex-args.jsonl");
+    mkdirSync(home);
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      await writeFile(
+        join(binDir, "codex"),
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
+          "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }));",
+          "console.log(JSON.stringify({ type: 'agent_message', text: args.includes('resume') ? 'resumed' : 'started' }));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(join(binDir, "codex"), 0o755);
+    });
+
+    const stdout: string[] = [];
+    const env = { ...process.env, HEADLESS_CAPTURE: captureFile, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` };
+    assert.equal(await runCli(["codex", "--session", "work", "--prompt", "hello"], { env, stdout: (text) => stdout.push(text) }), 0);
+    assert.equal(stdout.join(""), "started\n");
+    const store = JSON.parse(readFileSync(join(home, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.codex.work.nativeId, "thread-1");
+
+    stdout.length = 0;
+    assert.equal(await runCli(["codex", "--session", "work", "--prompt", "again"], { env, stdout: (text) => stdout.push(text) }), 0);
+    assert.equal(stdout.join(""), "resumed\n");
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(calls[1].includes("resume"), true);
+    assert.equal(calls[1].includes("thread-1"), true);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --session pre-creates and stores Cursor chats", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "agent-args.jsonl");
+    mkdirSync(home);
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      await writeFile(
+        join(binDir, "agent"),
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
+          "if (args[0] === 'create-chat') { console.log('chat-1'); process.exit(0); }",
+          "console.log(JSON.stringify({ role: 'assistant', content: 'cursor done' }));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(join(binDir, "agent"), 0o755);
+    });
+
+    const stdout: string[] = [];
+    const env = { ...process.env, HEADLESS_CAPTURE: captureFile, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` };
+    const code = await runCli(["cursor", "--session", "work", "--prompt", "hello"], {
+      env,
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "cursor done\n");
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(calls[0], ["create-chat"]);
+    assert.equal(calls[1].includes("--resume"), true);
+    assert.equal(calls[1].includes("chat-1"), true);
+    const store = JSON.parse(readFileSync(join(home, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.cursor.work.nativeId, "chat-1");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI rejects invalid --session combinations", async () => {
+  const stderr: string[] = [];
+  assert.equal(await runCli(["codex", "--session", "bad/name", "--prompt", "hello"], { stderr: (text) => stderr.push(text) }), 2);
+  assert.match(stderr.join(""), /invalid session name/);
+
+  stderr.length = 0;
+  assert.equal(
+    await runCli(["codex", "--session", "work", "--name", "other", "--tmux", "--prompt", "hello"], {
+      stderr: (text) => stderr.push(text),
+    }),
+    2,
+  );
+  assert.match(stderr.join(""), /--session cannot be used with --name/);
+
+  stderr.length = 0;
+  assert.equal(
+    await runCli(["codex", "--session", "work", "--docker", "--prompt", "hello"], { stderr: (text) => stderr.push(text) }),
+    2,
+  );
+  assert.match(stderr.join(""), /--session cannot be used with --docker/);
 });
 
 test("CLI --docker print-command wraps the selected agent command", async () => {
@@ -1441,6 +1638,64 @@ test("CLI --tmux launches an interactive tmux session and sends the prompt", asy
     ]);
     assert.match(sessionName, /^headless-codex-\d+$/);
     assert.match(stdout.join(""), new RegExp(`tmux attach-session -t ${sessionName}`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --tmux --session starts or sends to a named tmux session", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "tmux.jsonl");
+    const stateFile = join(dir, "active");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      await writeFile(
+        join(binDir, "tmux"),
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
+          "if (args[0] === 'has-session') process.exit(fs.existsSync(process.env.HEADLESS_TMUX_ACTIVE) ? 0 : 1);",
+          "if (args[0] === 'new-session') fs.writeFileSync(process.env.HEADLESS_TMUX_ACTIVE, '1');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(join(binDir, "tmux"), 0o755);
+    });
+
+    const env = {
+      ...process.env,
+      HEADLESS_TMUX_ACTIVE: stateFile,
+      HEADLESS_TMUX_CAPTURE: captureFile,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    const stdout: string[] = [];
+    assert.equal(
+      await runCli(["codex", "--prompt", "hello", "--work-dir", dir, "--tmux", "--session", "work"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.match(stdout.join(""), /tmux session: headless-codex-work/);
+
+    stdout.length = 0;
+    assert.equal(
+      await runCli(["codex", "--prompt", "again", "--work-dir", dir, "--tmux", "--session", "work"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "sent: headless-codex-work\n");
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(calls[0], ["has-session", "-t", "headless-codex-work"]);
+    assert.deepEqual(calls[1].slice(0, 4), ["new-session", "-d", "-s", "headless-codex-work"]);
+    assert.deepEqual(calls.at(-3), ["set-buffer", "-b", "headless-codex-work-send", "again"]);
+    assert.deepEqual(calls.at(-1), ["send-keys", "-t", "headless-codex-work", "Enter"]);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("pre-push hook builds and runs integration tests through the repo CLI", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-hook-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "npm-args.jsonl");
+    mkdirSync(binDir);
+    writeFileSync(
+      join(binDir, "npm"),
+      [
+        "#!/bin/sh",
+        "printf '%s\\t%s\\n' \"$*\" \"${HEADLESS_BIN:-}\" >> \"$HEADLESS_HOOK_CAPTURE\"",
+        "exit 0",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(".githooks/pre-push", {
+      cwd: repoRoot,
+      env: {
+        HEADLESS_HOOK_CAPTURE: captureFile,
+        PATH: `${binDir}:/bin:/usr/bin`,
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => line.split("\t"));
+    assert.deepEqual(calls, [
+      ["run build", ""],
+      ["run test:integration:local", join(repoRoot, "dist", "cli.js")],
+    ]);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/integration-local.test.ts
+++ b/tests/integration-local.test.ts
@@ -77,7 +77,7 @@ async function run(command: string, args: string[], options: RunOptions = {}): P
 }
 
 async function headless(args: string[], options: RunOptions = {}): Promise<CommandResult> {
-  return await run("headless", args, options);
+  return await run(process.env.HEADLESS_BIN ?? "headless", args, options);
 }
 
 function assertSuccess(result: CommandResult, label: string): void {

--- a/tests/integration-local.test.ts
+++ b/tests/integration-local.test.ts
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const agents = ["claude", "codex", "cursor", "gemini", "opencode", "pi"] as const;
+const commandTimeoutMs = Number.parseInt(process.env.HEADLESS_INTEGRATION_TIMEOUT_MS ?? "300000", 10);
+const dockerTimeoutMs = Number.parseInt(process.env.HEADLESS_INTEGRATION_DOCKER_TIMEOUT_MS ?? "900000", 10);
+const modalTimeoutMs = Number.parseInt(process.env.HEADLESS_INTEGRATION_MODAL_TIMEOUT_MS ?? "1200000", 10);
+const suiteNonce = `headless-local-${Date.now()}-${process.pid}`;
+const createdTmuxSessions = new Set<string>();
+const createdCursorTrustDirs = new Set<string>();
+
+interface CommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+interface RunOptions {
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+async function run(command: string, args: string[], options: RunOptions = {}): Promise<CommandResult> {
+  const timeoutMs = options.timeoutMs ?? commandTimeoutMs;
+  return await new Promise<CommandResult>((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 2000).unref();
+    }, timeoutMs);
+
+    const finish = (code: number) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut });
+    };
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      stderr += `${error.message}\n`;
+      finish(127);
+    });
+    child.on("close", (code, signal) => {
+      finish(timedOut ? 124 : signal ? 1 : (code ?? 1));
+    });
+  });
+}
+
+async function headless(args: string[], options: RunOptions = {}): Promise<CommandResult> {
+  return await run("headless", args, options);
+}
+
+function assertSuccess(result: CommandResult, label: string): void {
+  assert.equal(
+    result.code,
+    0,
+    [
+      `${label} failed with exit code ${result.code}${result.timedOut ? " after timeout" : ""}`,
+      "stdout:",
+      result.stdout,
+      "stderr:",
+      result.stderr,
+    ].join("\n"),
+  );
+}
+
+function assertNonce(result: CommandResult, nonce: string, label: string): void {
+  assertSuccess(result, label);
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    new RegExp(escapeRegExp(nonce)),
+    `${label} did not include nonce ${nonce}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function prompt(nonce: string): string {
+  return `Read-only check. Reply with this nonce and no file edits: ${nonce}`;
+}
+
+function tempWorkdir(label: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `headless-${label}-`));
+  writeFileSync(join(dir, "README.md"), `# ${label}\n\nTemporary Headless local integration workspace.\n`);
+  return dir;
+}
+
+function prepareAgentWorkdir(agent: (typeof agents)[number], dir: string): void {
+  if (agent === "cursor") {
+    trustCursorWorkspace(dir);
+  }
+}
+
+function trustCursorWorkspace(dir: string): void {
+  const workspace = realpathSync(dir);
+  const projectDir = join(process.env.HOME ?? homedir(), ".cursor", "projects", cursorProjectKey(workspace));
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(
+    join(projectDir, ".workspace-trusted"),
+    `${JSON.stringify({ trustedAt: new Date().toISOString(), workspacePath: workspace }, null, 2)}\n`,
+  );
+  createdCursorTrustDirs.add(projectDir);
+}
+
+function cursorProjectKey(workspace: string): string {
+  return workspace.replace(/^\/+/, "").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+async function tempGitWorkdir(label: string): Promise<string> {
+  const dir = tempWorkdir(label);
+  assertSuccess(await run("git", ["init"], { cwd: dir, timeoutMs: 30000 }), "git init");
+  return dir;
+}
+
+function sessionsPath(): string {
+  return join(process.env.HOME ?? homedir(), ".headless", "sessions.json");
+}
+
+function snapshotSessionStore(): () => void {
+  const path = sessionsPath();
+  const existed = existsSync(path);
+  const original = existed ? readFileSync(path) : undefined;
+  return () => {
+    if (original) {
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, original);
+      return;
+    }
+    if (!existed) {
+      rmSync(path, { force: true });
+    }
+  };
+}
+
+function modalConfigured(): boolean {
+  return Boolean(
+    (process.env.MODAL_TOKEN_ID && process.env.MODAL_TOKEN_SECRET) ||
+      existsSync(join(process.env.HOME ?? homedir(), ".modal.toml")),
+  );
+}
+
+async function killCreatedTmuxSessions(): Promise<void> {
+  await Promise.all(
+    [...createdTmuxSessions].map((session) =>
+      run("tmux", ["kill-session", "-t", session], { timeoutMs: 30000 }).catch(() => ({
+        code: 1,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+      })),
+    ),
+  );
+}
+
+test.after(async () => {
+  await killCreatedTmuxSessions();
+  for (const dir of createdCursorTrustDirs) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("preflight verifies global Headless, backends, Docker, Modal, and tmux", { timeout: 120000 }, async () => {
+  const help = await headless(["--help"], { timeoutMs: 30000 });
+  assertSuccess(help, "headless --help");
+  assert.match(help.stdout, /--session/, "global headless must support --session; reinstall or npm link this repo");
+
+  const check = await headless(["--check"], { timeoutMs: 120000 });
+  assertSuccess(check, "headless --check");
+  for (const agent of agents) {
+    assert.match(
+      check.stdout,
+      new RegExp(`^${agent}\\s+✓\\s+`, "m"),
+      `missing ${agent} backend in \`headless --check\`; install and authenticate all six backends`,
+    );
+  }
+  assert.match(check.stdout, /^docker\s+✓\s+/m, "Docker must be installed and running");
+
+  const docker = await run("docker", ["info"], { timeoutMs: 30000 });
+  assertSuccess(docker, "docker info");
+
+  const tmux = await run("tmux", ["-V"], { timeoutMs: 30000 });
+  assertSuccess(tmux, "tmux -V");
+
+  assert.equal(
+    modalConfigured(),
+    true,
+    "Modal must be configured with MODAL_TOKEN_ID/MODAL_TOKEN_SECRET or ~/.modal.toml",
+  );
+});
+
+test("all backends complete a basic read-only run", { timeout: commandTimeoutMs * agents.length }, async () => {
+  for (const agent of agents) {
+    const dir = tempWorkdir(`${agent}-basic`);
+    try {
+      prepareAgentWorkdir(agent, dir);
+      const nonce = `${suiteNonce}-${agent}-basic`;
+      const result = await headless([agent, "--work-dir", dir, "--allow", "read-only", "--prompt", prompt(nonce)], {
+        timeoutMs: commandTimeoutMs,
+      });
+      assertNonce(result, nonce, `${agent} basic run`);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+test("all backends support --json, --debug, and --usage", { timeout: commandTimeoutMs * agents.length * 3 }, async () => {
+  for (const agent of agents) {
+    for (const mode of ["--json", "--debug", "--usage"]) {
+      const dir = tempWorkdir(`${agent}-${mode.slice(2)}`);
+      try {
+        prepareAgentWorkdir(agent, dir);
+        const nonce = `${suiteNonce}-${agent}-${mode.slice(2)}`;
+        const result = await headless(
+          [agent, "--work-dir", dir, "--allow", "read-only", mode, "--prompt", prompt(nonce)],
+          { timeoutMs: commandTimeoutMs },
+        );
+        assertNonce(result, nonce, `${agent} ${mode}`);
+        if (mode === "--usage") {
+          assert.match(result.stdout, /"usage"\s*:/, `${agent} --usage did not print usage JSON`);
+        }
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    }
+  }
+});
+
+test("all backends start and resume native --session aliases", { timeout: commandTimeoutMs * agents.length * 2 }, async () => {
+  const restoreSessions = snapshotSessionStore();
+  try {
+    for (const agent of agents) {
+      const dir = tempWorkdir(`${agent}-session`);
+      try {
+        prepareAgentWorkdir(agent, dir);
+        const alias = `${suiteNonce}-${agent}-native`.replace(/[^A-Za-z0-9_.-]/g, "-");
+        const firstNonce = `${alias}-start`;
+        const secondNonce = `${alias}-resume`;
+        assertNonce(
+          await headless([agent, "--work-dir", dir, "--allow", "read-only", "--session", alias, "--prompt", prompt(firstNonce)], {
+            timeoutMs: commandTimeoutMs,
+          }),
+          firstNonce,
+          `${agent} --session start`,
+        );
+        assertNonce(
+          await headless(
+            [agent, "--work-dir", dir, "--allow", "read-only", "--session", alias, "--prompt", prompt(secondNonce)],
+            { timeoutMs: commandTimeoutMs },
+          ),
+          secondNonce,
+          `${agent} --session resume`,
+        );
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    }
+  } finally {
+    restoreSessions();
+  }
+});
+
+test("all backends start and send to --tmux --session aliases", { timeout: commandTimeoutMs * agents.length * 2 }, async () => {
+  for (const agent of agents) {
+    const dir = tempWorkdir(`${agent}-tmux`);
+    const alias = `${suiteNonce}-${agent}-tmux`.replace(/[^A-Za-z0-9_.-]/g, "-");
+    const sessionName = `headless-${agent}-${alias}`;
+    createdTmuxSessions.add(sessionName);
+    try {
+      const first = await headless(
+        [agent, "--work-dir", dir, "--allow", "read-only", "--tmux", "--session", alias, "--prompt", prompt(`${alias}-start`)],
+        { timeoutMs: commandTimeoutMs },
+      );
+      assertSuccess(first, `${agent} --tmux --session start`);
+      assert.match(first.stdout, new RegExp(`tmux session: ${escapeRegExp(sessionName)}`));
+
+      const second = await headless(
+        [agent, "--work-dir", dir, "--allow", "read-only", "--tmux", "--session", alias, "--prompt", prompt(`${alias}-send`)],
+        { timeoutMs: commandTimeoutMs },
+      );
+      assertSuccess(second, `${agent} --tmux --session send`);
+      assert.match(second.stdout, new RegExp(`sent: ${escapeRegExp(sessionName)}`));
+    } finally {
+      await run("tmux", ["kill-session", "-t", sessionName], { timeoutMs: 30000 });
+      createdTmuxSessions.delete(sessionName);
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+test("Codex completes through Docker", { timeout: dockerTimeoutMs }, async () => {
+  const dir = tempWorkdir("codex-docker");
+  try {
+    const nonce = `${suiteNonce}-codex-docker`;
+    const result = await headless(
+      ["codex", "--docker", "--work-dir", dir, "--allow", "read-only", "--prompt", prompt(nonce)],
+      { timeoutMs: dockerTimeoutMs },
+    );
+    assertNonce(result, nonce, "Codex Docker smoke");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Codex completes through Modal in a temporary git workdir", { timeout: modalTimeoutMs }, async () => {
+  const dir = await tempGitWorkdir("codex-modal");
+  try {
+    const nonce = `${suiteNonce}-codex-modal`;
+    const result = await headless(
+      [
+        "codex",
+        "--modal",
+        "--modal-timeout",
+        String(Math.ceil(modalTimeoutMs / 1000)),
+        "--work-dir",
+        dir,
+        "--allow",
+        "read-only",
+        "--prompt",
+        prompt(nonce),
+      ],
+      { timeoutMs: modalTimeoutMs },
+    );
+    assertNonce(result, nonce, "Codex Modal smoke");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/integration-local.test.ts
+++ b/tests/integration-local.test.ts
@@ -334,6 +334,25 @@ test("Codex completes through Docker", { timeout: dockerTimeoutMs }, async () =>
   }
 });
 
+test("Codex Docker non-smoke modes return nonce output", { timeout: dockerTimeoutMs * 3 }, async () => {
+  for (const mode of ["--json", "--debug", "--usage"]) {
+    const dir = tempWorkdir(`codex-docker-${mode.slice(2)}`);
+    try {
+      const nonce = `${suiteNonce}-codex-docker-${mode.slice(2)}`;
+      const result = await headless(
+        ["codex", "--docker", "--work-dir", dir, "--allow", "read-only", mode, "--prompt", prompt(nonce)],
+        { timeoutMs: dockerTimeoutMs },
+      );
+      assertNonce(result, nonce, `Codex Docker ${mode}`);
+      if (mode === "--usage") {
+        assert.match(result.stdout, /"usage"\s*:/, "Codex Docker --usage did not print usage JSON");
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
 test("Codex completes through Modal in a temporary git workdir", { timeout: modalTimeoutMs }, async () => {
   const dir = await tempGitWorkdir("codex-modal");
   try {
@@ -356,5 +375,36 @@ test("Codex completes through Modal in a temporary git workdir", { timeout: moda
     assertNonce(result, nonce, "Codex Modal smoke");
   } finally {
     rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Codex Modal non-smoke modes return nonce output", { timeout: modalTimeoutMs * 3 }, async () => {
+  for (const mode of ["--json", "--debug", "--usage"]) {
+    const dir = await tempGitWorkdir(`codex-modal-${mode.slice(2)}`);
+    try {
+      const nonce = `${suiteNonce}-codex-modal-${mode.slice(2)}`;
+      const result = await headless(
+        [
+          "codex",
+          "--modal",
+          "--modal-timeout",
+          String(Math.ceil(modalTimeoutMs / 1000)),
+          "--work-dir",
+          dir,
+          "--allow",
+          "read-only",
+          mode,
+          "--prompt",
+          prompt(nonce),
+        ],
+        { timeoutMs: modalTimeoutMs },
+      );
+      assertNonce(result, nonce, `Codex Modal ${mode}`);
+      if (mode === "--usage") {
+        assert.match(result.stdout, /"usage"\s*:/, "Codex Modal --usage did not print usage JSON");
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   }
 });


### PR DESCRIPTION
## What changed
- Added an opt-in real-agent local integration suite covering all six Headless backends, output modes, native sessions, tmux sessions, Docker, and Modal.
- Added a tracked .githooks/pre-push hook that blocks pushes unless the local integration suite passes.
- Added package scripts for installing the hook and running the local integration suite while keeping it out of npm test and npm run check.

## Why
The full real-agent integration suite should be available and enforced locally before push, without making normal unit checks depend on authenticated providers, Docker, or Modal.

## How to test
- npm run hooks:install
- npm run check
- npm run test:integration:local

## Verification
- npm run hooks:install
- npm run check: passed, 151 tests
- git push with enabled pre-push hook: passed npm run test:integration:local, 7/7 tests including Docker and Modal