### PR TITLE
feat: report agent auth availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added API/OAuth credential signal reporting to `headless --check` for supported agent backends.
 - Added named native session aliases for headless and tmux modes, stored per agent in `~/.headless/sessions.json`. Thanks @RobertTLange for PR #7.
 - Added a local integration suite plus a tracked pre-push hook that builds the local CLI before running integration coverage.
 - Added expanded Docker and Modal integration coverage for Codex `--json`, `--debug`, and `--usage` modes.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Options:
 - `rename <session-name> <new-name>`: rename an existing Headless tmux session.
 - `docker doctor`: check Docker setup and image availability.
 - `docker build`: build the packaged Dockerfile as `headless-local:dev`, or `--docker-image <image>`.
-- `--check`: check which supported agent binaries are installed and print their versions.
+- `--check`: check which supported agent binaries are installed, print their versions, and report local API/OAuth credential signals.
 - `--list`: list active tmux sessions created by Headless, including state and timestamps.
 - `--print-command`: print the shell command without executing it.
 - `--show-config`: print config paths and auth seed paths for an agent.

--- a/src/check.ts
+++ b/src/check.ts
@@ -15,6 +15,7 @@ interface AgentCheck {
   agent: AgentName;
   command: string;
   available: boolean;
+  auth: AuthLabel;
   version: string;
 }
 
@@ -25,6 +26,8 @@ interface DockerCheck {
   image: string;
   imageAvailable: boolean;
 }
+
+type AuthLabel = "-" | "api" | "oauth" | "api+oauth";
 
 export function commandForAgent(agent: AgentName, env: Env): string {
   if (agent === "cursor") {
@@ -65,6 +68,66 @@ export function findExecutable(command: string, env: Env): string | undefined {
 
 export function commandExists(command: string, env: Env): boolean {
   return findExecutable(command, env) !== undefined;
+}
+
+const commonProviderApiEnvNames = [
+  "ANTHROPIC_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+];
+
+const apiEnvNamesByAgent: Record<AgentName, string[]> = {
+  claude: ["ANTHROPIC_API_KEY"],
+  codex: ["CODEX_API_KEY", "OPENAI_API_KEY"],
+  cursor: ["CURSOR_API_KEY"],
+  gemini: ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"],
+  opencode: commonProviderApiEnvNames,
+  pi: ["PI_CODING_AGENT_API_KEY", ...commonProviderApiEnvNames],
+};
+
+const oauthEnvNamesByAgent: Record<AgentName, string[]> = {
+  claude: ["CLAUDE_CODE_OAUTH_TOKEN"],
+  codex: [],
+  cursor: [],
+  gemini: [],
+  opencode: [],
+  pi: [],
+};
+
+const oauthPathsByAgent: Record<AgentName, string[]> = {
+  claude: [".claude/.credentials.json", ".claude/auth.json"],
+  codex: [".codex/auth.json"],
+  cursor: [".cursor/cli-config.json"],
+  gemini: [".gemini/google_accounts.json"],
+  opencode: [".config/opencode"],
+  pi: [".pi/agent/auth.json"],
+};
+
+function detectAuth(agent: AgentName, env: Env): AuthLabel {
+  const hasApi = apiEnvNamesByAgent[agent].some((name) => Boolean(env[name]));
+  const hasOauth =
+    oauthEnvNamesByAgent[agent].some((name) => Boolean(env[name])) ||
+    oauthPathsByAgent[agent].some((relPath) => homePathExists(env, relPath));
+
+  if (hasApi && hasOauth) return "api+oauth";
+  if (hasApi) return "api";
+  if (hasOauth) return "oauth";
+  return "-";
+}
+
+function homePathExists(env: Env, relPath: string): boolean {
+  if (!env.HOME) {
+    return false;
+  }
+  try {
+    statSync(join(env.HOME, relPath));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 const versionTimeoutMs = 5000;
@@ -155,6 +218,7 @@ export async function checkAgents(env: Env): Promise<AgentCheck[]> {
         agent,
         command,
         available: executable !== undefined,
+        auth: detectAuth(agent, env),
         version: executable ? await captureVersion(executable, env) : "-",
       };
     }),
@@ -181,10 +245,11 @@ export async function checkDocker(env: Env, image: string): Promise<DockerCheck>
 
 export function renderAgentChecks(checks: AgentCheck[]): string {
   const rows = [
-    ["Agent", "Status", "Version", "Binary"],
+    ["Agent", "Status", "Auth", "Version", "Binary"],
     ...checks.map((check) => [
       check.agent,
       check.available ? "✓" : "✗",
+      check.auth,
       check.version,
       check.command,
     ]),

--- a/src/check.ts
+++ b/src/check.ts
@@ -79,6 +79,8 @@ const commonProviderApiEnvNames = [
   "OPENROUTER_API_KEY",
 ];
 
+const awsCredentialEnvNames = ["AWS_ACCESS_KEY_ID", "AWS_PROFILE"];
+
 const apiEnvNamesByAgent: Record<AgentName, string[]> = {
   claude: ["ANTHROPIC_API_KEY"],
   codex: ["CODEX_API_KEY", "OPENAI_API_KEY"],
@@ -107,7 +109,7 @@ const oauthPathsByAgent: Record<AgentName, string[]> = {
 };
 
 function detectAuth(agent: AgentName, env: Env): AuthLabel {
-  const hasApi = apiEnvNamesByAgent[agent].some((name) => Boolean(env[name]));
+  const hasApi = hasApiAuth(agent, env);
   const hasOauth =
     oauthEnvNamesByAgent[agent].some((name) => Boolean(env[name])) ||
     oauthPathsByAgent[agent].some((relPath) => homePathExists(env, relPath));
@@ -116,6 +118,21 @@ function detectAuth(agent: AgentName, env: Env): AuthLabel {
   if (hasApi) return "api";
   if (hasOauth) return "oauth";
   return "-";
+}
+
+function hasApiAuth(agent: AgentName, env: Env): boolean {
+  if (apiEnvNamesByAgent[agent].some((name) => Boolean(env[name]))) {
+    return true;
+  }
+  return agent === "pi" && piUsesAwsProvider(env) && awsCredentialEnvNames.some((name) => Boolean(env[name]));
+}
+
+function piUsesAwsProvider(env: Env): boolean {
+  const model = env.PI_CODING_AGENT_MODEL;
+  const slashIndex = model?.indexOf("/") ?? -1;
+  const provider = slashIndex > 0 ? model?.slice(0, slashIndex) : env.PI_CODING_AGENT_PROVIDER;
+  const normalized = provider?.toLowerCase();
+  return normalized === "aws" || normalized?.startsWith("aws-") === true || normalized?.includes("bedrock") === true;
 }
 
 function homePathExists(env: Env, relPath: string): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,7 +154,7 @@ function usage(): string {
     "  rename <session> <name> Rename an existing headless tmux session.",
     "  docker doctor       Check Docker setup and image availability.",
     "  docker build        Build the local Docker image tag headless-local:dev.",
-    "  --check              Check installed agent binaries and versions.",
+    "  --check              Check installed agent binaries, versions, and local API/OAuth credentials.",
     "  --list               List active headless tmux sessions.",
     "  --print-command      Print the command without executing it.",
     "  --show-config        Print harness config paths and auth seed paths.",

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -63,13 +63,13 @@ test("CLI --check prints installed status and numeric versions for all agents", 
 
     const output = stdout.join("");
     assert.equal(code, 0);
-    assert.match(output, /^Agent\s+Status\s+Version\s+Binary/m);
-    assert.match(output, /^codex\s+✓\s+1\.2\.3\s+codex$/m);
-    assert.match(output, /^gemini\s+✓\s+0\.39\.1\s+gemini$/m);
-    assert.match(output, /^opencode\s+✓\s+1\.4\.10\s+opencode$/m);
-    assert.match(output, /^pi\s+✓\s+4\.5\.6\s+pi-agent$/m);
-    assert.match(output, /^claude\s+✗\s+-\s+claude$/m);
-    assert.match(output, /^cursor\s+✗\s+-\s+agent$/m);
+    assert.match(output, /^Agent\s+Status\s+Auth\s+Version\s+Binary/m);
+    assert.match(output, /^codex\s+✓\s+-\s+1\.2\.3\s+codex$/m);
+    assert.match(output, /^gemini\s+✓\s+-\s+0\.39\.1\s+gemini$/m);
+    assert.match(output, /^opencode\s+✓\s+-\s+1\.4\.10\s+opencode$/m);
+    assert.match(output, /^pi\s+✓\s+-\s+4\.5\.6\s+pi-agent$/m);
+    assert.match(output, /^claude\s+✗\s+-\s+-\s+claude$/m);
+    assert.match(output, /^cursor\s+✗\s+-\s+-\s+agent$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -97,7 +97,7 @@ test("CLI --check uses cursor env binary and strips hash suffixes", async () => 
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^cursor\s+✓\s+2026\.04\.17\s+cursor-agent$/m);
+    assert.match(stdout.join(""), /^cursor\s+✓\s+-\s+2026\.04\.17\s+cursor-agent$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -125,7 +125,7 @@ test("CLI --check keeps installed status when version probe fails", async () => 
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^cursor\s+✓\s+unknown\s+cursor-agent$/m);
+    assert.match(stdout.join(""), /^cursor\s+✓\s+-\s+unknown\s+cursor-agent$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -157,7 +157,7 @@ test("CLI --check retries transient empty version output", async () => {
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^cursor\s+✓\s+9\.8\.7\s+cursor-agent$/m);
+    assert.match(stdout.join(""), /^cursor\s+✓\s+-\s+9\.8\.7\s+cursor-agent$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -188,6 +188,64 @@ test("CLI --check reports docker and default image status", async () => {
     assert.equal(code, 0);
     assert.match(stdout.join(""), /^Docker\s+Status\s+Version\s+Default image$/m);
     assert.match(stdout.join(""), /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/roberttlange\/headless:latest \(present\)$/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --check reports API auth from environment variables", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const stdout: string[] = [];
+    const code = await runCli(["--check"], {
+      env: { PATH: join(dir, "bin"), OPENAI_API_KEY: "sk-test" },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^codex\s+✗\s+api\s+-\s+codex$/m);
+    assert.match(stdout.join(""), /^opencode\s+✗\s+api\s+-\s+opencode$/m);
+    assert.match(stdout.join(""), /^pi\s+✗\s+api\s+-\s+pi$/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --check reports OAuth auth from local seed files", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(join(home, ".codex", "auth.json"), "{}\n");
+
+    const stdout: string[] = [];
+    const code = await runCli(["--check"], {
+      env: { HOME: home, PATH: join(dir, "bin") },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^codex\s+✗\s+oauth\s+-\s+codex$/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --check reports combined API and OAuth auth", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(join(home, ".codex", "auth.json"), "{}\n");
+
+    const stdout: string[] = [];
+    const code = await runCli(["--check"], {
+      env: { CODEX_API_KEY: "codex-test", HOME: home, PATH: join(dir, "bin") },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^codex\s+✗\s+api\+oauth\s+-\s+codex$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -250,3 +250,40 @@ test("CLI --check reports combined API and OAuth auth", async () => {
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("CLI --check reports Pi API auth from AWS credentials for Bedrock provider", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const stdout: string[] = [];
+    const code = await runCli(["--check"], {
+      env: {
+        AWS_PROFILE: "dev",
+        PATH: join(dir, "bin"),
+        PI_CODING_AGENT_PROVIDER: "bedrock",
+        PI_CODING_AGENT_MODEL: "opus",
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^pi\s+✗\s+api\s+-\s+pi$/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --check does not report Pi AWS auth for the default OpenAI provider", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const stdout: string[] = [];
+    const code = await runCli(["--check"], {
+      env: { AWS_PROFILE: "dev", PATH: join(dir, "bin") },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^pi\s+✗\s+-\s+-\s+pi$/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## What changed
- Add an Auth column to `headless --check` for local API/OAuth credential signals.
- Detect per-agent credential availability from supported env vars and known auth/config seed paths.
- Update CLI help, README docs, changelog, and check coverage.

## Why
This makes setup checks show whether installed agent CLIs also appear to have local API or OAuth credentials available, without validating tokens or making network calls.

## How to test
- `npm run check`
- pre-push hook: build + Codex local integration suite