### PR TITLE
Improve coordinated run observability

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,9 +10,11 @@ hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH= cd -- "$hook_dir/.." && pwd)
 headless_bin="$repo_root/dist/cli.js"
 integration_agents="codex"
+integration_full_sweep="0"
 
 if [ "${HEADLESS_HOOK_ALL_AGENTS:-}" = "1" ]; then
   integration_agents="all"
+  integration_full_sweep="1"
 fi
 
 cd "$repo_root"
@@ -29,7 +31,7 @@ EOF
 fi
 
 echo "headless pre-push: running local integration suite (${integration_agents})"
-if ! HEADLESS_BIN="$headless_bin" HEADLESS_INTEGRATION_AGENTS="$integration_agents" npm run test:integration:local; then
+if ! HEADLESS_BIN="$headless_bin" HEADLESS_INTEGRATION_AGENTS="$integration_agents" HEADLESS_INTEGRATION_FULL_SWEEP="$integration_full_sweep" npm run test:integration:local; then
   cat >&2 <<'EOF'
 headless pre-push: local integration suite failed.
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,7 +9,7 @@ fi
 hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH= cd -- "$hook_dir/.." && pwd)
 headless_bin="$repo_root/dist/cli.js"
-integration_agents="codex"
+integration_agents="claude"
 integration_full_sweep="0"
 
 if [ "${HEADLESS_HOOK_ALL_AGENTS:-}" = "1" ]; then
@@ -36,7 +36,7 @@ if ! HEADLESS_BIN="$headless_bin" HEADLESS_INTEGRATION_AGENTS="$integration_agen
 headless pre-push: local integration suite failed.
 
 Expected local prerequisites:
-  - Codex installed and authenticated by default
+  - Claude installed and authenticated by default
   - all six Headless backends installed and authenticated when HEADLESS_HOOK_ALL_AGENTS=1
   - Docker installed, running, and able to pull/run the default image
   - Modal configured with MODAL_TOKEN_ID/MODAL_TOKEN_SECRET or ~/.modal.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added a multi-agent role and run coordination spec in `docs/spec.md`.
 - Added a local integration suite plus a tracked pre-push hook that builds the local CLI before running integration coverage.
 - Added expanded Docker and Modal integration coverage for Codex `--json`, `--debug`, and `--usage` modes.
-- Changed the pre-push hook to run Codex integration by default; set `HEADLESS_HOOK_ALL_AGENTS=1` to run all agents.
+- Changed the pre-push hook to run Claude integration by default; set `HEADLESS_HOOK_ALL_AGENTS=1` to run all agents.
 - Changed read-only agent modes to preserve search/read capabilities where supported while still denying edits and shell execution.
 - Changed `headless --check`, `headless docker doctor`, and run views to use bordered, color-aware tables when appropriate.
 - Changed Docker run coordination to mount the host run directory into containers with `HEADLESS_RUN_DIR`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,23 @@
 
 - Added API/OAuth credential signal reporting to `headless --check` for supported agent backends.
 - Added named native session aliases for headless and tmux modes, stored per agent in `~/.headless/sessions.json`. Thanks @RobertTLange for PR #7.
+- Added role-aware coordinated runs with `--role orchestrator|explorer|worker|reviewer`, `--run`, `--node`, `--depends-on`, `--team`, and `--coordination session|tmux|oneshot`.
+- Added `headless run list|view|mark|message|wait` for local run observability, run graph rendering, node status updates, message routing, async child launches, and wait handling.
+- Added local run state under `~/.headless/runs`, including per-node logs, message/status events, usage metrics, private file permissions, and run-status stderr summaries for orchestrators.
+- Added configurable role defaults in `~/.headless/config.toml`, including role-specific model, reasoning effort, allow mode, and base instruction prompts.
+- Added `headless --version` and `headless -v` to print the packaged CLI version.
+- Added a multi-agent role and run coordination spec in `docs/spec.md`.
 - Added a local integration suite plus a tracked pre-push hook that builds the local CLI before running integration coverage.
 - Added expanded Docker and Modal integration coverage for Codex `--json`, `--debug`, and `--usage` modes.
 - Changed the pre-push hook to run Codex integration by default; set `HEADLESS_HOOK_ALL_AGENTS=1` to run all agents.
+- Changed read-only agent modes to preserve search/read capabilities where supported while still denying edits and shell execution.
+- Changed `headless --check`, `headless docker doctor`, and run views to use bordered, color-aware tables when appropriate.
+- Changed Docker run coordination to mount the host run directory into containers with `HEADLESS_RUN_DIR`.
+- Changed orchestrator pre-push coverage so `HEADLESS_HOOK_ALL_AGENTS=1` enables the full multi-agent integration sweep.
+- Fixed run and node ID validation to reject dot segments.
+- Fixed run nodes to be marked failed when setup or execution errors occur after registration.
+- Fixed `run message` so locked session/oneshot nodes do not record undelivered messages.
+- Fixed async `run message` wrappers to preserve child stderr in node logs and clean up node locks via shell traps.
 - Fixed the pre-push hook to run against the freshly built local CLI.
 - Fixed Gemini session alias persistence to select the newest native session.
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Modal mode is only for headless execution. It cannot be combined with `--docker`
 ### 7) Role and run coordination (`--role`, `--run`)
 
 Role mode adds compact instructions and, with `--run`, records a local roster, dependencies, statuses, recent messages, and log paths.
+When an orchestrator run executes locally or through Docker, Headless also writes timestamped lifecycle logs to stderr while it runs. The stream reports node status changes and message routes without printing prompt text, uses ANSI colors on TTYs unless `NO_COLOR` is set, and leaves stdout reserved for final answers or JSON/debug output. Tune the polling interval with `HEADLESS_RUN_STATUS_INTERVAL_MS` if needed. Modal orchestrator runs still rely on final synced run state and node logs for status.
 
 ```bash
 headless codex --role orchestrator --run auth --node orchestrator --team explorer --team worker=2 --prompt "Build auth"

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Modal mode is only for headless execution. It cannot be combined with `--docker`
 ### 7) Role and run coordination (`--role`, `--run`)
 
 Role mode adds compact instructions and, with `--run`, records a local roster, dependencies, statuses, recent messages, and log paths.
-When an orchestrator run executes locally or through Docker, Headless also writes timestamped lifecycle logs to stderr while it runs. The stream reports node status changes and message routes without printing prompt text, uses ANSI colors on TTYs unless `NO_COLOR` is set, and leaves stdout reserved for final answers or JSON/debug output. Tune the polling interval with `HEADLESS_RUN_STATUS_INTERVAL_MS` if needed. Modal orchestrator runs still rely on final synced run state and node logs for status.
+When an orchestrator run executes locally or through Docker, Headless also writes compact lifecycle logs to stderr while it runs. The stream reports node status changes and message routes without printing prompt text, uses short timestamps and ANSI colors on TTYs unless `NO_COLOR` is set, and leaves stdout reserved for final answers or JSON/debug output. Tune the polling interval with `HEADLESS_RUN_STATUS_INTERVAL_MS` if needed. Modal orchestrator runs still rely on final synced run state and node logs for status.
 
 ```bash
 headless codex --role orchestrator --run auth --node orchestrator --team explorer --team worker=2 --prompt "Build auth"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ headless codex --prompt "Summarize this repo" --model gpt-5 --usage
 headless codex --prompt "Fix the failing tests" --tmux
 # Start or resume a named native session.
 headless codex --prompt "Continue the fix" --session bughunt
+# Start an orchestrated run with a declared local team.
+headless codex --role orchestrator --run auth --node orchestrator --team explorer --team worker=2 --prompt "Build auth"
+# Inspect or message a coordinated run.
+headless run view auth
+headless run message auth worker-1 --prompt "Implement token refresh" --async
+headless run wait auth
 # Run the agent inside the default Docker image.
 headless codex --prompt "Fix the failing tests" --docker
 # Run the agent in a Modal CPU sandbox and sync edits back.
@@ -98,6 +104,10 @@ When no agent is specified, Headless selects the first installed agent in this o
 
 Pass `--session <name>` to start or resume a named session. Headless stores per-agent aliases in `~/.headless/sessions.json`, separate from `config.toml`, and maps each alias to the selected backend's native session id or session file. A missing alias starts a new session and records it after the run succeeds; an existing alias resumes that native session. In tmux mode, `--session <name>` maps to `headless-<agent>-<name>`: an active tmux session receives the prompt, otherwise Headless starts a new named tmux session. `--session` cannot be combined with `--name`, `--docker`, or `--modal`.
 
+Pass `--role orchestrator|explorer|worker|reviewer` to prepend role-specific coordination instructions. `explorer` and `reviewer` default to `--allow read-only` unless `--allow` is explicit; `worker` and `orchestrator` keep the normal edit-capable default. Add `--run <name>` and optional `--node <name>` to track local state in `~/.headless/runs/<name>/run.json`, with per-node logs under `nodes/<node>/`.
+
+Use `--coordination session|tmux|oneshot` to choose how a run node receives later messages. `session` resumes native Headless sessions, `tmux` sends through the existing tmux buffer flow, and `oneshot` launches a fresh stateless invocation. Orchestrators can declare prompt-only teams with repeatable `--team` specs such as `explorer`, `worker=2`, `claude/reviewer`, or `codex/worker=3`.
+
 ## User Defaults
 
 Headless reads optional model and reasoning defaults from `~/.headless/config.toml`. If the file is missing or unreadable, it silently falls back to built-in defaults.
@@ -134,7 +144,7 @@ reasoning_effort = "xhigh"
 
 The full template is tracked as `config.toml.example`.
 
-## 6 Execution Modes
+## 7 Execution Modes
 
 ### 1) Raw mode (default)
 
@@ -252,6 +262,26 @@ Modal mode requires a git workdir. By default, it uploads tracked and untracked 
 
 Modal mode is only for headless execution. It cannot be combined with `--docker`, `--tmux`, `send`, `rename`, or `--list`.
 
+### 7) Role and run coordination (`--role`, `--run`)
+
+Role mode adds compact instructions and, with `--run`, records a local roster, dependencies, statuses, recent messages, and log paths.
+
+```bash
+headless codex --role orchestrator --run auth --node orchestrator --team explorer --team worker=2 --prompt "Build auth"
+headless run view auth
+headless run message auth worker-1 --prompt "Continue with refresh token tests"
+headless run message auth reviewer --prompt "Review the diff" --async
+headless run wait auth
+```
+
+Run commands are local:
+
+- `headless run list`: list known runs.
+- `headless run view <run>`: render the graph, recent messages, and exact message/log/attach commands.
+- `headless run mark <run> <node> --status planned|starting|busy|idle|done|failed|unknown`: manually adjust status.
+- `headless run message <run> <node> --prompt "..." [--async]`: route a prompt using stored node metadata.
+- `headless run wait <run>`: wait until no nodes are `busy` or `starting`.
+
 ## CLI Reference
 
 ```bash
@@ -260,6 +290,7 @@ headless docker doctor [options]
 headless docker build [options]
 headless send <session-name> (--prompt <text> | --prompt-file <path>) [options]
 headless rename <session-name> <new-name> [options]
+headless run <list|view|mark|message|wait> [args] [options]
 ```
 
 Options:
@@ -269,6 +300,12 @@ Options:
 - `--model`, `--agent-model`: model override passed to the agent CLI.
 - `--reasoning-effort`: normalized reasoning effort, one of `low`, `medium`, `high`, or `xhigh`.
 - `--allow`: permission mode, either `read-only` or `yolo`.
+- `--role`: role prompt, one of `orchestrator`, `explorer`, `worker`, or `reviewer`.
+- `--coordination`: run coordination mode, one of `session`, `tmux`, or `oneshot`.
+- `--run`: local run id. Uses `~/.headless/runs/<run>` unless `HEADLESS_RUN_DIR` points to a concrete run directory.
+- `--node`: node id inside `--run`. Defaults to the role name.
+- `--depends-on`: record a dependency edge for run visualization. Repeatable.
+- `--team`: declare orchestrator team nodes. Repeatable; accepts `role`, `role=N`, `agent/role`, or `agent/role=N`.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--docker`: run the agent inside Docker for one-shot headless execution.
 - `--docker-image`: Docker image override. Defaults to `ghcr.io/roberttlange/headless:latest`.
@@ -292,6 +329,11 @@ Options:
 - `--session`: start or resume a named Headless session. Uses `~/.headless/sessions.json`; in tmux mode starts or sends to `headless-<agent>-<name>`.
 - `send <session-name>`: send a message to an existing Headless tmux session.
 - `rename <session-name> <new-name>`: rename an existing Headless tmux session.
+- `run list`: list known local coordinated runs.
+- `run view <run>`: show run graph, messages, and exact commands.
+- `run mark <run> <node> --status <status>`: manually update node status.
+- `run message <run> <node> --prompt "..." [--async]`: route a prompt to a node by stored metadata.
+- `run wait <run>`: wait until no nodes are busy.
 - `docker doctor`: check Docker setup and image availability.
 - `docker build`: build the packaged Dockerfile as `headless-local:dev`, or `--docker-image <image>`.
 - `--check`: check which supported agent binaries are installed, print their versions, and report local API/OAuth credential signals.
@@ -311,6 +353,7 @@ If no prompt or prompt file is supplied, Headless reads from piped stdin.
 - `PI_CODING_AGENT_PROVIDER`: Pi provider override used when the Pi model value does not include `provider/model`.
 - `PI_CODING_AGENT_MODEL`: Pi model override when `--model` is omitted. Accepts `provider/model` (for example, `openai-codex/gpt-5.5`) or a bare model paired with `PI_CODING_AGENT_PROVIDER`. When unset, Headless defaults Pi to `openai-codex/gpt-5.5`.
 - `PI_CODING_AGENT_MODELS`: passed to Pi as `--models`.
+- `HEADLESS_RUN_DIR`: concrete directory for the active run store, mainly used by Docker run coordination.
 
 Docker and Modal modes also pass common agent/provider credential variables when present, including `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, Cursor/Pi credential variables, common AWS variables, and OpenAI-compatible endpoint variables. Use `--docker-env` or `--modal-env` for anything else. Modal mode additionally supports named Modal Secrets with `--modal-secret`.
 
@@ -335,6 +378,10 @@ src/cli.ts      CLI parsing, validation, execution
 src/agents.ts   Agent registry and command builders
 src/output.ts   Final-message extraction from agent JSON traces
 src/modal.ts    Modal sandbox execution and workspace sync
+src/roles.ts    Role defaults and prompt composition
+src/runs.ts     Local run-state store and locks
+src/teams.ts    Team spec parser and generated node names
+src/run-view.ts Run graph/list rendering
 src/shell.ts    Shell-safe dry-run rendering
 src/types.ts    Shared TypeScript contracts
 tests/          CLI and command-builder coverage

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ npm run check
 npm run hooks:install
 ```
 
-`npm run check` builds the package and runs the TypeScript test suite. `npm run test:integration:local` runs authenticated local integration coverage; set `HEADLESS_INTEGRATION_AGENTS=codex` to limit it to Codex. After `npm run hooks:install`, the pre-push hook builds the local CLI and runs Codex integration by default; set `HEADLESS_HOOK_ALL_AGENTS=1` to run all agents. `npm run test:agents` is an optional real-agent smoke test; set `HEADLESS_AGENT_SMOKE=1` to run Codex, Claude, Pi, and Gemini with an example prompt. The package exports one binary, `headless`, from `dist/cli.js`.
+`npm run check` builds the package and runs the TypeScript test suite. `npm run test:integration:local` runs authenticated local integration coverage; set `HEADLESS_INTEGRATION_AGENTS=claude` to limit it to Claude. After `npm run hooks:install`, the pre-push hook builds the local CLI and runs Claude integration by default; set `HEADLESS_HOOK_ALL_AGENTS=1` to run all agents. `npm run test:agents` is an optional real-agent smoke test; set `HEADLESS_AGENT_SMOKE=1` to run Codex, Claude, Pi, and Gemini with an example prompt. The package exports one binary, `headless`, from `dist/cli.js`.
 
 ## Layout
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,3 +25,48 @@ model = "openai/gpt-5.4"
 [agents.pi]
 model = "openai-codex/gpt-5.5"
 # reasoning_effort = "xhigh"
+
+[roles.orchestrator]
+# model = "gpt-5.5" # Optional. Inherits the selected agent model when omitted.
+reasoning_effort = "high"
+allow = "yolo"
+base_instruction_prompt = """
+Role: orchestrator.
+Coordinate the declared team as the run contract. Assign clear, bounded work and keep the run moving.
+Launch planned child nodes with headless run message <run> <node> --prompt "..." --async when parallel work fits.
+Use headless run view <run> for status and headless run wait <run> before final handoff if children may still be active.
+Do not launch surprise agents unless the user explicitly asks.
+"""
+
+[roles.explorer]
+# model = "gpt-5.5" # Optional. Inherits the selected agent model when omitted.
+reasoning_effort = "medium"
+allow = "read-only"
+base_instruction_prompt = """
+Role: explorer.
+Stay read-only. Investigate the assigned question, cite concrete files, commands, and evidence, and report concise findings.
+Treat incoming run messages as the next task turn. Keep status short enough for run view lastMessage.
+When finished or blocked, report findings, uncertainty, and blockers.
+"""
+
+[roles.worker]
+# model = "gpt-5.5" # Optional. Inherits the selected agent model when omitted.
+reasoning_effort = "high"
+allow = "yolo"
+base_instruction_prompt = """
+Role: worker.
+Implement the assigned task with scoped edits. Respect nearby code patterns and existing user or agent changes.
+Run the relevant verification before handoff. Include changed files, tests, and blockers in the final status.
+Treat incoming run messages as the next task turn. Keep status short enough for run view lastMessage.
+"""
+
+[roles.reviewer]
+# model = "gpt-5.5" # Optional. Inherits the selected agent model when omitted.
+reasoning_effort = "high"
+allow = "read-only"
+base_instruction_prompt = """
+Role: reviewer.
+Stay read-only. Review for bugs, regressions, security risks, and missing tests.
+Lead with findings ordered by severity and include file and line references. Keep summaries secondary.
+Treat incoming run messages as the next review turn. Report blockers and residual risk clearly.
+"""

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,414 @@
+# Multi-Agent Role and Run Coordination Spec
+
+## Purpose
+
+Headless should support natural multi-agent work without requiring a graph
+configuration file. The first-class abstraction is a role-aware Headless
+invocation:
+
+```bash
+headless codex --role orchestrator --run auth --coordination session --prompt "Build auth"
+```
+
+The orchestrator remains an LLM agent. Headless provides prompt templates,
+run-state tracking, message routing, and async process supervision. The
+orchestrator decides how to use the team within the constraints Headless gives
+it.
+
+## Non-Goals
+
+- No `graph.yml` or required file-based graph configuration.
+- No `headless orchestrate` subcommand for v1.
+- No hard enforcement that the orchestrator only uses the declared team.
+- No networked cross-container message broker.
+- No required summaries. Run context should expose only roster, status, last
+  message, and messaging commands.
+
+## User-Facing CLI
+
+### Role Flags
+
+Add role and coordination flags to normal agent execution:
+
+```bash
+headless <agent> --role <role> [--coordination session|tmux|oneshot]
+```
+
+Built-in roles:
+
+- `orchestrator`: coordinates a fixed team of subagents.
+- `explorer`: read-only codebase investigation.
+- `worker`: edit-capable implementation.
+- `reviewer`: read-only findings-first review.
+
+`explorer` and `reviewer` default to `--allow read-only`. `worker` and
+`orchestrator` default to the normal edit-capable behavior. Explicit CLI flags
+override role defaults.
+
+### Run Flags
+
+Add run identity flags:
+
+```bash
+--run <run>
+--node <node>
+--depends-on <node>    # repeatable
+--team <spec>          # repeatable, orchestrator prompt input
+```
+
+`--run` identifies the shared coordination context. `--node` identifies the
+current agent inside that run. If omitted for a role invocation, Headless may
+derive a node name from the role, but orchestrator flows should use explicit
+nodes.
+
+`--depends-on` records dependency edges for observability. It should not block
+execution by itself.
+
+### Team Grammar
+
+`--team` is prompt/context only. It informs the orchestrator which team to
+create, but does not prevent surprise nodes.
+
+Supported forms:
+
+```bash
+--team explorer
+--team worker=2
+--team reviewer
+--team claude/reviewer
+--team codex/worker=3
+```
+
+Fields:
+
+- `role`
+- `role=N`
+- `agent/role`
+- `agent/role=N`
+
+Rules:
+
+- Agent prefix is optional. Without a prefix, inherit the orchestrator agent.
+- Count defaults to `1`.
+- Count must be positive.
+- Role must be built-in or configured.
+- Agent must be one of the supported Headless agents.
+
+Generated node names:
+
+- `explorer` for a single explorer.
+- `reviewer` for a single reviewer.
+- `worker-1`, `worker-2` for repeated workers.
+- For mixed-agent teams, include the agent only when needed for
+  disambiguation, e.g. `reviewer-claude` or `worker-codex-1`.
+
+## Coordination Modes
+
+### `session`
+
+Default mode. Communication is turn-based via native Headless session aliases:
+
+```bash
+headless codex --role worker --run auth --node worker-1 --session worker-1 --prompt "..."
+headless run message auth worker-1 --prompt "Continue with X"
+```
+
+This is persistent conversation messaging, not stdin injection into a running
+process. Headless must guard against concurrent writes to the same node/session
+with a per-node lock.
+
+### `tmux`
+
+Interactive mode. Nodes are long-lived tmux-backed sessions:
+
+```bash
+headless codex --role worker --run auth --node worker-1 --tmux --session worker-1 --prompt "..."
+headless run message auth worker-1 --prompt "Continue with X"
+```
+
+`run message` routes through existing tmux send behavior. Status is best effort
+unless the role explicitly reports back.
+
+### `oneshot`
+
+Stateless child invocations:
+
+```bash
+headless codex --role explorer --run auth --node explorer --prompt "..."
+```
+
+`run message` launches a new one-shot invocation using the stored node metadata.
+
+## Run Commands
+
+Add a `run` command group:
+
+```bash
+headless run list
+headless run view <run>
+headless run mark <run> <node> --status idle|busy|done|failed|unknown
+headless run message <run> <node> --prompt "..." [--async]
+headless run wait <run>
+```
+
+### `run list`
+
+Lists known runs from the local run store.
+
+### `run view`
+
+Prints the current roster, node statuses, last messages, dependencies, and exact
+commands for messaging each node.
+
+### `run mark`
+
+Manually updates node status. This is useful for tmux and failure recovery.
+
+### `run message`
+
+Sends a prompt to a registered node using the node's stored metadata:
+
+- `agent`
+- `role`
+- `coordination`
+- `allow`
+- `model`
+- `reasoningEffort`
+- `sessionAlias` or tmux session name
+
+Defaults come from the stored node record. CLI overrides may be added later,
+but v1 should prefer the stored record to keep command usage simple.
+
+Synchronous behavior:
+
+- `session`: resume stored native session and wait.
+- `oneshot`: run the stored node once and wait.
+- `tmux`: send the prompt and return after paste/send.
+
+Async behavior:
+
+```bash
+headless run message auth worker-1 --prompt "Implement X" --async
+```
+
+For `session` and `oneshot`, async starts a detached child process that invokes
+Headless internally. The node becomes `busy`, logs are written under the run
+store, and completion updates status to `idle` or `failed`.
+
+For `tmux`, messaging is already fire-and-forget.
+
+### `run wait`
+
+Waits until no nodes in the run are `busy`. The orchestrator prompt must tell
+the parent agent to call this before final response when it has launched async
+children.
+
+## Run Store
+
+Default local store:
+
+```text
+~/.headless/runs/<run>/
+  events.jsonl
+  run.json
+  nodes/
+    <node>/
+      state.json
+      latest.stdout.log
+      latest.stderr.log
+```
+
+Allow override via:
+
+```bash
+HEADLESS_RUN_DIR=/path/to/run
+```
+
+### Node State
+
+Node state should be lightweight:
+
+```json
+{
+  "runId": "auth",
+  "nodeId": "worker-1",
+  "role": "worker",
+  "agent": "codex",
+  "coordination": "session",
+  "sessionAlias": "worker-1",
+  "status": "idle",
+  "lastMessage": "Implemented token refresh; tests pass.",
+  "dependsOn": ["explorer"],
+  "updatedAt": "2026-04-28T12:00:00.000Z"
+}
+```
+
+Statuses:
+
+- `starting`
+- `busy`
+- `idle`
+- `done`
+- `failed`
+- `unknown`
+
+### Events
+
+Append-only JSONL events make the graph auditable:
+
+```json
+{
+  "type": "node_started",
+  "runId": "auth",
+  "nodeId": "worker-1",
+  "parentNodeId": "orchestrator",
+  "role": "worker",
+  "agent": "codex",
+  "coordination": "session",
+  "dependsOn": ["explorer"],
+  "createdAt": "2026-04-28T12:00:00.000Z"
+}
+```
+
+Useful event types:
+
+- `run_started`
+- `node_registered`
+- `node_started`
+- `message_sent`
+- `status_changed`
+- `node_output`
+- `node_failed`
+- `node_completed`
+
+## Prompt Contracts
+
+### Common Injected Context
+
+For any role invocation with `--run`, Headless prepends compact context:
+
+- run id
+- current node id
+- current role
+- coordination mode
+- roster from run state and `--team`
+- each node's status
+- each node's last message
+- exact command to message each node
+
+Do not inject summaries.
+
+### Orchestrator Prompt
+
+The orchestrator role prompt must state:
+
+- Create the declared team at the beginning of the run.
+- After initial team creation, do not spawn new agents.
+- Use `headless run message <run> <node>` for later communication.
+- Use the selected `--coordination` style when starting nodes.
+- Use async messaging for parallel work when appropriate.
+- Call `headless run wait <run>` before final response if async work is running.
+- Coordinate based on roster status and last messages.
+
+### Explorer Prompt
+
+The explorer role prompt must state:
+
+- Stay read-only.
+- Investigate and report concise findings.
+- When finished or blocked, message the orchestrator:
+
+```bash
+headless run message <run> orchestrator --prompt "<findings or blocker>"
+```
+
+### Worker Prompt
+
+The worker role prompt must state:
+
+- Implement the assigned task.
+- Keep changes scoped.
+- Run relevant verification.
+- When finished or blocked, message the orchestrator with changes, tests, and
+  blockers:
+
+```bash
+headless run message <run> orchestrator --prompt "<status>"
+```
+
+### Reviewer Prompt
+
+The reviewer role prompt must state:
+
+- Stay read-only.
+- Review for bugs, regressions, security risks, and missing tests.
+- Lead with findings and file references.
+- When finished, message the orchestrator with findings or `No findings`:
+
+```bash
+headless run message <run> orchestrator --prompt "<findings>"
+```
+
+## Docker Behavior
+
+When a top-level Docker invocation has `--run`, Headless should bind-mount the
+host run directory into the container and set `HEADLESS_RUN_DIR`:
+
+```text
+~/.headless/runs/<run>:/headless-runs/<run>
+HEADLESS_RUN_DIR=/headless-runs/<run>
+```
+
+The Docker orchestrator is the execution island. Child Headless processes are
+spawned inside the same container. They share the mounted run store and can be
+visible from the host through the same files.
+
+Async children must finish before the top-level container exits. The
+orchestrator prompt enforces this via `headless run wait <run>`.
+
+## Modal Behavior
+
+The Modal orchestrator is also an execution island. Child Headless processes are
+spawned inside the same sandbox.
+
+Host-side visibility should be provided by event mirroring:
+
+```text
+@@HEADLESS_EVENT@@{"runId":"auth","nodeId":"worker-1","status":"busy"}
+```
+
+The local Modal wrapper consumes these framed events and mirrors state into the
+host's `~/.headless/runs/<run>` store. The sandbox still writes its own run
+store internally. Final workspace sync can reconcile artifacts where practical.
+
+As with Docker, async children must finish before the top-level sandbox exits.
+The orchestrator prompt must call `headless run wait <run>` before final
+response when async work is active.
+
+## Implementation Notes
+
+- Keep the feature primitive-first. Roles and run commands should compose with
+  existing `--session`, `--tmux`, Docker, and Modal behavior.
+- Reuse the existing session store concepts, but keep run state in
+  `~/.headless/runs` instead of `~/.headless/sessions.json`.
+- Use atomic writes for `state.json` and append-only writes for `events.jsonl`.
+- Add per-node locks for `session` and `oneshot` messaging to avoid concurrent
+  native session resumes.
+- Do not rely on final message extraction for correctness. Explicit
+  role-to-orchestrator messages are the primary coordination mechanism.
+  Opportunistic output capture is still useful for observability and failure
+  recovery.
+- CLI flags should override role defaults.
+- Missing `--run` should still allow `--role`; it just skips run-state context.
+
+## Suggested Implementation Phases
+
+1. Add role parsing, built-in prompt templates, and role default options.
+2. Add run store primitives and `run list/view/mark`.
+3. Record node state for normal role invocations with `--run` and `--node`.
+4. Implement `run message` synchronously for `session`, `oneshot`, and `tmux`.
+5. Add async detached child process support and per-node locks.
+6. Add `run wait`.
+7. Add Docker run-dir bind mount support.
+8. Add Modal event-frame mirroring.
+9. Expand docs and integration tests.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -146,7 +146,7 @@ Add a `run` command group:
 ```bash
 headless run list
 headless run view <run>
-headless run mark <run> <node> --status idle|busy|done|failed|unknown
+headless run mark <run> <node> --status planned|starting|busy|idle|done|failed|unknown
 headless run message <run> <node> --prompt "..." [--async]
 headless run wait <run>
 ```
@@ -158,7 +158,42 @@ Lists known runs from the local run store.
 ### `run view`
 
 Prints the current roster, node statuses, last messages, dependencies, and exact
-commands for messaging each node.
+commands for messaging each node. The default human output should include a
+compact graph view first. Do not require a separate `graph` subcommand for v1.
+
+Example:
+
+```text
+auth  session  4 nodes
+
+Graph
+orchestrator [busy]
+|- explorer [done] last: Found auth middleware paths
+|- worker-1 [busy] depends: explorer
+`- reviewer [planned] depends: worker-1
+
+Recent messages
+orchestrator -> worker-1  Implement token refresh
+explorer -> orchestrator  Found auth middleware paths
+
+Commands
+message worker-1: headless run message auth worker-1 --prompt "..."
+logs worker-1:    tail -f ~/.headless/runs/auth/nodes/worker-1/latest.stdout.log
+```
+
+Graph rendering rules:
+
+- Render the orchestrator-rooted tree first because most runs are
+  orchestrator-centered.
+- Support arbitrary DAG state in storage. For edges that do not fit the primary
+  tree, show inline `depends: a,b` and add an `Extra edges` section when needed.
+- Treat `--depends-on` as structural dependency edges.
+- Treat `message_sent` events as runtime communication edges. Show recent
+  message flow separately from dependencies.
+- Show latest node state first. Include a short recent-event or recent-message
+  trail so the user can see how the graph reached that state.
+- Keep exact messaging, attach, and log commands in a separate command section
+  instead of inline in graph labels.
 
 ### `run mark`
 
@@ -203,6 +238,18 @@ Waits until no nodes in the run are `busy`. The orchestrator prompt must tell
 the parent agent to call this before final response when it has launched async
 children.
 
+### Team Registration
+
+When an orchestrator invocation includes `--team`, Headless should pre-register
+the declared nodes before they are launched. These nodes start as `planned` and
+become `starting`, `busy`, `idle`, `done`, or `failed` as execution produces
+events. This makes `run view` useful immediately and makes never-started nodes
+visible.
+
+Nodes that appear outside the declared team should still be recorded and shown.
+Mark them as `planned: false` or `unplanned: true` so the CLI can distinguish
+surprise nodes from the orchestrator's initial team.
+
 ## Run Store
 
 Default local store:
@@ -239,12 +286,15 @@ Node state should be lightweight:
   "status": "idle",
   "lastMessage": "Implemented token refresh; tests pass.",
   "dependsOn": ["explorer"],
+  "planned": true,
+  "unplanned": false,
   "updatedAt": "2026-04-28T12:00:00.000Z"
 }
 ```
 
 Statuses:
 
+- `planned`
 - `starting`
 - `busy`
 - `idle`
@@ -281,6 +331,13 @@ Useful event types:
 - `node_failed`
 - `node_completed`
 
+Dependency and message edges have different meanings:
+
+- `dependsOn` records structural planning edges. These edges drive the primary
+  graph visualization.
+- `message_sent` records runtime communication edges. These edges drive recent
+  message flow and audit history.
+
 ## Prompt Contracts
 
 ### Common Injected Context
@@ -294,21 +351,28 @@ For any role invocation with `--run`, Headless prepends compact context:
 - roster from run state and `--team`
 - each node's status
 - each node's last message
+- each node's dependencies
+- whether each node is planned or unplanned
 - exact command to message each node
 
-Do not inject summaries.
+Do not inject summaries or full event history. The context should mark the
+current node clearly.
 
 ### Orchestrator Prompt
 
 The orchestrator role prompt must state:
 
 - Create the declared team at the beginning of the run.
-- After initial team creation, do not spawn new agents.
+- Treat the declared team as the coordination contract.
+- After initial team creation, do not spawn new agents unless the user
+  explicitly asks.
 - Use `headless run message <run> <node>` for later communication.
 - Use the selected `--coordination` style when starting nodes.
 - Use async messaging for parallel work when appropriate.
 - Call `headless run wait <run>` before final response if async work is running.
 - Coordinate based on roster status and last messages.
+- Ask each child to send an explicit status message back to the orchestrator
+  when finished or blocked.
 
 ### Explorer Prompt
 
@@ -316,6 +380,8 @@ The explorer role prompt must state:
 
 - Stay read-only.
 - Investigate and report concise findings.
+- Include enough status detail for `run view` to show useful `lastMessage`
+  text.
 - When finished or blocked, message the orchestrator:
 
 ```bash
@@ -329,6 +395,8 @@ The worker role prompt must state:
 - Implement the assigned task.
 - Keep changes scoped.
 - Run relevant verification.
+- Include enough status detail for `run view` to show useful `lastMessage`
+  text.
 - When finished or blocked, message the orchestrator with changes, tests, and
   blockers:
 
@@ -343,6 +411,8 @@ The reviewer role prompt must state:
 - Stay read-only.
 - Review for bugs, regressions, security risks, and missing tests.
 - Lead with findings and file references.
+- Include enough status detail for `run view` to show useful `lastMessage`
+  text.
 - When finished, message the orchestrator with findings or `No findings`:
 
 ```bash

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -129,9 +129,6 @@ function buildClaude(options: BuildOptions): BuiltCommand {
     args.push("--resume", options.sessionId);
   } else if (options.sessionMode === "new" && options.sessionId) {
     args.push("--session-id", options.sessionId);
-    if (options.sessionAlias) {
-      args.push("--name", options.sessionAlias);
-    }
   }
 
   if (options.promptFile) {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -17,13 +17,15 @@ export const DEFAULT_CURSOR_MODEL = BUILTIN_AGENT_DEFAULTS.cursor.model ?? "gpt-
 export const DEFAULT_GEMINI_MODEL = BUILTIN_AGENT_DEFAULTS.gemini.model ?? "gemini-3.1-pro-preview";
 export const DEFAULT_OPENCODE_MODEL = BUILTIN_AGENT_DEFAULTS.opencode.model ?? "openai/gpt-5.4";
 export const DEFAULT_PI_MODEL = BUILTIN_AGENT_DEFAULTS.pi.model ?? "openai-codex/gpt-5.5";
+const claudeReadOnlyTools = "Read,Grep,Glob,LS,WebFetch,WebSearch";
 const opencodeReadOnlyConfig = JSON.stringify({
   permission: {
+    read: "allow",
     edit: "deny",
     bash: "deny",
-    webfetch: "deny",
-    websearch: "deny",
-    codesearch: "deny",
+    webfetch: "allow",
+    websearch: "allow",
+    codesearch: "allow",
     task: "deny",
   },
 });
@@ -38,7 +40,7 @@ function withClaudeEffort(args: string[], effort: ReasoningEffort | undefined): 
 
 function withClaudeAllow(args: string[], allow: AllowMode | undefined): string[] {
   if (allow === "read-only") {
-    return [...args, "--permission-mode", "plan"];
+    return [...args, "--permission-mode", "plan", "--allowedTools", claudeReadOnlyTools];
   }
   return allow === "yolo" || allow === undefined ? [...args, "--dangerously-skip-permissions"] : args;
 }
@@ -148,7 +150,7 @@ function buildCodex(options: BuildOptions, env: Env): BuiltCommand {
   const model = options.model || env.CODEX_MODEL || defaultCodexModel;
   const args = [
     ...(options.allow === "read-only"
-      ? ["--sandbox", "read-only", "--ask-for-approval", "never"]
+      ? ["--sandbox", "read-only", "--ask-for-approval", "never", "--search"]
       : ["--dangerously-bypass-approvals-and-sandbox"]),
     "exec",
     ...(options.sessionMode === "resume" && options.sessionId ? ["resume"] : []),
@@ -174,7 +176,7 @@ function buildInteractiveCodex(options: BuildOptions, env: Env): BuiltCommand {
   const model = options.model || env.CODEX_MODEL || defaultCodexModel;
   const args =
     options.allow === "read-only"
-      ? ["--sandbox", "read-only", "--ask-for-approval", "never"]
+      ? ["--sandbox", "read-only", "--ask-for-approval", "never", "--search"]
       : options.allow === "yolo" || options.allow === undefined
         ? ["--dangerously-bypass-approvals-and-sandbox"]
         : [];

--- a/src/check.ts
+++ b/src/check.ts
@@ -3,6 +3,7 @@ import { accessSync, constants, statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 
 import { listAgents } from "./agents.js";
+import { cell, renderTable, type TableColor } from "./table.js";
 import type { AgentName, Env } from "./types.js";
 
 interface CaptureResult {
@@ -261,39 +262,39 @@ export async function checkDocker(env: Env, image: string): Promise<DockerCheck>
 }
 
 export function renderAgentChecks(checks: AgentCheck[]): string {
-  const rows = [
-    ["Agent", "Status", "Auth", "Version", "Binary"],
-    ...checks.map((check) => [
+  return renderTable({
+    columns: ["Agent", "Status", "Auth", "Version", "Binary"],
+    rows: checks.map((check) => [
       check.agent,
-      check.available ? "✓" : "✗",
-      check.auth,
+      cell(check.available ? "✓" : "✗", check.available ? "green" : "red"),
+      cell(check.auth, authColor(check.auth)),
       check.version,
       check.command,
     ]),
-  ];
-  const widths = rows[0].map((_, column) => Math.max(...rows.map((row) => row[column].length)));
-  return rows
-    .map((row) => row.map((cell, index) => cell.padEnd(widths[index])).join("  ").trimEnd())
-    .join("\n")
-    .concat("\n");
+  });
 }
 
 export function renderDockerCheck(check: DockerCheck): string {
-  return renderRows([
-    ["Docker", "Status", "Version", "Default image"],
-    [
+  return renderTable({
+    columns: ["Docker", "Status", "Version", "Default image"],
+    rows: [[
       check.command,
-      check.available ? "✓" : "✗",
+      cell(check.available ? "✓" : "✗", check.available ? "green" : "red"),
       check.version,
       check.available ? `${check.image} (${check.imageAvailable ? "present" : "missing"})` : check.image,
-    ],
-  ]);
+    ]],
+  });
 }
 
-function renderRows(rows: string[][]): string {
-  const widths = rows[0].map((_, column) => Math.max(...rows.map((row) => row[column].length)));
-  return rows
-    .map((row) => row.map((cell, index) => cell.padEnd(widths[index])).join("  ").trimEnd())
-    .join("\n")
-    .concat("\n");
+function authColor(auth: AuthLabel): TableColor {
+  switch (auth) {
+    case "api":
+      return "cyan";
+    case "oauth":
+      return "magenta";
+    case "api+oauth":
+      return "green";
+    case "-":
+      return "dim";
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,7 @@ import {
 } from "./output.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import {
+  appendNodeLog,
   readRun,
   registerNode,
   runDirectory,
@@ -766,6 +767,7 @@ type StdoutHandling = "capture" | "stream" | "capture-and-stream";
 interface ExecuteCommandOptions {
   stdoutHandling: StdoutHandling;
   stdout: (text: string) => void;
+  stderr?: (text: string) => void;
 }
 
 interface SessionPlan {
@@ -1028,13 +1030,16 @@ async function executeCommand(
       });
       child.stderr?.setEncoding("utf8");
       child.stderr?.on("data", (chunk: string) => {
+        options.stderr?.(chunk);
         const filtered = suppressKnownStderr(agent, chunk);
         if (filtered) {
           stderr(filtered);
         }
       });
       child.on("error", (error) => {
-        stderr(`${error.message}\n`);
+        const message = `${error.message}\n`;
+        options.stderr?.(message);
+        stderr(message);
         resolve({ code: 127, stdout: capturedStdout });
       });
       child.on("close", (code, signal) => {
@@ -1341,6 +1346,52 @@ function trustCursorWorkspace(cwd: string | undefined, env: Env): void {
   );
 }
 
+function appendRunInvocationLog(env: Env, runId: string, nodeId: string, label: string): void {
+  const header = `\n===== ${label} ${new Date().toISOString()} =====\n`;
+  appendNodeLog(env, runId, nodeId, "stdout", header);
+  appendNodeLog(env, runId, nodeId, "stderr", header);
+}
+
+function appendCapturedRunStdout(
+  env: Env,
+  runId: string | undefined,
+  nodeId: string | undefined,
+  stdoutHandling: StdoutHandling,
+  capturedStdout: string,
+): void {
+  if (!runId || !nodeId || stdoutHandling !== "capture") {
+    return;
+  }
+  appendNodeLog(env, runId, nodeId, "stdout", capturedStdout);
+}
+
+function runStdoutLogger(
+  env: Env,
+  runId: string | undefined,
+  nodeId: string | undefined,
+  stdoutHandling: StdoutHandling,
+  stdout: (text: string) => void,
+): (text: string) => void {
+  if (!runId || !nodeId || stdoutHandling === "capture") {
+    return stdout;
+  }
+  return (text: string) => {
+    appendNodeLog(env, runId, nodeId, "stdout", text);
+    stdout(text);
+  };
+}
+
+function runStderrLogger(
+  env: Env,
+  runId: string | undefined,
+  nodeId: string | undefined,
+): ((text: string) => void) | undefined {
+  if (!runId || !nodeId) {
+    return undefined;
+  }
+  return (text: string) => appendNodeLog(env, runId, nodeId, "stderr", text);
+}
+
 async function executeSimpleCommand(
   command: BuiltCommand,
   cwd: string | undefined,
@@ -1503,7 +1554,13 @@ async function executeStoredNode(
     node.runId,
     node.nodeId,
   );
-  const result = await executeCommand(node.agent, command, node.workDir, env, stderr, { stdout, stdoutHandling });
+  appendRunInvocationLog(env, node.runId, node.nodeId, "run message");
+  const result = await executeCommand(node.agent, command, node.workDir, env, stderr, {
+    stdout: runStdoutLogger(env, node.runId, node.nodeId, stdoutHandling, stdout),
+    stdoutHandling,
+    stderr: runStderrLogger(env, node.runId, node.nodeId),
+  });
+  appendCapturedRunStdout(env, node.runId, node.nodeId, stdoutHandling, result.stdout);
   if (result.code === 0 && sessionPlan) {
     await persistSessionPlan(node.agent, sessionPlan, result.stdout, node.workDir, env);
   }
@@ -2012,6 +2069,11 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       : parsed.debug
         ? "capture-and-stream"
         : "capture";
+    if (parsed.runId && parsed.role && nodeId) {
+      appendRunInvocationLog(env, parsed.runId, nodeId, "node invocation");
+    }
+    const commandStdout = runStdoutLogger(env, parsed.runId, nodeId, stdoutHandling, stdout);
+    const commandStderr = runStderrLogger(env, parsed.runId, nodeId);
     const result = parsed.modal
       ? await executeModalAgent({
           agent: parsed.agent,
@@ -2026,20 +2088,23 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
           modalEnv: parsed.modalEnv,
           modalSecrets: parsed.modalSecrets,
           stderr: (text) => {
+            commandStderr?.(text);
             const filtered = suppressKnownStderr(parsed.agent as AgentName, text);
             if (filtered) {
               stderr(filtered);
             }
           },
-          stdout,
+          stdout: commandStdout,
           stdoutHandling,
           timeoutSeconds: parsed.modalTimeoutSeconds ?? DEFAULT_MODAL_TIMEOUT_SECONDS,
           workDir: cwd ?? process.cwd(),
         })
       : await executeCommand(parsed.agent, command, cwd, env, stderr, {
-          stdout,
+          stdout: commandStdout,
           stdoutHandling,
+          stderr: commandStderr,
         });
+    appendCapturedRunStdout(env, parsed.runId, nodeId, stdoutHandling, result.stdout);
     if (parsed.runId && parsed.role && nodeId) {
       const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
       updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import { extractRunNodeMetrics } from "./run-metrics.js";
 import {
   appendNodeLog,
+  completeIdleRunNodes,
   readRun,
   registerNode,
   runDirectory,
@@ -2116,14 +2117,11 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     if (parsed.runId && parsed.role && nodeId) {
       const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
-      updateNodeStatus(
-        env,
-        parsed.runId,
-        nodeId,
-        result.code === 0 ? "idle" : "failed",
-        finalMessage || undefined,
-        extractRunNodeMetrics(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)),
-      );
+      const metrics = extractRunNodeMetrics(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env));
+      updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined, metrics);
+      if (result.code === 0 && parsed.role === "orchestrator" && finalMessage) {
+        completeIdleRunNodes(env, parsed.runId, nodeId, finalMessage);
+      }
     }
     if (result.code === 0 && sessionPlan) {
       await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1790,6 +1790,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     const cwd = validateWorkDir(parsed.workDir);
     const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux || parsed.role !== undefined || parsed.runId !== undefined });
     const allow = parsed.allow ?? roleDefaultAllow(parsed.role);
+    if (parsed.runId && parsed.role === "orchestrator" && allow === "read-only") {
+      throw new CliError("--role orchestrator with --run cannot use --allow read-only; it must be able to launch child nodes and update run state");
+    }
     const team = parsed.teamSpecs.length > 0 ? expandTeamSpecs(parsed.agent, parsed.teamSpecs) : [];
     if (!parsed.printCommand && parsed.runId && parsed.role && nodeId) {
       for (const teamNode of team) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,7 @@ import {
 } from "./output.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import { extractRunNodeMetrics } from "./run-metrics.js";
+import { createRunStatusReporter, parseRunStatusIntervalMs } from "./run-status.js";
 import {
   appendNodeLog,
   completeIdleRunNodes,
@@ -565,6 +566,17 @@ function hasModalOptions(parsed: ParsedArgs): boolean {
     parsed.modalMemoryMiB !== undefined ||
     parsed.modalSecrets.length > 0 ||
     parsed.modalTimeoutSeconds !== undefined
+  );
+}
+
+function shouldStreamRunStatus(parsed: ParsedArgs): boolean {
+  return (
+    parsed.runId !== undefined &&
+    parsed.role === "orchestrator" &&
+    !parsed.printCommand &&
+    !parsed.json &&
+    !parsed.tmux &&
+    !parsed.modal
   );
 }
 
@@ -2074,54 +2086,73 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         : "capture";
     if (parsed.runId && parsed.role && nodeId) {
       appendRunInvocationLog(env, parsed.runId, nodeId, "node invocation");
-      updateNodeStatus(env, parsed.runId, nodeId, "busy");
     }
-    const commandStdoutLog = runStdoutLogger(env, parsed.runId, nodeId);
-    const commandStderr = runStderrLogger(env, parsed.runId, nodeId);
-    const result = parsed.modal
-      ? await executeModalAgent({
-          agent: parsed.agent,
-          appName: parsed.modalApp ?? DEFAULT_MODAL_APP,
-          command,
-          cpu: parsed.modalCpu ?? DEFAULT_MODAL_CPU,
+    const statusReporter = shouldStreamRunStatus(parsed) && parsed.runId
+      ? createRunStatusReporter({
           env,
-          image: parsed.modalImage ?? DEFAULT_MODAL_IMAGE,
-          imageSecret: parsed.modalImageSecret,
-          includeGit: parsed.modalIncludeGit,
-          memoryMiB: parsed.modalMemoryMiB ?? DEFAULT_MODAL_MEMORY_MIB,
-          modalEnv: parsed.modalEnv,
-          modalSecrets: parsed.modalSecrets,
-          stderr: (text) => {
-            commandStderr?.(text);
-            const filtered = suppressKnownStderr(parsed.agent as AgentName, text);
-            if (filtered) {
-              stderr(filtered);
-            }
-          },
-          stdout: (text) => {
-            commandStdoutLog?.(text);
-            stdout(text);
-          },
-          stdoutHandling,
-          timeoutSeconds: parsed.modalTimeoutSeconds ?? DEFAULT_MODAL_TIMEOUT_SECONDS,
-          workDir: cwd ?? process.cwd(),
+          intervalMs: parseRunStatusIntervalMs(env.HEADLESS_RUN_STATUS_INTERVAL_MS),
+          runId: parsed.runId,
+          write: stderr,
         })
-      : await executeCommand(parsed.agent, command, cwd, env, stderr, {
-          stdout,
-          stdoutHandling,
-          stdoutLog: commandStdoutLog,
-          stderr: commandStderr,
-        });
-    if (parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
-      appendNodeLog(env, parsed.runId, nodeId, "stdout", result.stdout);
-    }
-    if (parsed.runId && parsed.role && nodeId) {
-      const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
-      const metrics = extractRunNodeMetrics(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env));
-      updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined, metrics);
-      if (result.code === 0 && parsed.role === "orchestrator" && finalMessage) {
-        completeIdleRunNodes(env, parsed.runId, nodeId, finalMessage);
+      : undefined;
+    statusReporter?.start();
+    let result: ExecuteResult | undefined;
+    try {
+      if (parsed.runId && parsed.role && nodeId) {
+        updateNodeStatus(env, parsed.runId, nodeId, "busy");
       }
+      const commandStdoutLog = runStdoutLogger(env, parsed.runId, nodeId);
+      const commandStderr = runStderrLogger(env, parsed.runId, nodeId);
+      result = parsed.modal
+        ? await executeModalAgent({
+            agent: parsed.agent,
+            appName: parsed.modalApp ?? DEFAULT_MODAL_APP,
+            command,
+            cpu: parsed.modalCpu ?? DEFAULT_MODAL_CPU,
+            env,
+            image: parsed.modalImage ?? DEFAULT_MODAL_IMAGE,
+            imageSecret: parsed.modalImageSecret,
+            includeGit: parsed.modalIncludeGit,
+            memoryMiB: parsed.modalMemoryMiB ?? DEFAULT_MODAL_MEMORY_MIB,
+            modalEnv: parsed.modalEnv,
+            modalSecrets: parsed.modalSecrets,
+            stderr: (text) => {
+              commandStderr?.(text);
+              const filtered = suppressKnownStderr(parsed.agent as AgentName, text);
+              if (filtered) {
+                stderr(filtered);
+              }
+            },
+            stdout: (text) => {
+              commandStdoutLog?.(text);
+              stdout(text);
+            },
+            stdoutHandling,
+            timeoutSeconds: parsed.modalTimeoutSeconds ?? DEFAULT_MODAL_TIMEOUT_SECONDS,
+            workDir: cwd ?? process.cwd(),
+          })
+        : await executeCommand(parsed.agent, command, cwd, env, stderr, {
+            stdout,
+            stdoutHandling,
+            stdoutLog: commandStdoutLog,
+            stderr: commandStderr,
+          });
+      if (parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
+        appendNodeLog(env, parsed.runId, nodeId, "stdout", result.stdout);
+      }
+      if (parsed.runId && parsed.role && nodeId) {
+        const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
+        const metrics = extractRunNodeMetrics(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env));
+        updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined, metrics);
+        if (result.code === 0 && parsed.role === "orchestrator" && finalMessage) {
+          completeIdleRunNodes(env, parsed.runId, nodeId, finalMessage);
+        }
+      }
+    } finally {
+      statusReporter?.stop();
+    }
+    if (!result) {
+      throw new CliError("agent execution did not produce a result");
     }
     if (result.code === 0 && sessionPlan) {
       await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,6 +132,7 @@ interface ParsedArgs {
   list: boolean;
   tmux: boolean;
   help: boolean;
+  version: boolean;
 }
 
 interface CliDeps {
@@ -206,6 +207,7 @@ function usage(): string {
     "  --list               List active headless tmux sessions.",
     "  --print-command      Print the command without executing it.",
     "  --show-config        Print harness config paths and auth seed paths.",
+    "  -v, --version        Print the Headless CLI version.",
     "  -h, --help           Show this help.",
     "",
     "If neither --prompt nor --prompt-file is provided, stdin is used when piped.",
@@ -236,6 +238,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     list: false,
     tmux: false,
     help: false,
+    version: false,
   };
   const args = [...argv];
 
@@ -247,6 +250,10 @@ function parseArgs(argv: string[]): ParsedArgs {
   const first = args.shift();
   if (first === "-h" || first === "--help") {
     parsed.help = true;
+    return parsed;
+  }
+  if (first === "-v" || first === "--version") {
+    parsed.version = true;
     return parsed;
   }
   if (first === undefined) {
@@ -388,6 +395,10 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--show-config":
         parsed.showConfig = true;
+        break;
+      case "-v":
+      case "--version":
+        parsed.version = true;
         break;
       case "-h":
       case "--help":
@@ -594,6 +605,14 @@ function renderConfig(agent: AgentName): string {
 
 function packageRoot(): string {
   return dirname(dirname(fileURLToPath(import.meta.url)));
+}
+
+function packageVersion(): string {
+  const packageJson = JSON.parse(readFileSync(join(packageRoot(), "package.json"), "utf8")) as { version?: unknown };
+  if (typeof packageJson.version !== "string") {
+    throw new CliError("package version not found");
+  }
+  return packageJson.version;
 }
 
 function dockerfilePath(): string {
@@ -1586,6 +1605,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
 
     if (parsed.help) {
       stdout(usage());
+      return 0;
+    }
+    if (parsed.version) {
+      stdout(`${packageVersion()}\n`);
       return 0;
     }
     if (parsed.runCommand) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,7 @@ import {
   priceUsageSummary,
 } from "./output.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
+import { extractRunNodeMetrics } from "./run-metrics.js";
 import {
   appendNodeLog,
   readRun,
@@ -2072,6 +2073,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         : "capture";
     if (parsed.runId && parsed.role && nodeId) {
       appendRunInvocationLog(env, parsed.runId, nodeId, "node invocation");
+      updateNodeStatus(env, parsed.runId, nodeId, "busy");
     }
     const commandStdoutLog = runStdoutLogger(env, parsed.runId, nodeId);
     const commandStderr = runStderrLogger(env, parsed.runId, nodeId);
@@ -2114,7 +2116,14 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     if (parsed.runId && parsed.role && nodeId) {
       const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
-      updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined);
+      updateNodeStatus(
+        env,
+        parsed.runId,
+        nodeId,
+        result.code === 0 ? "idle" : "failed",
+        finalMessage || undefined,
+        extractRunNodeMetrics(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)),
+      );
     }
     if (result.code === 0 && sessionPlan) {
       await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1579,6 +1579,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
   const stdout = deps.stdout ?? ((text: string) => process.stdout.write(text));
   const stderr = deps.stderr ?? ((text: string) => process.stderr.write(text));
   const env = deps.env ?? process.env;
+  let registeredRunNode: { runId: string; nodeId: string } | undefined;
 
   try {
     const parsed = parseArgs(argv);
@@ -1895,6 +1896,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         workDir: cwd ?? process.cwd(),
         sessionAlias: coordination === "session" ? (parsed.sessionAlias ?? nodeId) : parsed.sessionAlias,
       });
+      registeredRunNode = { runId: parsed.runId, nodeId };
     }
     const composedPrompt = composeRolePrompt(
       prompt.prompt,
@@ -2194,6 +2196,19 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     return result.code;
   } catch (error) {
+    if (registeredRunNode) {
+      try {
+        updateNodeStatus(
+          env,
+          registeredRunNode.runId,
+          registeredRunNode.nodeId,
+          "failed",
+          error instanceof Error ? error.message : String(error),
+        );
+      } catch {
+        // Preserve the original CLI error.
+      }
+    }
     if (error instanceof CliError) {
       stderr(`headless: ${error.message}\n`);
       return 2;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1929,9 +1929,8 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
           return 0;
         }
         const code = await executeTmuxSendCommands(tmuxCommands, env, stderr);
-        if (code === 0) {
-          stdout(`sent: ${tmuxCommands.sessionName}\n`);
-          if (parsed.runId && parsed.role && nodeId) {
+        if (parsed.runId && parsed.role && nodeId) {
+          if (code === 0) {
             registerNode(env, {
               runId: parsed.runId,
               nodeId,
@@ -1948,7 +1947,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
               sessionAlias: parsed.sessionAlias ?? nodeId,
               tmuxSessionName: sessionName,
             });
+          } else {
+            updateNodeStatus(env, parsed.runId, nodeId, "failed", `tmux command exited with code ${code}`);
           }
+        }
+        if (code === 0) {
+          stdout(`sent: ${tmuxCommands.sessionName}\n`);
         }
         return code;
       }
@@ -1974,25 +1978,6 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         env,
         parsed.sessionAlias ?? parsed.tmuxName,
       );
-      if (!parsed.printCommand && parsed.runId && parsed.role && nodeId) {
-        registerNode(env, {
-          runId: parsed.runId,
-          nodeId,
-          role: parsed.role,
-          agent: parsed.agent,
-          coordination,
-          status: "busy",
-          dependsOn: parsed.dependsOn,
-          planned: true,
-          allow,
-          model: configuredDefaults.model,
-          reasoningEffort: configuredDefaults.reasoningEffort,
-          workDir: cwd ?? process.cwd(),
-          sessionAlias: parsed.sessionAlias ?? parsed.tmuxName ?? nodeId,
-          tmuxSessionName: tmuxCommands.sessionName,
-        });
-      }
-
       if (parsed.printCommand) {
         stdout(`${quoteCommand(tmuxCommands.newSession)}\n`);
         for (const postLaunch of tmuxCommands.postLaunch) {
@@ -2009,6 +1994,28 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       }
 
       const code = await executeTmuxCommands(tmuxCommands, cwd, env, stderr);
+      if (parsed.runId && parsed.role && nodeId) {
+        if (code === 0) {
+          registerNode(env, {
+            runId: parsed.runId,
+            nodeId,
+            role: parsed.role,
+            agent: parsed.agent,
+            coordination,
+            status: "busy",
+            dependsOn: parsed.dependsOn,
+            planned: true,
+            allow,
+            model: configuredDefaults.model,
+            reasoningEffort: configuredDefaults.reasoningEffort,
+            workDir: cwd ?? process.cwd(),
+            sessionAlias: parsed.sessionAlias ?? parsed.tmuxName ?? nodeId,
+            tmuxSessionName: tmuxCommands.sessionName,
+          });
+        } else {
+          updateNodeStatus(env, parsed.runId, nodeId, "failed", `tmux command exited with code ${code}`);
+        }
+      }
       if (code === 0) {
         stdout(`tmux session: ${tmuxCommands.sessionName}\n`);
         stdout(`attach: tmux attach-session -t ${tmuxCommands.sessionName}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,8 +53,29 @@ import {
   fetchModelsDevPricing,
   priceUsageSummary,
 } from "./output.js";
+import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
+import {
+  readRun,
+  registerNode,
+  runDirectory,
+  updateNodeStatus,
+  validateRunId,
+  type RunNode,
+} from "./runs.js";
 import { readStoredSession, sessionStorePath, writeStoredSession } from "./sessions.js";
 import { quoteCommand } from "./shell.js";
+import {
+  composeRolePrompt,
+  isCoordinationMode,
+  isRole,
+  isRunStatus,
+  nodeIdForRole,
+  roleDefaultAllow,
+  type CoordinationMode,
+  type Role,
+  type RunStatus,
+} from "./roles.js";
+import { expandTeamSpecs } from "./teams.js";
 import type { AgentName, AllowMode, BuiltCommand, Env, ReasoningEffort } from "./types.js";
 
 interface ParsedArgs {
@@ -63,8 +84,19 @@ interface ParsedArgs {
   rename: boolean;
   renameSession?: string;
   renameName?: string;
+  runCommand?: "list" | "view" | "mark" | "message" | "wait";
+  runCommandRunId?: string;
+  runCommandNodeId?: string;
+  runCommandStatus?: RunStatus;
+  runCommandAsync: boolean;
   dockerCommand?: "build" | "doctor";
   agent?: AgentName;
+  role?: Role;
+  coordination?: CoordinationMode;
+  runId?: string;
+  nodeId?: string;
+  dependsOn: string[];
+  teamSpecs: string[];
   prompt?: string;
   promptFile?: string;
   model?: string;
@@ -120,6 +152,7 @@ function usage(): string {
     "       headless docker build [options]",
     "       headless send <session-name> (--prompt <text> | --prompt-file <path>) [options]",
     "       headless rename <session-name> <new-name> [options]",
+    "       headless run <list|view|mark|message|wait> [args] [options]",
     "",
     `Agents: ${listAgents().join(", ")}`,
     "",
@@ -127,6 +160,12 @@ function usage(): string {
     "  --model <name>        Agent model override.",
     "  --reasoning-effort <level> Reasoning effort: low, medium, high, or xhigh.",
     "  --allow <mode>        Permission mode: read-only or yolo.",
+    "  --role <role>         Role: orchestrator, explorer, worker, or reviewer.",
+    "  --coordination <mode> Coordination: session, tmux, or oneshot.",
+    "  --run <run>           Register this invocation in a local run.",
+    "  --node <node>         Node name inside --run. Defaults to the role name.",
+    "  --depends-on <node>   Record a dependency edge. Repeatable.",
+    "  --team <spec>         Declare orchestrator team nodes, e.g. worker=2 or codex/worker=3.",
     "  --prompt, -p <text>   Prompt text.",
     "  --prompt-file <path>  Read prompt from a file.",
     "  --work-dir, -C <path> Run from this directory.",
@@ -152,6 +191,11 @@ function usage(): string {
     "  --session <name>     Start or resume a named Headless session.",
     "  send <session-name>  Send a message to an existing headless tmux session.",
     "  rename <session> <name> Rename an existing headless tmux session.",
+    "  run list            List local coordinated runs.",
+    "  run view <run>      Show run graph, recent messages, and exact node commands.",
+    "  run mark <run> <node> --status <status> Update node status.",
+    "  run message <run> <node> --prompt <text> [--async] Route a message to a node.",
+    "  run wait <run>      Wait until no nodes are busy.",
     "  docker doctor       Check Docker setup and image availability.",
     "  docker build        Build the local Docker image tag headless-local:dev.",
     "  --check              Check installed agent binaries, versions, and local API/OAuth credentials.",
@@ -169,6 +213,9 @@ function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = {
     send: false,
     rename: false,
+    runCommandAsync: false,
+    dependsOn: [],
+    teamSpecs: [],
     docker: false,
     dockerArgs: [],
     dockerEnv: [],
@@ -206,6 +253,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     parsed.send = true;
   } else if (first === "rename") {
     parsed.rename = true;
+  } else if (first === "run") {
+    parsed.runCommand = parseRunCommand(args.shift());
   } else if (first === "docker") {
     parsed.dockerCommand = parseDockerCommand(args.shift());
   } else if (isAgentName(first)) {
@@ -235,6 +284,24 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--allow":
         parsed.allow = parseAllowMode(takeValue(args, arg));
+        break;
+      case "--role":
+        parsed.role = parseRole(takeValue(args, arg));
+        break;
+      case "--coordination":
+        parsed.coordination = parseCoordinationMode(takeValue(args, arg));
+        break;
+      case "--run":
+        parsed.runId = validateSafeName(takeValue(args, arg), "run");
+        break;
+      case "--node":
+        parsed.nodeId = validateSafeName(takeValue(args, arg), "node");
+        break;
+      case "--depends-on":
+        parsed.dependsOn.push(validateSafeName(takeValue(args, arg), "dependency"));
+        break;
+      case "--team":
+        parsed.teamSpecs.push(takeValue(args, arg));
         break;
       case "--work-dir":
       case "-C":
@@ -309,6 +376,12 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--print-command":
         parsed.printCommand = true;
         break;
+      case "--status":
+        parsed.runCommandStatus = parseRunStatus(takeValue(args, arg));
+        break;
+      case "--async":
+        parsed.runCommandAsync = true;
+        break;
       case "--show-config":
         parsed.showConfig = true;
         break;
@@ -337,11 +410,31 @@ function parseArgs(argv: string[]): ParsedArgs {
             break;
           }
         }
+        if (parsed.runCommand && arg && !arg.startsWith("-")) {
+          if (parsed.runCommandRunId === undefined) {
+            parsed.runCommandRunId = validateSafeName(arg, "run");
+            break;
+          }
+          if (
+            (parsed.runCommand === "mark" || parsed.runCommand === "message") &&
+            parsed.runCommandNodeId === undefined
+          ) {
+            parsed.runCommandNodeId = validateSafeName(arg, "node");
+            break;
+          }
+        }
         throw new CliError(`unknown argument: ${arg ?? ""}`);
     }
   }
 
   return parsed;
+}
+
+function parseRunCommand(value: string | undefined): "list" | "view" | "mark" | "message" | "wait" {
+  if (value === "list" || value === "view" || value === "mark" || value === "message" || value === "wait") {
+    return value;
+  }
+  throw new CliError("missing run command; use run list, view, mark, message, or wait");
 }
 
 function takeValue(args: string[], flag: string | undefined): string {
@@ -357,6 +450,35 @@ function parseAllowMode(value: string): AllowMode {
     return value;
   }
   throw new CliError(`unsupported allow mode: ${value}`);
+}
+
+function parseRole(value: string): Role {
+  if (isRole(value)) {
+    return value;
+  }
+  throw new CliError(`unsupported role: ${value}`);
+}
+
+function parseCoordinationMode(value: string): CoordinationMode {
+  if (isCoordinationMode(value)) {
+    return value;
+  }
+  throw new CliError(`unsupported coordination mode: ${value}`);
+}
+
+function parseRunStatus(value: string): RunStatus {
+  if (isRunStatus(value)) {
+    return value;
+  }
+  throw new CliError(`unsupported run status: ${value}`);
+}
+
+function validateSafeName(value: string | undefined, label: string): string {
+  try {
+    return validateRunId(value, label);
+  } catch (error) {
+    throw new CliError(error instanceof Error ? error.message : String(error));
+  }
 }
 
 function parseReasoningEffort(value: string): ReasoningEffort {
@@ -1297,6 +1419,97 @@ async function executeTmuxRenameCommand(
   return await executeSimpleCommand(command.command, undefined, env, stderr);
 }
 
+function effectiveCoordination(parsed: ParsedArgs): CoordinationMode {
+  if (parsed.coordination) {
+    return parsed.coordination;
+  }
+  if (parsed.tmux) {
+    return "tmux";
+  }
+  if ((parsed.docker || parsed.modal) && parsed.role) {
+    return "oneshot";
+  }
+  return "session";
+}
+
+function withRunEnvironment(command: BuiltCommand, runId: string | undefined, nodeId: string | undefined): BuiltCommand {
+  if (!runId && !nodeId) {
+    return command;
+  }
+  return {
+    ...command,
+    env: {
+      ...command.env,
+      ...(runId ? { HEADLESS_RUN_ID: runId } : {}),
+      ...(nodeId ? { HEADLESS_RUN_NODE: nodeId } : {}),
+    },
+  };
+}
+
+async function executeStoredNode(
+  node: {
+    agent: AgentName;
+    allow?: AllowMode;
+    coordination: CoordinationMode;
+    model?: string;
+    reasoningEffort?: ReasoningEffort;
+    runId: string;
+    nodeId: string;
+    role: Role;
+    sessionAlias?: string;
+    workDir?: string;
+  },
+  rawPrompt: string,
+  env: Env,
+  stderr: (text: string) => void,
+  stdout: (text: string) => void,
+  stdoutHandling: StdoutHandling,
+): Promise<ExecuteResult> {
+  const run = readRun(env, node.runId);
+  const prompt = composeRolePrompt(
+    rawPrompt,
+    {
+      agent: node.agent,
+      role: node.role,
+      coordination: node.coordination,
+      runId: node.runId,
+      nodeId: node.nodeId,
+      dependsOn: [],
+      team: [],
+      allow: node.allow,
+      model: node.model,
+      reasoningEffort: node.reasoningEffort,
+      workDir: node.workDir,
+      sessionAlias: node.sessionAlias,
+    },
+    run,
+  );
+  const sessionPlan =
+    node.coordination === "session" ? await prepareSessionPlan(node.agent, buildSessionPlan(node.agent, node.sessionAlias ?? node.nodeId, env), node.workDir, env) : undefined;
+  const command = withRunEnvironment(
+    buildAgentCommand(
+      node.agent,
+      applySessionPlan(
+        {
+          prompt,
+          model: node.model,
+          allow: node.allow,
+          reasoningEffort: node.reasoningEffort,
+        },
+        sessionPlan,
+      ),
+      env,
+    ),
+    node.runId,
+    node.nodeId,
+  );
+  const result = await executeCommand(node.agent, command, node.workDir, env, stderr, { stdout, stdoutHandling });
+  if (result.code === 0 && sessionPlan) {
+    await persistSessionPlan(node.agent, sessionPlan, result.stdout, node.workDir, env);
+  }
+  return result;
+}
+
 export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number> {
   const stdout = deps.stdout ?? ((text: string) => process.stdout.write(text));
   const stderr = deps.stderr ?? ((text: string) => process.stderr.write(text));
@@ -1308,6 +1521,40 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.help) {
       stdout(usage());
       return 0;
+    }
+    if (parsed.runCommand) {
+      try {
+        return await handleRunCommandImpl(
+          {
+            command: parsed.runCommand,
+            runId: parsed.runCommandRunId,
+            nodeId: parsed.runCommandNodeId,
+            status: parsed.runCommandStatus,
+            async: parsed.runCommandAsync,
+            printCommand: parsed.printCommand,
+          },
+          {
+            env,
+            stdout,
+            stderr,
+            resolvePrompt: () => resolvePrompt(parsed, deps, { forceText: true, requireAgent: false }),
+            executeNode: (node: RunNode, prompt: string) =>
+              executeStoredNode(node, prompt, env, stderr, stdout, "capture"),
+            sendTmux: async (sessionName: string, prompt: string, printCommand: boolean) => {
+              const tmuxCommands = buildTmuxSendCommands(sessionName, prompt);
+              if (printCommand) {
+                for (const command of tmuxCommands.commands) {
+                  stdout(`${quoteCommand(command)}\n`);
+                }
+                return 0;
+              }
+              return await executeTmuxSendCommands(tmuxCommands, env, stderr);
+            },
+          },
+        );
+      } catch (error) {
+        throw new CliError(error instanceof Error ? error.message : String(error));
+      }
     }
     if (parsed.dockerCommand) {
       if (parsed.prompt !== undefined || parsed.promptFile !== undefined) {
@@ -1473,6 +1720,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (!parsed.agent) {
       parsed.agent = parsed.docker || parsed.modal ? autoAgentPreference[0] : selectDefaultAgent(env);
     }
+    if (parsed.coordination === "tmux") {
+      parsed.tmux = true;
+    }
     if (parsed.tmux && parsed.docker) {
       throw new CliError("--docker cannot be used with --tmux");
     }
@@ -1507,6 +1757,20 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       throw new CliError("--session cannot be used with --modal");
     }
     validateSessionAlias(parsed.sessionAlias);
+    const coordination = effectiveCoordination(parsed);
+    const nodeId = nodeIdForRole(parsed.role, parsed.nodeId);
+    if (parsed.runId !== undefined && parsed.role === undefined) {
+      throw new CliError("--run requires --role");
+    }
+    if (parsed.nodeId !== undefined && parsed.runId === undefined) {
+      throw new CliError("--node requires --run");
+    }
+    if (parsed.dependsOn.length > 0 && parsed.runId === undefined) {
+      throw new CliError("--depends-on requires --run");
+    }
+    if (parsed.teamSpecs.length > 0 && parsed.role !== "orchestrator") {
+      throw new CliError("--team requires --role orchestrator");
+    }
     if (parsed.showConfig) {
       stdout(renderConfig(parsed.agent));
       return 0;
@@ -1524,14 +1788,65 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       throw new CliError(error instanceof Error ? error.message : String(error));
     }
     const cwd = validateWorkDir(parsed.workDir);
-    const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux });
+    const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux || parsed.role !== undefined || parsed.runId !== undefined });
+    const allow = parsed.allow ?? roleDefaultAllow(parsed.role);
+    const team = parsed.teamSpecs.length > 0 ? expandTeamSpecs(parsed.agent, parsed.teamSpecs) : [];
+    if (!parsed.printCommand && parsed.runId && parsed.role && nodeId) {
+      for (const teamNode of team) {
+        registerNode(env, {
+          runId: parsed.runId,
+          nodeId: teamNode.nodeId,
+          role: teamNode.role,
+          agent: teamNode.agent,
+          coordination,
+          status: "planned",
+          planned: true,
+          allow: roleDefaultAllow(teamNode.role),
+          workDir: cwd ?? process.cwd(),
+          sessionAlias: teamNode.nodeId,
+        });
+      }
+      registerNode(env, {
+        runId: parsed.runId,
+        nodeId,
+        role: parsed.role,
+        agent: parsed.agent,
+        coordination,
+        status: "starting",
+        dependsOn: parsed.dependsOn,
+        planned: true,
+        allow,
+        model: configuredDefaults.model,
+        reasoningEffort: configuredDefaults.reasoningEffort,
+        workDir: cwd ?? process.cwd(),
+        sessionAlias: coordination === "session" ? (parsed.sessionAlias ?? nodeId) : parsed.sessionAlias,
+      });
+    }
+    const composedPrompt = composeRolePrompt(
+      prompt.prompt,
+      {
+        agent: parsed.agent,
+        role: parsed.role,
+        coordination,
+        runId: parsed.runId,
+        nodeId,
+        dependsOn: parsed.dependsOn,
+        team,
+        allow,
+        model: configuredDefaults.model,
+        reasoningEffort: configuredDefaults.reasoningEffort,
+        workDir: cwd ?? process.cwd(),
+        sessionAlias: coordination === "session" ? (parsed.sessionAlias ?? nodeId) : parsed.sessionAlias,
+      },
+      parsed.runId ? readRun(env, parsed.runId) : undefined,
+    );
 
     if (parsed.tmux) {
       const sessionName = parsed.sessionAlias
         ? buildHeadlessTmuxSessionName(parsed.agent, parsed.sessionAlias)
         : undefined;
       if (sessionName && (await headlessTmuxSessionExists(sessionName, env))) {
-        const tmuxCommands = buildTmuxSendCommands(sessionName, prompt.prompt);
+        const tmuxCommands = buildTmuxSendCommands(sessionName, composedPrompt);
         if (parsed.printCommand) {
           for (const command of tmuxCommands.commands) {
             stdout(`${quoteCommand(command)}\n`);
@@ -1541,15 +1856,33 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         const code = await executeTmuxSendCommands(tmuxCommands, env, stderr);
         if (code === 0) {
           stdout(`sent: ${tmuxCommands.sessionName}\n`);
+          if (parsed.runId && parsed.role && nodeId) {
+            registerNode(env, {
+              runId: parsed.runId,
+              nodeId,
+              role: parsed.role,
+              agent: parsed.agent,
+              coordination,
+              status: "busy",
+              dependsOn: parsed.dependsOn,
+              planned: true,
+              allow,
+              model: configuredDefaults.model,
+              reasoningEffort: configuredDefaults.reasoningEffort,
+              workDir: cwd ?? process.cwd(),
+              sessionAlias: parsed.sessionAlias ?? nodeId,
+              tmuxSessionName: sessionName,
+            });
+          }
         }
         return code;
       }
       const tmuxCommand = buildInteractiveAgentCommand(
         parsed.agent,
         {
-          prompt: prompt.prompt,
+          prompt: composedPrompt,
           model: configuredDefaults.model,
-          allow: parsed.allow,
+          allow,
           reasoningEffort: configuredDefaults.reasoningEffort,
         },
         env,
@@ -1561,11 +1894,29 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       const tmuxCommands = buildTmuxCommands(
         parsed.agent,
         tmuxCommand,
-        prompt.prompt,
+        composedPrompt,
         cwd,
         env,
         parsed.sessionAlias ?? parsed.tmuxName,
       );
+      if (!parsed.printCommand && parsed.runId && parsed.role && nodeId) {
+        registerNode(env, {
+          runId: parsed.runId,
+          nodeId,
+          role: parsed.role,
+          agent: parsed.agent,
+          coordination,
+          status: "busy",
+          dependsOn: parsed.dependsOn,
+          planned: true,
+          allow,
+          model: configuredDefaults.model,
+          reasoningEffort: configuredDefaults.reasoningEffort,
+          workDir: cwd ?? process.cwd(),
+          sessionAlias: parsed.sessionAlias ?? parsed.tmuxName ?? nodeId,
+          tmuxSessionName: tmuxCommands.sessionName,
+        });
+      }
 
       if (parsed.printCommand) {
         stdout(`${quoteCommand(tmuxCommands.newSession)}\n`);
@@ -1591,20 +1942,26 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
 
     let sessionPlan = buildSessionPlan(parsed.agent, parsed.sessionAlias, env);
+    if (parsed.runId && parsed.role && coordination === "session" && !parsed.sessionAlias) {
+      sessionPlan = buildSessionPlan(parsed.agent, nodeId, env);
+    }
+    if (parsed.runId && parsed.role && coordination === "oneshot") {
+      sessionPlan = undefined;
+    }
     if (!parsed.printCommand) {
       sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env);
     }
-    let command = buildAgentCommand(
+    let command = withRunEnvironment(buildAgentCommand(
       parsed.agent,
       applySessionPlan({
-        prompt: prompt.prompt,
-        promptFile: prompt.promptFile,
+        prompt: composedPrompt,
+        promptFile: parsed.role || parsed.runId ? undefined : prompt.promptFile,
         model: configuredDefaults.model,
-        allow: parsed.allow,
+        allow,
         reasoningEffort: configuredDefaults.reasoningEffort,
       }, sessionPlan),
       env,
-    );
+    ), parsed.runId, nodeId);
     const reasoningWarning = unsupportedReasoningEffortWarning(parsed.agent, configuredDefaults.reasoningEffort, "headless");
     if (reasoningWarning) {
       stderr(reasoningWarning);
@@ -1618,6 +1975,8 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         env,
         hostUser: detectDockerHostUser(),
         image: parsed.dockerImage ?? DEFAULT_DOCKER_IMAGE,
+        runDirHost: parsed.runId ? runDirectory(env, parsed.runId) : undefined,
+        runId: parsed.runId,
         workDir: cwd ?? process.cwd(),
       });
     }
@@ -1678,6 +2037,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
           stdout,
           stdoutHandling,
         });
+    if (parsed.runId && parsed.role && nodeId) {
+      const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
+      updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined);
+    }
     if (result.code === 0 && sessionPlan) {
       await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import {
   listAgents,
 } from "./agents.js";
 import { checkAgents, checkDocker, commandExists, commandForAgent, renderAgentChecks, renderDockerCheck } from "./check.js";
-import { loadHeadlessConfig, resolveAgentDefaults, type AgentDefaults } from "./config.js";
+import { loadHeadlessConfig, resolveInvocationDefaults, type HeadlessConfig, type InvocationDefaults } from "./config.js";
 import {
   buildDockerAgentCommand,
   DEFAULT_DOCKER_IMAGE,
@@ -686,7 +686,7 @@ function commandEnv(baseEnv: Env, command: BuiltCommand): Env {
   return command.env ? { ...baseEnv, ...command.env } : baseEnv;
 }
 
-function usageContext(agent: AgentName, defaults: AgentDefaults, env: Env): { provider?: string; model?: string } {
+function usageContext(agent: AgentName, defaults: InvocationDefaults, env: Env): { provider?: string; model?: string } {
   if (agent === "codex") {
     return { provider: "openai", model: defaults.model ?? env.CODEX_MODEL ?? "gpt-5.5" };
   }
@@ -767,6 +767,7 @@ type StdoutHandling = "capture" | "stream" | "capture-and-stream";
 interface ExecuteCommandOptions {
   stdoutHandling: StdoutHandling;
   stdout: (text: string) => void;
+  stdoutLog?: (text: string) => void;
   stderr?: (text: string) => void;
 }
 
@@ -1024,6 +1025,7 @@ async function executeCommand(
         if (options.stdoutHandling !== "stream") {
           capturedStdout += chunk;
         }
+        options.stdoutLog?.(chunk);
         if (options.stdoutHandling !== "capture") {
           options.stdout(chunk);
         }
@@ -1352,33 +1354,15 @@ function appendRunInvocationLog(env: Env, runId: string, nodeId: string, label: 
   appendNodeLog(env, runId, nodeId, "stderr", header);
 }
 
-function appendCapturedRunStdout(
-  env: Env,
-  runId: string | undefined,
-  nodeId: string | undefined,
-  stdoutHandling: StdoutHandling,
-  capturedStdout: string,
-): void {
-  if (!runId || !nodeId || stdoutHandling !== "capture") {
-    return;
-  }
-  appendNodeLog(env, runId, nodeId, "stdout", capturedStdout);
-}
-
 function runStdoutLogger(
   env: Env,
   runId: string | undefined,
   nodeId: string | undefined,
-  stdoutHandling: StdoutHandling,
-  stdout: (text: string) => void,
-): (text: string) => void {
-  if (!runId || !nodeId || stdoutHandling === "capture") {
-    return stdout;
+): ((text: string) => void) | undefined {
+  if (!runId || !nodeId) {
+    return undefined;
   }
-  return (text: string) => {
-    appendNodeLog(env, runId, nodeId, "stdout", text);
-    stdout(text);
-  };
+  return (text: string) => appendNodeLog(env, runId, nodeId, "stdout", text);
 }
 
 function runStderrLogger(
@@ -1517,6 +1501,15 @@ async function executeStoredNode(
   stdoutHandling: StdoutHandling,
 ): Promise<ExecuteResult> {
   const run = readRun(env, node.runId);
+  const config = loadHeadlessConfig(env);
+  const defaults = resolveInvocationDefaults(
+    node.agent,
+    node.role,
+    { model: node.model, reasoningEffort: node.reasoningEffort, allow: node.allow },
+    env,
+    config,
+  );
+  const allow = defaults.allow ?? roleDefaultAllow(node.role);
   const prompt = composeRolePrompt(
     rawPrompt,
     {
@@ -1527,13 +1520,14 @@ async function executeStoredNode(
       nodeId: node.nodeId,
       dependsOn: [],
       team: [],
-      allow: node.allow,
-      model: node.model,
-      reasoningEffort: node.reasoningEffort,
+      allow,
+      model: defaults.model,
+      reasoningEffort: defaults.reasoningEffort,
       workDir: node.workDir,
       sessionAlias: node.sessionAlias,
     },
     run,
+    { baseInstructionPrompt: defaults.baseInstructionPrompt },
   );
   const sessionPlan =
     node.coordination === "session" ? await prepareSessionPlan(node.agent, buildSessionPlan(node.agent, node.sessionAlias ?? node.nodeId, env), node.workDir, env) : undefined;
@@ -1543,9 +1537,9 @@ async function executeStoredNode(
       applySessionPlan(
         {
           prompt,
-          model: node.model,
-          allow: node.allow,
-          reasoningEffort: node.reasoningEffort,
+          model: defaults.model,
+          allow,
+          reasoningEffort: defaults.reasoningEffort,
         },
         sessionPlan,
       ),
@@ -1556,11 +1550,11 @@ async function executeStoredNode(
   );
   appendRunInvocationLog(env, node.runId, node.nodeId, "run message");
   const result = await executeCommand(node.agent, command, node.workDir, env, stderr, {
-    stdout: runStdoutLogger(env, node.runId, node.nodeId, stdoutHandling, stdout),
+    stdout,
     stdoutHandling,
+    stdoutLog: runStdoutLogger(env, node.runId, node.nodeId),
     stderr: runStderrLogger(env, node.runId, node.nodeId),
   });
-  appendCapturedRunStdout(env, node.runId, node.nodeId, stdoutHandling, result.stdout);
   if (result.code === 0 && sessionPlan) {
     await persistSessionPlan(node.agent, sessionPlan, result.stdout, node.workDir, env);
   }
@@ -1833,26 +1827,30 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return 0;
     }
 
-    let configuredDefaults: AgentDefaults;
+    let config: HeadlessConfig;
+    let configuredDefaults: InvocationDefaults;
     try {
-      configuredDefaults = resolveAgentDefaults(
+      config = loadHeadlessConfig(env);
+      configuredDefaults = resolveInvocationDefaults(
         parsed.agent,
-        { model: parsed.model, reasoningEffort: parsed.reasoningEffort },
+        parsed.role,
+        { model: parsed.model, reasoningEffort: parsed.reasoningEffort, allow: parsed.allow },
         env,
-        loadHeadlessConfig(env),
+        config,
       );
     } catch (error) {
       throw new CliError(error instanceof Error ? error.message : String(error));
     }
     const cwd = validateWorkDir(parsed.workDir);
     const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux || parsed.role !== undefined || parsed.runId !== undefined });
-    const allow = parsed.allow ?? roleDefaultAllow(parsed.role);
+    const allow = configuredDefaults.allow ?? roleDefaultAllow(parsed.role);
     if (parsed.runId && parsed.role === "orchestrator" && allow === "read-only") {
       throw new CliError("--role orchestrator with --run cannot use --allow read-only; it must be able to launch child nodes and update run state");
     }
     const team = parsed.teamSpecs.length > 0 ? expandTeamSpecs(parsed.agent, parsed.teamSpecs) : [];
     if (!parsed.printCommand && parsed.runId && parsed.role && nodeId) {
       for (const teamNode of team) {
+        const teamDefaults = resolveInvocationDefaults(teamNode.agent, teamNode.role, {}, env, config);
         registerNode(env, {
           runId: parsed.runId,
           nodeId: teamNode.nodeId,
@@ -1861,7 +1859,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
           coordination,
           status: "planned",
           planned: true,
-          allow: roleDefaultAllow(teamNode.role),
+          allow: teamDefaults.allow ?? roleDefaultAllow(teamNode.role),
+          model: teamDefaults.model,
+          reasoningEffort: teamDefaults.reasoningEffort,
           workDir: cwd ?? process.cwd(),
           sessionAlias: teamNode.nodeId,
         });
@@ -1899,6 +1899,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         sessionAlias: coordination === "session" ? (parsed.sessionAlias ?? nodeId) : parsed.sessionAlias,
       },
       parsed.runId ? readRun(env, parsed.runId) : undefined,
+      { baseInstructionPrompt: configuredDefaults.baseInstructionPrompt },
     );
 
     if (parsed.tmux) {
@@ -2072,7 +2073,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.runId && parsed.role && nodeId) {
       appendRunInvocationLog(env, parsed.runId, nodeId, "node invocation");
     }
-    const commandStdout = runStdoutLogger(env, parsed.runId, nodeId, stdoutHandling, stdout);
+    const commandStdoutLog = runStdoutLogger(env, parsed.runId, nodeId);
     const commandStderr = runStderrLogger(env, parsed.runId, nodeId);
     const result = parsed.modal
       ? await executeModalAgent({
@@ -2094,17 +2095,23 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
               stderr(filtered);
             }
           },
-          stdout: commandStdout,
+          stdout: (text) => {
+            commandStdoutLog?.(text);
+            stdout(text);
+          },
           stdoutHandling,
           timeoutSeconds: parsed.modalTimeoutSeconds ?? DEFAULT_MODAL_TIMEOUT_SECONDS,
           workDir: cwd ?? process.cwd(),
         })
       : await executeCommand(parsed.agent, command, cwd, env, stderr, {
-          stdout: commandStdout,
+          stdout,
           stdoutHandling,
+          stdoutLog: commandStdoutLog,
           stderr: commandStderr,
         });
-    appendCapturedRunStdout(env, parsed.runId, nodeId, stdoutHandling, result.stdout);
+    if (parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
+      appendNodeLog(env, parsed.runId, nodeId, "stdout", result.stdout);
+    }
     if (parsed.runId && parsed.role && nodeId) {
       const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
       updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2085,7 +2085,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
 
     const stdoutHandling: StdoutHandling = parsed.json
-      ? parsed.sessionAlias
+      ? parsed.sessionAlias || parsed.runId
         ? "capture-and-stream"
         : "stream"
       : parsed.debug

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,29 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import type { AgentName, Env, ReasoningEffort } from "./types.js";
+import { isRole, type Role } from "./roles.js";
+import type { AgentName, AllowMode, Env, ReasoningEffort } from "./types.js";
 
 export interface AgentDefaults {
   model?: string;
   reasoningEffort?: ReasoningEffort;
 }
 
+export interface RoleDefaults {
+  model?: string;
+  reasoningEffort?: ReasoningEffort;
+  allow?: AllowMode;
+  baseInstructionPrompt?: string;
+}
+
+export interface InvocationDefaults extends AgentDefaults {
+  allow?: AllowMode;
+  baseInstructionPrompt?: string;
+}
+
 export interface HeadlessConfig {
   agents: Partial<Record<AgentName, AgentDefaults>>;
+  roles: Partial<Record<Role, RoleDefaults>>;
 }
 
 export const BUILTIN_AGENT_DEFAULTS: Record<AgentName, AgentDefaults> = {
@@ -27,13 +41,13 @@ export function headlessConfigPath(env: Env): string | undefined {
 
 export function loadHeadlessConfig(env: Env): HeadlessConfig {
   const path = headlessConfigPath(env);
-  if (!path) return { agents: {} };
+  if (!path) return emptyHeadlessConfig();
 
   let content: string;
   try {
     content = readFileSync(path, "utf8");
   } catch {
-    return { agents: {} };
+    return emptyHeadlessConfig();
   }
   return parseHeadlessConfig(content);
 }
@@ -51,46 +65,99 @@ export function resolveAgentDefaults(
   };
 }
 
+export function resolveInvocationDefaults(
+  agent: AgentName,
+  role: Role | undefined,
+  options: InvocationDefaults,
+  env: Env,
+  config: HeadlessConfig,
+): InvocationDefaults {
+  const configuredAgent = config.agents[agent] ?? {};
+  const configuredRole = role ? (config.roles[role] ?? {}) : {};
+  return {
+    model: options.model ?? envModelDefault(agent, env) ?? configuredRole.model ?? configuredAgent.model,
+    reasoningEffort: options.reasoningEffort ?? configuredRole.reasoningEffort ?? configuredAgent.reasoningEffort,
+    allow: options.allow ?? configuredRole.allow,
+    baseInstructionPrompt: configuredRole.baseInstructionPrompt,
+  };
+}
+
 function envModelDefault(agent: AgentName, env: Env): string | undefined {
   if (agent === "codex") return env.CODEX_MODEL;
   if (agent === "pi") return env.PI_CODING_AGENT_MODEL;
   return undefined;
 }
 
-function parseHeadlessConfig(content: string): HeadlessConfig {
-  const config: HeadlessConfig = { agents: {} };
-  let currentAgent: AgentName | undefined;
+function emptyHeadlessConfig(): HeadlessConfig {
+  return { agents: {}, roles: {} };
+}
 
-  for (const [index, rawLine] of content.split(/\r?\n/).entries()) {
+type ConfigSection = { kind: "agent"; name: AgentName } | { kind: "role"; name: Role };
+
+export function parseHeadlessConfig(content: string): HeadlessConfig {
+  const config = emptyHeadlessConfig();
+  let currentSection: ConfigSection | undefined;
+  const lines = content.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index] ?? "";
     const line = stripTomlComment(rawLine).trim();
     if (!line) continue;
 
-    const section = line.match(/^\[agents\.([A-Za-z0-9_-]+)\]$/);
+    const section = line.match(/^\[(agents|roles)\.([A-Za-z0-9_-]+)\]$/);
     if (section) {
-      currentAgent = parseAgentName(section[1] ?? "", index + 1);
-      config.agents[currentAgent] = config.agents[currentAgent] ?? {};
+      if (section[1] === "agents") {
+        const name = parseAgentName(section[2] ?? "", index + 1);
+        currentSection = { kind: "agent", name };
+        config.agents[name] = config.agents[name] ?? {};
+      } else {
+        const name = parseRoleName(section[2] ?? "", index + 1);
+        currentSection = { kind: "role", name };
+        config.roles[name] = config.roles[name] ?? {};
+      }
       continue;
+    }
+    if (/^\[/.test(line)) {
+      throw new Error(`unsupported headless config section at line ${index + 1}: ${rawLine}`);
     }
 
     const assignment = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*=\s*(.+)$/);
     if (!assignment) {
       throw new Error(`invalid headless config at line ${index + 1}: ${rawLine}`);
     }
-    if (!currentAgent) {
-      throw new Error(`headless config key must be inside [agents.<name>] at line ${index + 1}`);
+    if (!currentSection) {
+      throw new Error(`headless config key must be inside [agents.<name>] or [roles.<name>] at line ${index + 1}`);
     }
 
     const key = assignment[1] ?? "";
-    const value = parseTomlString(assignment[2] ?? "", index + 1);
-    const defaults = config.agents[currentAgent] ?? {};
-    if (key === "model") {
-      defaults.model = value;
-    } else if (key === "reasoning_effort") {
-      defaults.reasoningEffort = parseConfigReasoningEffort(value, index + 1);
-    } else {
-      throw new Error(`unsupported headless config key at line ${index + 1}: ${key}`);
+    const parsedValue = parseTomlString(assignment[2] ?? "", index + 1, lines, index);
+    index = parsedValue.nextIndex;
+    if (currentSection.kind === "agent") {
+      const defaults = config.agents[currentSection.name] ?? {};
+      if (key === "model") {
+        defaults.model = parsedValue.value;
+      } else if (key === "reasoning_effort") {
+        defaults.reasoningEffort = parseConfigReasoningEffort(parsedValue.value, index + 1);
+      } else {
+        throw new Error(`unsupported headless agent config key at line ${index + 1}: ${key}`);
+      }
+      config.agents[currentSection.name] = defaults;
+      continue;
     }
-    config.agents[currentAgent] = defaults;
+
+    const defaults = config.roles[currentSection.name] ?? {};
+    if (key === "model") {
+      defaults.model = parsedValue.value;
+    } else if (key === "reasoning_effort") {
+      defaults.reasoningEffort = parseConfigReasoningEffort(parsedValue.value, index + 1);
+    } else if (key === "allow") {
+      defaults.allow = parseConfigAllow(parsedValue.value, index + 1);
+    } else if (key === "base_instruction_prompt") {
+      defaults.baseInstructionPrompt = parsedValue.value;
+    } else {
+      throw new Error(`unsupported headless role config key at line ${index + 1}: ${key}`);
+    }
+    config.roles[currentSection.name] = defaults;
   }
 
   return config;
@@ -110,6 +177,13 @@ function parseAgentName(value: string, lineNumber: number): AgentName {
   throw new Error(`unsupported headless config agent at line ${lineNumber}: ${value}`);
 }
 
+function parseRoleName(value: string, lineNumber: number): Role {
+  if (isRole(value)) {
+    return value;
+  }
+  throw new Error(`unsupported headless config role at line ${lineNumber}: ${value}`);
+}
+
 function parseConfigReasoningEffort(value: string, lineNumber: number): ReasoningEffort {
   if (value === "low" || value === "medium" || value === "high" || value === "xhigh") {
     return value;
@@ -117,15 +191,60 @@ function parseConfigReasoningEffort(value: string, lineNumber: number): Reasonin
   throw new Error(`unsupported headless config reasoning_effort at line ${lineNumber}: ${value}`);
 }
 
-function parseTomlString(value: string, lineNumber: number): string {
+function parseConfigAllow(value: string, lineNumber: number): AllowMode {
+  if (value === "read-only" || value === "yolo") {
+    return value;
+  }
+  throw new Error(`unsupported headless config allow at line ${lineNumber}: ${value}`);
+}
+
+function parseTomlString(
+  value: string,
+  lineNumber: number,
+  lines: string[],
+  index: number,
+): { value: string; nextIndex: number } {
   const trimmed = value.trim();
+  if (trimmed.startsWith('"""') || trimmed.startsWith("'''")) {
+    return parseMultilineTomlString(trimmed, lineNumber, lines, index);
+  }
   if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    return JSON.parse(trimmed) as string;
+    return { value: JSON.parse(trimmed) as string, nextIndex: index };
   }
   if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
-    return trimmed.slice(1, -1);
+    return { value: trimmed.slice(1, -1), nextIndex: index };
   }
   throw new Error(`headless config value must be a quoted string at line ${lineNumber}`);
+}
+
+function parseMultilineTomlString(
+  firstValue: string,
+  lineNumber: number,
+  lines: string[],
+  startIndex: number,
+): { value: string; nextIndex: number } {
+  const delimiter = firstValue.startsWith('"""') ? '"""' : "'''";
+  const pieces: string[] = [];
+  let rest = firstValue.slice(3);
+  let nextIndex = startIndex;
+
+  while (true) {
+    const end = rest.indexOf(delimiter);
+    if (end >= 0) {
+      pieces.push(rest.slice(0, end));
+      return { value: normalizeMultilineString(pieces.join("\n")), nextIndex };
+    }
+    pieces.push(rest);
+    nextIndex += 1;
+    if (nextIndex >= lines.length) {
+      throw new Error(`unterminated multiline string at line ${lineNumber}`);
+    }
+    rest = lines[nextIndex] ?? "";
+  }
+}
+
+function normalizeMultilineString(value: string): string {
+  return value.replace(/^\n/, "").replace(/\n$/, "");
 }
 
 function stripTomlComment(line: string): string {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -26,6 +26,8 @@ export interface DockerAgentCommandOptions {
   env: Env;
   hostUser?: string;
   image: string;
+  runDirHost?: string;
+  runId?: string;
   workDir: string;
 }
 
@@ -49,6 +51,10 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
   const workDir = realpathSync(options.workDir);
   const dockerEnvEntries = collectDockerEnvEntries(options.env, options.command.env, options.dockerEnv);
   args.push("--workdir", workDir, "--volume", `${workDir}:${workDir}`);
+  if (options.runDirHost && options.runId) {
+    const containerRunDir = `/headless-runs/${options.runId}`;
+    args.push("--volume", `${options.runDirHost}:${containerRunDir}`, "--env", `HEADLESS_RUN_DIR=${containerRunDir}`);
+  }
   args.push(...agentConfigMountArgs(options.agent, options.env));
   args.push(...credentialMountArgs(options.env, dockerEnvEntries, workDir));
   args.push(...dockerEnvArgs(dockerEnvEntries));

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -53,13 +53,14 @@ export function composeRolePrompt(
   prompt: string,
   invocation: RoleInvocation,
   run: RunRecord | undefined,
+  options: { baseInstructionPrompt?: string } = {},
 ): string {
   if (!invocation.role && !invocation.runId) {
     return prompt;
   }
 
   const parts = [
-    roleInstructions(invocation.role, invocation.runId),
+    options.baseInstructionPrompt ?? roleInstructions(invocation.role, invocation.runId),
     invocation.runId ? runContext(invocation, run) : "",
     "User prompt:",
     prompt,

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -1,0 +1,167 @@
+import type { AllowMode, AgentName, ReasoningEffort } from "./types.js";
+import type { RunNode, RunRecord } from "./runs.js";
+import type { TeamNodeSpec } from "./teams.js";
+
+export const roles = ["orchestrator", "explorer", "worker", "reviewer"] as const;
+export const coordinationModes = ["session", "tmux", "oneshot"] as const;
+export const runStatuses = ["planned", "starting", "busy", "idle", "done", "failed", "unknown"] as const;
+
+export type Role = (typeof roles)[number];
+export type CoordinationMode = (typeof coordinationModes)[number];
+export type RunStatus = (typeof runStatuses)[number];
+
+export interface RoleInvocation {
+  agent: AgentName;
+  role?: Role;
+  coordination: CoordinationMode;
+  runId?: string;
+  nodeId?: string;
+  dependsOn: string[];
+  team: TeamNodeSpec[];
+  allow?: AllowMode;
+  model?: string;
+  reasoningEffort?: ReasoningEffort;
+  workDir?: string;
+  sessionAlias?: string;
+  tmuxSessionName?: string;
+}
+
+export function isRole(value: string): value is Role {
+  return roles.includes(value as Role);
+}
+
+export function isCoordinationMode(value: string): value is CoordinationMode {
+  return coordinationModes.includes(value as CoordinationMode);
+}
+
+export function isRunStatus(value: string): value is RunStatus {
+  return runStatuses.includes(value as RunStatus);
+}
+
+export function roleDefaultAllow(role: Role | undefined): AllowMode | undefined {
+  if (role === "explorer" || role === "reviewer") {
+    return "read-only";
+  }
+  return undefined;
+}
+
+export function nodeIdForRole(role: Role | undefined, explicitNode: string | undefined): string | undefined {
+  return explicitNode ?? role;
+}
+
+export function composeRolePrompt(
+  prompt: string,
+  invocation: RoleInvocation,
+  run: RunRecord | undefined,
+): string {
+  if (!invocation.role && !invocation.runId) {
+    return prompt;
+  }
+
+  const parts = [
+    roleInstructions(invocation.role, invocation.runId),
+    invocation.runId ? runContext(invocation, run) : "",
+    "User prompt:",
+    prompt,
+  ].filter(Boolean);
+  return parts.join("\n\n");
+}
+
+function roleInstructions(role: Role | undefined, runId: string | undefined): string {
+  if (!role) {
+    return "";
+  }
+  const commandHelp = runId
+    ? [
+        "Coordination commands:",
+        `- headless run message ${runId} <node> --prompt "..." sends a turn to that node using stored run metadata.`,
+        "- Add --async to run session/oneshot nodes in the background; status becomes busy, logs are written, then status becomes idle or failed.",
+        `- headless run view ${runId} shows roster, status, last messages, dependencies, and log/attach commands.`,
+        `- headless run wait ${runId} waits until no nodes are busy or starting.`,
+        "- Run headless --help for full command syntax.",
+      ].join("\n")
+    : "Run headless --help for full command syntax.";
+  const finishCommand = runId
+    ? [
+        `When finished or blocked, send status with: headless run message ${runId} orchestrator --prompt "<status>"`,
+        "Include findings, changed files, tests, and blockers as relevant.",
+      ].join("\n")
+    : "When finished or blocked, report concise status in your final response.";
+
+  switch (role) {
+    case "orchestrator":
+      return [
+        "Role: orchestrator.",
+        "Coordinate the declared team at the beginning of the run and treat it as the coordination contract.",
+        "After initial team creation, do not launch surprise agents unless the user explicitly asks.",
+        "Use run message to assign work; use --async for parallel child work; ask children to report back explicitly.",
+        commandHelp,
+        runId
+          ? `Before your final response, call headless run wait ${runId} if async children may still be running.`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    case "explorer":
+      return [
+        "Role: explorer.",
+        "Stay read-only. Investigate and report concise findings.",
+        "Treat incoming run messages as the next task turn. Keep status concise enough for run view lastMessage.",
+        commandHelp,
+        finishCommand,
+      ].join("\n");
+    case "worker":
+      return [
+        "Role: worker.",
+        "Implement the assigned task. Keep changes scoped and run relevant verification.",
+        "Treat incoming run messages as the next task turn. Keep status concise enough for run view lastMessage.",
+        commandHelp,
+        finishCommand,
+      ].join("\n");
+    case "reviewer":
+      return [
+        "Role: reviewer.",
+        "Stay read-only. Review for bugs, regressions, security risks, and missing tests.",
+        "Lead with findings and file references. Treat incoming run messages as the next review turn.",
+        "Keep status concise enough for run view lastMessage.",
+        commandHelp,
+        finishCommand,
+      ].join("\n");
+  }
+}
+
+function runContext(invocation: RoleInvocation, run: RunRecord | undefined): string {
+  const nodes = run ? Object.values(run.nodes).sort((left, right) => left.nodeId.localeCompare(right.nodeId)) : [];
+  const currentNode = invocation.nodeId ?? nodeIdForRole(invocation.role, undefined) ?? "unknown";
+  const lines = [
+    "Headless run context:",
+    `run: ${invocation.runId}`,
+    `current node: ${currentNode}`,
+    `current role: ${invocation.role ?? "unknown"}`,
+    `coordination: ${invocation.coordination}`,
+    "roster:",
+    ...(nodes.length > 0 ? nodes.map(renderNodeContext) : ["- none registered yet"]),
+  ];
+  if (invocation.team.length > 0) {
+    lines.push("declared team:");
+    lines.push(...invocation.team.map((node) => `- ${node.nodeId}: ${node.agent}/${node.role}`));
+  }
+  lines.push("commands:");
+  lines.push(`- view: headless run view ${invocation.runId}`);
+  lines.push(`- wait: headless run wait ${invocation.runId}`);
+  for (const node of nodes) {
+    lines.push(`- message ${node.nodeId}: headless run message ${invocation.runId} ${node.nodeId} --prompt "..."`);
+  }
+  return lines.join("\n");
+}
+
+function renderNodeContext(node: RunNode): string {
+  const depends = node.dependsOn.length > 0 ? ` depends=${node.dependsOn.join(",")}` : "";
+  const last = node.lastMessage ? ` last=${JSON.stringify(truncate(node.lastMessage, 120))}` : "";
+  const planned = node.unplanned ? " unplanned" : " planned";
+  return `- ${node.nodeId}: ${node.agent}/${node.role} ${node.coordination} ${node.status}${depends}${planned}${last}`;
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
+}

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -83,7 +83,8 @@ function roleInstructions(role: Role | undefined, runId: string | undefined): st
     : "Run headless --help for full command syntax.";
   const finishCommand = runId
     ? [
-        `When finished or blocked, send status with: headless run message ${runId} orchestrator --prompt "<status>"`,
+        `When finished or blocked, send status with: headless run message ${runId} orchestrator --prompt "<status>" if your permissions allow it.`,
+        "If that command is blocked, put the same status in your final response; Headless captures final output into run state.",
         "Include findings, changed files, tests, and blockers as relevant.",
       ].join("\n")
     : "When finished or blocked, report concise status in your final response.";
@@ -94,6 +95,7 @@ function roleInstructions(role: Role | undefined, runId: string | undefined): st
         "Role: orchestrator.",
         "Coordinate the declared team at the beginning of the run and treat it as the coordination contract.",
         "After initial team creation, do not launch surprise agents unless the user explicitly asks.",
+        "At the start, launch each planned child with headless run message <run> <node> --prompt \"...\" --async unless the user asks for a sequential workflow.",
         "Use run message to assign work; use --async for parallel child work; ask children to report back explicitly.",
         commandHelp,
         runId

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -92,7 +92,6 @@ async function handleRunMessage(
     throw new Error(`unknown node in run ${runId}: ${nodeId}`);
   }
   const prompt = await handlers.resolvePrompt();
-  recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt.prompt);
 
   if (node.coordination === "tmux") {
     const sessionName = node.tmuxSessionName ?? `headless-${node.agent}-${node.sessionAlias ?? node.nodeId}`;
@@ -103,8 +102,18 @@ async function handleRunMessage(
     return code;
   }
 
+  if (input.printCommand) {
+    const command = input.async
+      ? buildAsyncRunMessageCommand(handlers.env, runId, nodeId, node, prompt.prompt)
+      : buildNodeInvocationCommand(handlers.env, runId, nodeId, node, prompt.prompt);
+    handlers.stdout(`${quoteCommand(command)}\n`);
+    return 0;
+  }
+
+  recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt.prompt);
+
   if (input.async) {
-    return startAsyncRunMessage(input, handlers, runId, nodeId, node, prompt.prompt);
+    return startAsyncRunMessage(handlers, runId, nodeId, node, prompt.prompt);
   }
 
   const releaseLock = acquireNodeLock(handlers.env, runId, nodeId);
@@ -148,7 +157,6 @@ async function waitForRunIdle(env: Env, runId: string): Promise<void> {
 }
 
 function startAsyncRunMessage(
-  input: RunCommandInput,
   handlers: RunCommandHandlers,
   runId: string,
   nodeId: string,
@@ -156,42 +164,11 @@ function startAsyncRunMessage(
   prompt: string,
 ): number {
   const releaseLock = acquireNodeLock(handlers.env, runId, nodeId);
-  const stdoutLog = node.logs?.stdout ?? join(runDirectory(handlers.env, runId), "nodes", nodeId, "latest.stdout.log");
   const stderrLog = node.logs?.stderr ?? join(runDirectory(handlers.env, runId), "nodes", nodeId, "latest.stderr.log");
   updateNodeStatus(handlers.env, runId, nodeId, "busy");
   appendNodeLog(handlers.env, runId, nodeId, "stdout", `\n===== async message ${new Date().toISOString()} =====\n`);
   appendNodeLog(handlers.env, runId, nodeId, "stderr", `\n===== async message ${new Date().toISOString()} =====\n`);
-  const cli = handlers.env.HEADLESS_CLI_BIN ?? "headless";
-  const childArgs = [
-    node.agent,
-    "--role",
-    node.role,
-    "--coordination",
-    node.coordination,
-    "--run",
-    runId,
-    "--node",
-    nodeId,
-    "--prompt",
-    prompt,
-    ...(node.allow ? ["--allow", node.allow] : []),
-    ...(node.model ? ["--model", node.model] : []),
-    ...(node.reasoningEffort ? ["--reasoning-effort", node.reasoningEffort] : []),
-    ...(node.workDir ? ["--work-dir", node.workDir] : []),
-    ...(node.coordination === "session" ? ["--session", node.sessionAlias ?? nodeId] : []),
-  ];
-  const child = quoteCommand({ command: cli, args: childArgs });
-  const success = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "idle"] });
-  const failure = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "failed"] });
-  const unlock = quoteCommand({ command: "rm", args: ["-f", nodeLockPath(handlers.env, runId, nodeId)] });
-  const script = `${child} >/dev/null 2>/dev/null; code=$?; if [ "$code" -eq 0 ]; then ${success} >/dev/null 2>> ${quotePath(stderrLog)}; else printf '%s\\n' "async child exited with code $code" >> ${quotePath(stderrLog)}; ${failure} >/dev/null 2>> ${quotePath(stderrLog)}; fi; ${unlock}; exit "$code"`;
-  const command = { command: "sh", args: ["-c", script] };
-
-  if (input.printCommand) {
-    releaseLock();
-    handlers.stdout(`${quoteCommand(command)}\n`);
-    return 0;
-  }
+  const command = buildAsyncRunMessageCommand(handlers.env, runId, nodeId, node, prompt);
 
   const errFd = openSync(stderrLog, "a");
   try {
@@ -211,6 +188,48 @@ function startAsyncRunMessage(
   }
   handlers.stdout(`started: ${runId}/${nodeId}\n`);
   return 0;
+}
+
+function buildNodeInvocationCommand(env: Env, runId: string, nodeId: string, node: RunNode, prompt: string): {
+  command: string;
+  args: string[];
+} {
+  const cli = env.HEADLESS_CLI_BIN ?? "headless";
+  return {
+    command: cli,
+    args: [
+      node.agent,
+      "--role",
+      node.role,
+      "--coordination",
+      node.coordination,
+      "--run",
+      runId,
+      "--node",
+      nodeId,
+      "--prompt",
+      prompt,
+      ...(node.allow ? ["--allow", node.allow] : []),
+      ...(node.model ? ["--model", node.model] : []),
+      ...(node.reasoningEffort ? ["--reasoning-effort", node.reasoningEffort] : []),
+      ...(node.workDir ? ["--work-dir", node.workDir] : []),
+      ...(node.coordination === "session" ? ["--session", node.sessionAlias ?? nodeId] : []),
+    ],
+  };
+}
+
+function buildAsyncRunMessageCommand(env: Env, runId: string, nodeId: string, node: RunNode, prompt: string): {
+  command: string;
+  args: string[];
+} {
+  const stderrLog = node.logs?.stderr ?? join(runDirectory(env, runId), "nodes", nodeId, "latest.stderr.log");
+  const child = quoteCommand(buildNodeInvocationCommand(env, runId, nodeId, node, prompt));
+  const cli = env.HEADLESS_CLI_BIN ?? "headless";
+  const success = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "idle"] });
+  const failure = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "failed"] });
+  const unlock = quoteCommand({ command: "rm", args: ["-f", nodeLockPath(env, runId, nodeId)] });
+  const script = `${child} >/dev/null 2>/dev/null; code=$?; if [ "$code" -eq 0 ]; then ${success} >/dev/null 2>> ${quotePath(stderrLog)}; else printf '%s\\n' "async child exited with code $code" >> ${quotePath(stderrLog)}; ${failure} >/dev/null 2>> ${quotePath(stderrLog)}; fi; ${unlock}; exit "$code"`;
+  return { command: "sh", args: ["-c", script] };
 }
 
 function parseDelayMs(value: string | undefined, fallback: number): number {

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -229,7 +229,16 @@ function buildAsyncRunMessageCommand(env: Env, runId: string, nodeId: string, no
   const success = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "idle"] });
   const failure = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "failed"] });
   const unlock = quoteCommand({ command: "rm", args: ["-f", nodeLockPath(env, runId, nodeId)] });
-  const script = `${child} >/dev/null 2>/dev/null; code=$?; if [ "$code" -eq 0 ]; then ${success} >/dev/null 2>> ${quotePath(stderrLog)}; else printf '%s\\n' "async child exited with code $code" >> ${quotePath(stderrLog)}; ${failure} >/dev/null 2>> ${quotePath(stderrLog)}; fi; ${unlock}; exit "$code"`;
+  const quotedStderrLog = quotePath(stderrLog);
+  const signalFailure = `${failure} >/dev/null 2>> ${quotedStderrLog}; ${unlock}; exit 143`;
+  const script = [
+    `trap "${signalFailure}" INT TERM HUP`,
+    `trap "${unlock}" EXIT`,
+    `${child} >/dev/null 2>> ${quotedStderrLog}`,
+    "code=$?",
+    `if [ "$code" -eq 0 ]; then ${success} >/dev/null 2>> ${quotedStderrLog}; else printf '%s\\n' "async child exited with code $code" >> ${quotedStderrLog}; ${failure} >/dev/null 2>> ${quotedStderrLog}; fi`,
+    'exit "$code"',
+  ].join("; ");
   return { command: "sh", args: ["-c", script] };
 }
 

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -111,14 +111,13 @@ async function handleRunMessage(
     return 0;
   }
 
-  recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt.prompt);
-
   if (input.async) {
     return startAsyncRunMessage(handlers, runId, nodeId, node, prompt.prompt);
   }
 
   const releaseLock = acquireNodeLock(handlers.env, runId, nodeId);
   try {
+    recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt.prompt);
     updateNodeStatus(handlers.env, runId, nodeId, "busy");
     const result = await handlers.executeNode(node, prompt.prompt);
     const finalMessage = extractFinalMessage(node.agent, result.stdout);
@@ -166,6 +165,7 @@ function startAsyncRunMessage(
 ): number {
   const releaseLock = acquireNodeLock(handlers.env, runId, nodeId);
   const stderrLog = node.logs?.stderr ?? join(runDirectory(handlers.env, runId), "nodes", nodeId, "latest.stderr.log");
+  recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt);
   updateNodeStatus(handlers.env, runId, nodeId, "busy");
   appendNodeLog(handlers.env, runId, nodeId, "stdout", `\n===== async message ${new Date().toISOString()} =====\n`);
   appendNodeLog(handlers.env, runId, nodeId, "stderr", `\n===== async message ${new Date().toISOString()} =====\n`);

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -97,6 +97,7 @@ async function handleRunMessage(
     const sessionName = node.tmuxSessionName ?? `headless-${node.agent}-${node.sessionAlias ?? node.nodeId}`;
     const code = await handlers.sendTmux(sessionName, prompt.prompt, input.printCommand);
     if (code === 0 && !input.printCommand) {
+      recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt.prompt);
       handlers.stdout(`sent: ${runId}/${nodeId}\n`);
     }
     return code;

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { join } from "node:path";
 
 import { extractFinalMessage } from "./output.js";
+import { extractRunNodeMetrics } from "./run-metrics.js";
 import { renderRunList, renderRunView } from "./run-view.js";
 import {
   acquireNodeLock,
@@ -111,7 +112,14 @@ async function handleRunMessage(
     updateNodeStatus(handlers.env, runId, nodeId, "busy");
     const result = await handlers.executeNode(node, prompt.prompt);
     const finalMessage = extractFinalMessage(node.agent, result.stdout);
-    updateNodeStatus(handlers.env, runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined);
+    updateNodeStatus(
+      handlers.env,
+      runId,
+      nodeId,
+      result.code === 0 ? "idle" : "failed",
+      finalMessage || undefined,
+      extractRunNodeMetrics(node.agent, result.stdout, { model: node.model }),
+    );
     if (finalMessage) {
       handlers.stdout(`${finalMessage}\n`);
     }

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -177,7 +177,7 @@ function startAsyncRunMessage(
   const failure = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "failed"] });
   const unlock = quoteCommand({ command: "rm", args: ["-f", nodeLockPath(handlers.env, runId, nodeId)] });
   const script = `${child} >/dev/null 2>/dev/null; code=$?; if [ "$code" -eq 0 ]; then ${success} >/dev/null 2>> ${quotePath(stderrLog)}; else printf '%s\\n' "async child exited with code $code" >> ${quotePath(stderrLog)}; ${failure} >/dev/null 2>> ${quotePath(stderrLog)}; fi; ${unlock}; exit "$code"`;
-  const command = { command: "sh", args: ["-lc", script] };
+  const command = { command: "sh", args: ["-c", script] };
 
   if (input.printCommand) {
     releaseLock();

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -1,0 +1,221 @@
+import { closeSync, openSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+
+import { extractFinalMessage } from "./output.js";
+import { renderRunList, renderRunView } from "./run-view.js";
+import {
+  acquireNodeLock,
+  listRuns,
+  nodeLockPath,
+  readRun,
+  recordMessage,
+  runDirectory,
+  updateNodeStatus,
+  type RunNode,
+} from "./runs.js";
+import { quoteCommand } from "./shell.js";
+import type { AgentName, Env } from "./types.js";
+import type { RunStatus } from "./roles.js";
+
+export interface RunCommandInput {
+  command: "list" | "view" | "mark" | "message" | "wait";
+  runId?: string;
+  nodeId?: string;
+  status?: RunStatus;
+  async: boolean;
+  printCommand: boolean;
+}
+
+export interface ResolvedPrompt {
+  prompt: string;
+  promptFile?: string;
+}
+
+export interface RunCommandHandlers {
+  env: Env;
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+  resolvePrompt: () => Promise<ResolvedPrompt>;
+  executeNode: (node: RunNode, prompt: string) => Promise<{ code: number; stdout: string }>;
+  sendTmux: (sessionName: string, prompt: string, printCommand: boolean) => Promise<number>;
+}
+
+export async function handleRunCommand(input: RunCommandInput, handlers: RunCommandHandlers): Promise<number> {
+  if (input.command === "list") {
+    handlers.stdout(renderRunList(listRuns(handlers.env)));
+    return 0;
+  }
+  const runId = requireValue(input.runId, "run");
+  if (input.command === "view") {
+    const run = readRun(handlers.env, runId);
+    if (!run) {
+      throw new Error(`unknown run: ${runId}`);
+    }
+    handlers.stdout(renderRunView(run));
+    return 0;
+  }
+  if (input.command === "mark") {
+    const nodeId = requireValue(input.nodeId, "node");
+    if (!input.status) {
+      throw new Error("run mark requires --status");
+    }
+    updateNodeStatus(handlers.env, runId, nodeId, input.status);
+    handlers.stdout(`marked: ${runId}/${nodeId} ${input.status}\n`);
+    return 0;
+  }
+  if (input.command === "wait") {
+    await waitForRunIdle(handlers.env, runId);
+    handlers.stdout(`run idle: ${runId}\n`);
+    return 0;
+  }
+  if (input.command === "message") {
+    return await handleRunMessage(input, handlers, runId);
+  }
+  throw new Error("unsupported run command");
+}
+
+async function handleRunMessage(
+  input: RunCommandInput,
+  handlers: RunCommandHandlers,
+  runId: string,
+): Promise<number> {
+  const nodeId = requireValue(input.nodeId, "node");
+  const run = readRun(handlers.env, runId);
+  if (!run) {
+    throw new Error(`unknown run: ${runId}`);
+  }
+  const node = run.nodes[nodeId];
+  if (!node) {
+    throw new Error(`unknown node in run ${runId}: ${nodeId}`);
+  }
+  const prompt = await handlers.resolvePrompt();
+  recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt.prompt);
+
+  if (node.coordination === "tmux") {
+    const sessionName = node.tmuxSessionName ?? `headless-${node.agent}-${node.sessionAlias ?? node.nodeId}`;
+    const code = await handlers.sendTmux(sessionName, prompt.prompt, input.printCommand);
+    if (code === 0 && !input.printCommand) {
+      handlers.stdout(`sent: ${runId}/${nodeId}\n`);
+    }
+    return code;
+  }
+
+  if (input.async) {
+    return startAsyncRunMessage(input, handlers, runId, nodeId, node, prompt.prompt);
+  }
+
+  const releaseLock = acquireNodeLock(handlers.env, runId, nodeId);
+  try {
+    updateNodeStatus(handlers.env, runId, nodeId, "busy");
+    const result = await handlers.executeNode(node, prompt.prompt);
+    const finalMessage = extractFinalMessage(node.agent, result.stdout);
+    updateNodeStatus(handlers.env, runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined);
+    if (finalMessage) {
+      handlers.stdout(`${finalMessage}\n`);
+    }
+    return result.code;
+  } finally {
+    releaseLock();
+  }
+}
+
+async function waitForRunIdle(env: Env, runId: string): Promise<void> {
+  const intervalMs = parseDelayMs(env.HEADLESS_RUN_WAIT_INTERVAL_MS, 1000);
+  while (true) {
+    const run = readRun(env, runId);
+    if (!run) {
+      throw new Error(`unknown run: ${runId}`);
+    }
+    const busy = Object.values(run.nodes).some((node) => node.status === "busy" || node.status === "starting");
+    if (!busy) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+function startAsyncRunMessage(
+  input: RunCommandInput,
+  handlers: RunCommandHandlers,
+  runId: string,
+  nodeId: string,
+  node: RunNode,
+  prompt: string,
+): number {
+  const releaseLock = acquireNodeLock(handlers.env, runId, nodeId);
+  const stdoutLog = node.logs?.stdout ?? join(runDirectory(handlers.env, runId), "nodes", nodeId, "latest.stdout.log");
+  const stderrLog = node.logs?.stderr ?? join(runDirectory(handlers.env, runId), "nodes", nodeId, "latest.stderr.log");
+  updateNodeStatus(handlers.env, runId, nodeId, "busy");
+  const cli = handlers.env.HEADLESS_CLI_BIN ?? "headless";
+  const childArgs = [
+    node.agent,
+    "--role",
+    node.role,
+    "--coordination",
+    node.coordination,
+    "--run",
+    runId,
+    "--node",
+    nodeId,
+    "--prompt",
+    prompt,
+    ...(node.allow ? ["--allow", node.allow] : []),
+    ...(node.model ? ["--model", node.model] : []),
+    ...(node.reasoningEffort ? ["--reasoning-effort", node.reasoningEffort] : []),
+    ...(node.workDir ? ["--work-dir", node.workDir] : []),
+    ...(node.coordination === "session" ? ["--session", node.sessionAlias ?? nodeId] : []),
+  ];
+  const child = quoteCommand({ command: cli, args: childArgs });
+  const success = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "idle"] });
+  const failure = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "failed"] });
+  const unlock = quoteCommand({ command: "rm", args: ["-f", nodeLockPath(handlers.env, runId, nodeId)] });
+  const script = `${child} > ${quotePath(stdoutLog)} 2> ${quotePath(stderrLog)}; code=$?; if [ "$code" -eq 0 ]; then ${success}; else ${failure}; fi; ${unlock}; exit "$code"`;
+  const command = { command: "sh", args: ["-lc", script] };
+
+  if (input.printCommand) {
+    releaseLock();
+    handlers.stdout(`${quoteCommand(command)}\n`);
+    return 0;
+  }
+
+  const outFd = openSync(stdoutLog, "w");
+  const errFd = openSync(stderrLog, "w");
+  try {
+    const childProcess = spawn(command.command, command.args, {
+      cwd: node.workDir,
+      env: handlers.env as NodeJS.ProcessEnv,
+      detached: true,
+      stdio: ["ignore", outFd, errFd],
+    });
+    childProcess.unref();
+  } catch (error) {
+    releaseLock();
+    updateNodeStatus(handlers.env, runId, nodeId, "failed", error instanceof Error ? error.message : String(error));
+    throw error;
+  } finally {
+    closeSync(outFd);
+    closeSync(errFd);
+  }
+  handlers.stdout(`started: ${runId}/${nodeId}\n`);
+  return 0;
+}
+
+function parseDelayMs(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function quotePath(path: string): string {
+  return quoteCommand({ command: path, args: [] });
+}
+
+function requireValue(value: string | undefined, label: string): string {
+  if (!value) {
+    throw new Error(`invalid ${label}; use letters, numbers, dots, dashes, or underscores`);
+  }
+  return value;
+}

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -194,7 +194,7 @@ function buildNodeInvocationCommand(env: Env, runId: string, nodeId: string, nod
   command: string;
   args: string[];
 } {
-  const cli = env.HEADLESS_CLI_BIN ?? "headless";
+  const cli = headlessCli(env);
   return {
     command: cli,
     args: [
@@ -224,12 +224,16 @@ function buildAsyncRunMessageCommand(env: Env, runId: string, nodeId: string, no
 } {
   const stderrLog = node.logs?.stderr ?? join(runDirectory(env, runId), "nodes", nodeId, "latest.stderr.log");
   const child = quoteCommand(buildNodeInvocationCommand(env, runId, nodeId, node, prompt));
-  const cli = env.HEADLESS_CLI_BIN ?? "headless";
+  const cli = headlessCli(env);
   const success = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "idle"] });
   const failure = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "failed"] });
   const unlock = quoteCommand({ command: "rm", args: ["-f", nodeLockPath(env, runId, nodeId)] });
   const script = `${child} >/dev/null 2>/dev/null; code=$?; if [ "$code" -eq 0 ]; then ${success} >/dev/null 2>> ${quotePath(stderrLog)}; else printf '%s\\n' "async child exited with code $code" >> ${quotePath(stderrLog)}; ${failure} >/dev/null 2>> ${quotePath(stderrLog)}; fi; ${unlock}; exit "$code"`;
   return { command: "sh", args: ["-c", script] };
+}
+
+function headlessCli(env: Env): string {
+  return env.HEADLESS_CLI_BIN ?? env.HEADLESS_BIN ?? "headless";
 }
 
 function parseDelayMs(value: string | undefined, fallback: number): number {

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -122,12 +122,15 @@ async function handleRunMessage(
 
 async function waitForRunIdle(env: Env, runId: string): Promise<void> {
   const intervalMs = parseDelayMs(env.HEADLESS_RUN_WAIT_INTERVAL_MS, 1000);
+  const currentNode = env.HEADLESS_RUN_NODE;
   while (true) {
     const run = readRun(env, runId);
     if (!run) {
       throw new Error(`unknown run: ${runId}`);
     }
-    const busy = Object.values(run.nodes).some((node) => node.status === "busy" || node.status === "starting");
+    const busy = Object.values(run.nodes).some(
+      (node) => node.nodeId !== currentNode && (node.status === "busy" || node.status === "starting"),
+    );
     if (!busy) {
       return;
     }

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -6,6 +6,7 @@ import { extractFinalMessage } from "./output.js";
 import { renderRunList, renderRunView } from "./run-view.js";
 import {
   acquireNodeLock,
+  appendNodeLog,
   listRuns,
   nodeLockPath,
   readRun,
@@ -150,6 +151,8 @@ function startAsyncRunMessage(
   const stdoutLog = node.logs?.stdout ?? join(runDirectory(handlers.env, runId), "nodes", nodeId, "latest.stdout.log");
   const stderrLog = node.logs?.stderr ?? join(runDirectory(handlers.env, runId), "nodes", nodeId, "latest.stderr.log");
   updateNodeStatus(handlers.env, runId, nodeId, "busy");
+  appendNodeLog(handlers.env, runId, nodeId, "stdout", `\n===== async message ${new Date().toISOString()} =====\n`);
+  appendNodeLog(handlers.env, runId, nodeId, "stderr", `\n===== async message ${new Date().toISOString()} =====\n`);
   const cli = handlers.env.HEADLESS_CLI_BIN ?? "headless";
   const childArgs = [
     node.agent,
@@ -173,7 +176,7 @@ function startAsyncRunMessage(
   const success = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "idle"] });
   const failure = quoteCommand({ command: cli, args: ["run", "mark", runId, nodeId, "--status", "failed"] });
   const unlock = quoteCommand({ command: "rm", args: ["-f", nodeLockPath(handlers.env, runId, nodeId)] });
-  const script = `${child} > ${quotePath(stdoutLog)} 2> ${quotePath(stderrLog)}; code=$?; if [ "$code" -eq 0 ]; then ${success}; else ${failure}; fi; ${unlock}; exit "$code"`;
+  const script = `${child} >/dev/null 2>/dev/null; code=$?; if [ "$code" -eq 0 ]; then ${success} >/dev/null 2>> ${quotePath(stderrLog)}; else printf '%s\\n' "async child exited with code $code" >> ${quotePath(stderrLog)}; ${failure} >/dev/null 2>> ${quotePath(stderrLog)}; fi; ${unlock}; exit "$code"`;
   const command = { command: "sh", args: ["-lc", script] };
 
   if (input.printCommand) {
@@ -182,14 +185,13 @@ function startAsyncRunMessage(
     return 0;
   }
 
-  const outFd = openSync(stdoutLog, "w");
-  const errFd = openSync(stderrLog, "w");
+  const errFd = openSync(stderrLog, "a");
   try {
     const childProcess = spawn(command.command, command.args, {
       cwd: node.workDir,
       env: handlers.env as NodeJS.ProcessEnv,
       detached: true,
-      stdio: ["ignore", outFd, errFd],
+      stdio: ["ignore", "ignore", errFd],
     });
     childProcess.unref();
   } catch (error) {
@@ -197,7 +199,6 @@ function startAsyncRunMessage(
     updateNodeStatus(handlers.env, runId, nodeId, "failed", error instanceof Error ? error.message : String(error));
     throw error;
   } finally {
-    closeSync(outFd);
     closeSync(errFd);
   }
   handlers.stdout(`started: ${runId}/${nodeId}\n`);

--- a/src/run-metrics.ts
+++ b/src/run-metrics.ts
@@ -1,0 +1,69 @@
+import { extractUsageSummary } from "./output.js";
+import type { RunNodeMetrics } from "./runs.js";
+import type { AgentName } from "./types.js";
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseJsonValues(stdout: string): unknown[] {
+  const values: unknown[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      values.push(JSON.parse(trimmed) as unknown);
+    } catch {
+      // Agent CLIs may emit non-JSON warnings before or between trace rows.
+    }
+  }
+  if (values.length > 0) return values;
+
+  try {
+    const parsed = JSON.parse(stdout) as unknown;
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return [];
+  }
+}
+
+function flattenRecords(value: unknown): JsonRecord[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => flattenRecords(item));
+  }
+  const record = asRecord(value);
+  return Object.keys(record).length > 0 ? [record] : [];
+}
+
+function latestNumber(records: JsonRecord[], field: string): number | undefined {
+  return records.map((record) => asNumber(record[field])).filter((value): value is number => value !== undefined).at(-1);
+}
+
+export function extractRunNodeMetrics(
+  agent: AgentName,
+  stdout: string,
+  context: { provider?: string; model?: string } = {},
+): RunNodeMetrics | undefined {
+  const records = parseJsonValues(stdout).flatMap(flattenRecords);
+  const usage = extractUsageSummary(agent, stdout, context);
+  const metrics: RunNodeMetrics = {
+    turns: latestNumber(records, "num_turns"),
+    durationMs: latestNumber(records, "duration_ms"),
+    apiDurationMs: latestNumber(records, "duration_api_ms"),
+    totalCostUsd: usage.cost?.total ?? latestNumber(records, "total_cost_usd"),
+    inputTokens: usage.inputTokens || undefined,
+    cacheReadTokens: usage.cacheReadTokens || undefined,
+    cacheWriteTokens: usage.cacheWriteTokens || undefined,
+    outputTokens: usage.outputTokens || undefined,
+    reasoningOutputTokens: usage.reasoningOutputTokens || undefined,
+    totalTokens: usage.totalTokens || undefined,
+  };
+  const present = Object.fromEntries(Object.entries(metrics).filter(([, value]) => value !== undefined)) as RunNodeMetrics;
+  return Object.keys(present).length > 0 ? present : undefined;
+}

--- a/src/run-status.ts
+++ b/src/run-status.ts
@@ -1,0 +1,247 @@
+import { readRun, type RunNode, type RunRecord } from "./runs.js";
+import type { RunStatus } from "./roles.js";
+import type { Env } from "./types.js";
+
+export interface RunStatusReporter {
+  poll: () => void;
+  start: () => void;
+  stop: () => void;
+}
+
+export interface RunStatusReporterOptions {
+  color?: boolean;
+  env: Env;
+  intervalMs?: number;
+  now?: () => Date;
+  runId: string;
+  write: (text: string) => void;
+}
+
+interface RunSnapshot {
+  eventCount: number;
+  statuses: Map<string, string>;
+}
+
+const defaultIntervalMs = 1000;
+const colorCodes = {
+  cyan: "36",
+  dim: "2",
+  green: "32",
+  red: "31",
+  yellow: "33",
+} as const;
+
+type AnsiColor = keyof typeof colorCodes;
+type LogLevel = "info" | "ok" | "warn" | "error";
+
+export function createRunStatusReporter(options: RunStatusReporterOptions): RunStatusReporter {
+  const intervalMs = options.intervalMs ?? parseRunStatusIntervalMs(options.env.HEADLESS_RUN_STATUS_INTERVAL_MS);
+  const color = shouldUseColor(options);
+  const now = options.now ?? (() => new Date());
+  let previous: RunSnapshot | undefined;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
+  let finalEmitted = false;
+
+  const poll = (): void => {
+    const run = readRun(options.env, options.runId);
+    if (!run) {
+      return;
+    }
+
+    if (!previous) {
+      writeLog(options.write, now, color, "info", run.runId, `started ${rootNodeName(run)} (${initialRunSummary(run, color)})`);
+      previous = snapshot(run);
+      return;
+    }
+
+    emitStatusTransitions(options.write, now, color, previous, run);
+    emitMessageEvents(options.write, now, color, previous.eventCount, run);
+    previous = snapshot(run);
+  };
+
+  const start = (): void => {
+    if (timer || stopped) {
+      return;
+    }
+    poll();
+    timer = setInterval(poll, intervalMs);
+    timer.unref?.();
+  };
+
+  const stop = (): void => {
+    if (timer) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+    stopped = true;
+    poll();
+    const run = readRun(options.env, options.runId);
+    if (run && !finalEmitted) {
+      finalEmitted = true;
+      const label = activeCount(run) === 0 ? "idle" : "stopped";
+      writeLog(options.write, now, color, activeCount(run) === 0 ? "ok" : "warn", run.runId, `${label} (${runSummary(run, color)})`);
+    }
+  };
+
+  return { poll, start, stop };
+}
+
+export function parseRunStatusIntervalMs(value: string | undefined): number {
+  if (value === undefined) {
+    return defaultIntervalMs;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : defaultIntervalMs;
+}
+
+function emitStatusTransitions(
+  write: (text: string) => void,
+  now: () => Date,
+  color: boolean,
+  previous: RunSnapshot,
+  run: RunRecord,
+): void {
+  for (const node of sortedNodes(run)) {
+    const oldStatus = previous.statuses.get(node.nodeId);
+    if (oldStatus === undefined) {
+      writeLog(write, now, color, "info", run.runId, `${node.nodeId} registered ${paintStatus(node.status, color)}`);
+      continue;
+    }
+    if (oldStatus !== node.status) {
+      writeLog(
+        write,
+        now,
+        color,
+        transitionLevel(node.status),
+        run.runId,
+        `${node.nodeId} ${paintStatus(oldStatus, color)} -> ${paintStatus(node.status, color)}`,
+      );
+    }
+  }
+}
+
+function emitMessageEvents(
+  write: (text: string) => void,
+  now: () => Date,
+  color: boolean,
+  previousEventCount: number,
+  run: RunRecord,
+): void {
+  const start = previousEventCount <= run.events.length ? previousEventCount : run.events.length;
+  for (const event of run.events.slice(start)) {
+    if (event.type !== "message_sent") {
+      continue;
+    }
+    writeLog(write, now, color, "info", run.runId, `message ${event.nodeId ?? "cli"} -> ${event.targetNodeId ?? "unknown"}`);
+  }
+}
+
+function snapshot(run: RunRecord): RunSnapshot {
+  return {
+    eventCount: run.events.length,
+    statuses: new Map(sortedNodes(run).map((node) => [node.nodeId, node.status])),
+  };
+}
+
+function rootNodeName(run: RunRecord): string {
+  return run.nodes.orchestrator ? "orchestrator" : (sortedNodes(run)[0]?.nodeId ?? "run");
+}
+
+function runSummary(run: RunRecord, color: boolean): string {
+  return `${activeCount(run)} active; ${statusSummary(run, color)}`;
+}
+
+function initialRunSummary(run: RunRecord, color: boolean): string {
+  return `${sortedNodes(run).length} nodes, ${runSummary(run, color)}`;
+}
+
+function activeCount(run: RunRecord): number {
+  return sortedNodes(run).filter((node) => node.status === "busy" || node.status === "starting").length;
+}
+
+function statusSummary(run: RunRecord, color: boolean): string {
+  const counts = new Map<string, number>();
+  for (const node of sortedNodes(run)) {
+    counts.set(node.status, (counts.get(node.status) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([status, count]) => `${count} ${paintStatus(status, color)}`)
+    .join(", ");
+}
+
+function sortedNodes(run: RunRecord): RunNode[] {
+  return Object.values(run.nodes).sort((left, right) => left.nodeId.localeCompare(right.nodeId));
+}
+
+function writeLog(
+  write: (text: string) => void,
+  now: () => Date,
+  color: boolean,
+  level: LogLevel,
+  runId: string,
+  message: string,
+): void {
+  const timestamp = paint(now().toISOString(), "dim", color);
+  const label = level.toUpperCase();
+  write(`${timestamp} ${paint(label, levelColor(level), color)}${" ".repeat(5 - label.length)} headless run ${runId} ${message}\n`);
+}
+
+function transitionLevel(status: string): LogLevel {
+  if (status === "failed" || status === "unknown") return "error";
+  if (status === "done" || status === "idle") return "ok";
+  if (status === "busy" || status === "starting") return "info";
+  return "info";
+}
+
+function paintStatus(status: string, color: boolean): string {
+  return paint(status, statusColor(status), color);
+}
+
+function statusColor(status: string): AnsiColor | undefined {
+  switch (status as RunStatus) {
+    case "done":
+      return "green";
+    case "busy":
+    case "starting":
+      return "yellow";
+    case "failed":
+    case "unknown":
+      return "red";
+    case "idle":
+      return "cyan";
+    case "planned":
+      return "dim";
+  }
+}
+
+function levelColor(level: LogLevel): AnsiColor {
+  switch (level) {
+    case "ok":
+      return "green";
+    case "warn":
+      return "yellow";
+    case "error":
+      return "red";
+    case "info":
+      return "cyan";
+  }
+}
+
+function paint(text: string, color: AnsiColor | undefined, enabled: boolean): string {
+  if (!enabled || !color) {
+    return text;
+  }
+  return `\x1b[${colorCodes[color]}m${text}\x1b[0m`;
+}
+
+function shouldUseColor(options: RunStatusReporterOptions): boolean {
+  if (options.env.NO_COLOR !== undefined) {
+    return false;
+  }
+  if (options.color !== undefined) {
+    return options.color;
+  }
+  return process.stderr.isTTY === true;
+}

--- a/src/run-status.ts
+++ b/src/run-status.ts
@@ -10,6 +10,7 @@ export interface RunStatusReporter {
 
 export interface RunStatusReporterOptions {
   color?: boolean;
+  columns?: number;
   env: Env;
   intervalMs?: number;
   now?: () => Date;
@@ -37,6 +38,7 @@ type LogLevel = "info" | "ok" | "warn" | "error";
 export function createRunStatusReporter(options: RunStatusReporterOptions): RunStatusReporter {
   const intervalMs = options.intervalMs ?? parseRunStatusIntervalMs(options.env.HEADLESS_RUN_STATUS_INTERVAL_MS);
   const color = shouldUseColor(options);
+  const columns = Math.max(40, options.columns ?? process.stderr.columns ?? 100);
   const now = options.now ?? (() => new Date());
   let previous: RunSnapshot | undefined;
   let timer: ReturnType<typeof setInterval> | undefined;
@@ -50,13 +52,13 @@ export function createRunStatusReporter(options: RunStatusReporterOptions): RunS
     }
 
     if (!previous) {
-      writeLog(options.write, now, color, "info", run.runId, `started ${rootNodeName(run)} (${initialRunSummary(run, color)})`);
+      writeLog(options.write, now, color, columns, "info", run.runId, `started ${rootNodeName(run)} (${initialRunSummary(run, color)})`);
       previous = snapshot(run);
       return;
     }
 
-    emitStatusTransitions(options.write, now, color, previous, run);
-    emitMessageEvents(options.write, now, color, previous.eventCount, run);
+    emitStatusTransitions(options.write, now, color, columns, previous, run);
+    emitMessageEvents(options.write, now, color, columns, previous.eventCount, run);
     previous = snapshot(run);
   };
 
@@ -80,7 +82,7 @@ export function createRunStatusReporter(options: RunStatusReporterOptions): RunS
     if (run && !finalEmitted) {
       finalEmitted = true;
       const label = activeCount(run) === 0 ? "idle" : "stopped";
-      writeLog(options.write, now, color, activeCount(run) === 0 ? "ok" : "warn", run.runId, `${label} (${runSummary(run, color)})`);
+      writeLog(options.write, now, color, columns, activeCount(run) === 0 ? "ok" : "warn", run.runId, `${label} (${runSummary(run, color)})`);
     }
   };
 
@@ -99,13 +101,14 @@ function emitStatusTransitions(
   write: (text: string) => void,
   now: () => Date,
   color: boolean,
+  columns: number,
   previous: RunSnapshot,
   run: RunRecord,
 ): void {
   for (const node of sortedNodes(run)) {
     const oldStatus = previous.statuses.get(node.nodeId);
     if (oldStatus === undefined) {
-      writeLog(write, now, color, "info", run.runId, `${node.nodeId} registered ${paintStatus(node.status, color)}`);
+      writeLog(write, now, color, columns, "info", run.runId, `${node.nodeId} registered ${paintStatus(node.status, color)}`);
       continue;
     }
     if (oldStatus !== node.status) {
@@ -113,6 +116,7 @@ function emitStatusTransitions(
         write,
         now,
         color,
+        columns,
         transitionLevel(node.status),
         run.runId,
         `${node.nodeId} ${paintStatus(oldStatus, color)} -> ${paintStatus(node.status, color)}`,
@@ -125,6 +129,7 @@ function emitMessageEvents(
   write: (text: string) => void,
   now: () => Date,
   color: boolean,
+  columns: number,
   previousEventCount: number,
   run: RunRecord,
 ): void {
@@ -133,7 +138,7 @@ function emitMessageEvents(
     if (event.type !== "message_sent") {
       continue;
     }
-    writeLog(write, now, color, "info", run.runId, `message ${event.nodeId ?? "cli"} -> ${event.targetNodeId ?? "unknown"}`);
+    writeLog(write, now, color, columns, "info", run.runId, `message ${event.nodeId ?? "cli"} -> ${event.targetNodeId ?? "unknown"}`);
   }
 }
 
@@ -179,13 +184,55 @@ function writeLog(
   write: (text: string) => void,
   now: () => Date,
   color: boolean,
+  columns: number,
   level: LogLevel,
   runId: string,
   message: string,
 ): void {
-  const timestamp = paint(now().toISOString(), "dim", color);
+  const timestamp = paint(formatTimestamp(now()), "dim", color);
   const label = level.toUpperCase();
-  write(`${timestamp} ${paint(label, levelColor(level), color)}${" ".repeat(5 - label.length)} headless run ${runId} ${message}\n`);
+  const line = `${timestamp} ${paint(label, levelColor(level), color)}${" ".repeat(5 - label.length)} ${runId} ${message}`;
+  write(`${truncateAnsi(line, columns)}\n`);
+}
+
+function formatTimestamp(date: Date): string {
+  const hours = pad2(date.getHours());
+  const minutes = pad2(date.getMinutes());
+  const seconds = pad2(date.getSeconds());
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function truncateAnsi(text: string, maxWidth: number): string {
+  if (visibleLength(text) <= maxWidth) {
+    return text;
+  }
+  const limit = Math.max(0, maxWidth - 3);
+  const ansiPattern = /\x1b\[[0-9;]*m/y;
+  let output = "";
+  let visible = 0;
+  let sawAnsi = false;
+  for (let index = 0; index < text.length && visible < limit;) {
+    ansiPattern.lastIndex = index;
+    const match = ansiPattern.exec(text);
+    if (match) {
+      sawAnsi = true;
+      output += match[0];
+      index += match[0].length;
+      continue;
+    }
+    output += text[index];
+    visible += 1;
+    index += 1;
+  }
+  return `${output}...${sawAnsi ? "\x1b[0m" : ""}`;
+}
+
+function visibleLength(text: string): number {
+  return text.replace(/\x1b\[[0-9;]*m/g, "").length;
 }
 
 function transitionLevel(status: string): LogLevel {

--- a/src/run-view.ts
+++ b/src/run-view.ts
@@ -73,7 +73,7 @@ function renderNode(node: RunNode, now: number): string {
 
 function renderNodeTable(nodes: RunNode[], now: number): string[] {
   const rows = [
-    ["NODE", "ROLE", "AGENT", "STATUS", "UPDATED", "AGE", "TURNS", "DURATION", "COST", "TOKENS", "LAST"],
+    ["NODE", "ROLE", "AGENT", "STATUS", "UPDATED", "AGE", "LAST"],
     ...nodes.map((node) => [
       node.nodeId,
       node.role,
@@ -81,10 +81,6 @@ function renderNodeTable(nodes: RunNode[], now: number): string[] {
       node.status,
       node.updatedAt,
       formatAge(node.updatedAt, now),
-      formatNumber(node.metrics?.turns),
-      formatDuration(node.metrics?.durationMs),
-      formatCost(node.metrics?.totalCostUsd),
-      formatCompactNumber(node.metrics?.totalTokens),
       truncate(oneLine(node.lastMessage ?? ""), 60) || "-",
     ]),
   ];
@@ -142,25 +138,4 @@ function formatDuration(value: number | undefined): string {
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
   return `${hours}h${String(remainingMinutes).padStart(2, "0")}m`;
-}
-
-function formatNumber(value: number | undefined): string {
-  return value === undefined ? "-" : String(value);
-}
-
-function formatCompactNumber(value: number | undefined): string {
-  if (value === undefined) return "-";
-  if (value >= 1_000_000) return `${trimTrailingZero(value / 1_000_000)}m`;
-  if (value >= 1_000) return `${trimTrailingZero(value / 1_000)}k`;
-  return String(value);
-}
-
-function formatCost(value: number | undefined): string {
-  if (value === undefined) return "-";
-  if (value === 0) return "$0";
-  return `$${value < 0.01 ? value.toFixed(4) : value.toFixed(2)}`;
-}
-
-function trimTrailingZero(value: number): string {
-  return value.toFixed(1).replace(/\.0$/, "");
 }

--- a/src/run-view.ts
+++ b/src/run-view.ts
@@ -4,24 +4,35 @@ export function renderRunList(runs: RunRecord[]): string {
   if (runs.length === 0) {
     return "No headless runs\n";
   }
+  const now = Date.now();
   const rows = runs.map((run) => {
     const nodes = Object.values(run.nodes);
-    const busy = nodes.filter((node) => node.status === "busy").length;
+    const active = nodes.filter((node) => node.status === "busy" || node.status === "starting").length;
     const mode = nodes[0]?.coordination ?? "unknown";
-    return `${run.runId}\t${mode}\t${nodes.length} nodes\t${busy} busy\t${run.updatedAt}`;
+    return `${run.runId}\t${mode}\t${nodes.length} nodes\t${active} active\t${run.updatedAt}\t${formatAge(run.updatedAt, now)}`;
   });
-  return `${["RUN\tMODE\tNODES\tBUSY\tUPDATED", ...rows].join("\n")}\n`;
+  return `${["RUN\tMODE\tNODES\tACTIVE\tUPDATED\tAGE", ...rows].join("\n")}\n`;
 }
 
 export function renderRunView(run: RunRecord): string {
   const nodes = Object.values(run.nodes).sort((left, right) => left.nodeId.localeCompare(right.nodeId));
   const mode = nodes.find((node) => node.nodeId === "orchestrator")?.coordination ?? nodes[0]?.coordination ?? "unknown";
-  const lines = [`${run.runId}  ${mode}  ${nodes.length} nodes`, "", "Graph"];
-  lines.push(...renderGraph(nodes));
+  const now = Date.now();
+  const lines = [
+    `${run.runId}  ${mode}  ${nodes.length} nodes  status: ${statusSummary(nodes)}`,
+    `created: ${run.createdAt}  updated: ${run.updatedAt}  age: ${formatAge(run.createdAt, now)}  updated: ${formatAge(run.updatedAt, now)} ago`,
+    "",
+    "Graph",
+  ];
+  lines.push(...renderGraph(nodes, now));
   const extraEdges = dependencyEdges(nodes).filter(([from, to]) => from !== "orchestrator" && to !== "orchestrator");
   if (extraEdges.length > 0) {
     lines.push("", "Extra edges");
     lines.push(...extraEdges.map(([from, to]) => `${from} -> ${to}`));
+  }
+  if (nodes.length > 0) {
+    lines.push("", "Node details");
+    lines.push(...renderNodeTable(nodes, now));
   }
   const messages = run.events.filter((event) => event.type === "message_sent").slice(-8);
   if (messages.length > 0) {
@@ -41,24 +52,48 @@ export function renderRunView(run: RunRecord): string {
   return `${lines.join("\n")}\n`;
 }
 
-function renderGraph(nodes: RunNode[]): string[] {
+function renderGraph(nodes: RunNode[], now: number): string[] {
   if (nodes.length === 0) {
     return ["(empty)"];
   }
   const root = nodes.find((node) => node.nodeId === "orchestrator") ?? nodes[0];
   const children = nodes.filter((node) => node.nodeId !== root.nodeId);
-  return [renderNode(root), ...children.map((node, index) => `${index === children.length - 1 ? "`-" : "|-"} ${renderNode(node)}`)];
+  return [
+    renderNode(root, now),
+    ...children.map((node, index) => `${index === children.length - 1 ? "`-" : "|-"} ${renderNode(node, now)}`),
+  ];
 }
 
-function renderNode(node: RunNode): string {
+function renderNode(node: RunNode, now: number): string {
   const depends = node.dependsOn.length > 0 ? ` depends: ${node.dependsOn.join(",")}` : "";
   const last = node.lastMessage ? ` last: ${truncate(node.lastMessage, 80)}` : "";
   const planned = node.unplanned ? " unplanned" : "";
-  return `${node.nodeId} [${node.status}]${depends}${planned}${last}`;
+  return `${node.nodeId} [${node.status} ${formatAge(node.updatedAt, now)} ago]${depends}${planned}${last}`;
+}
+
+function renderNodeTable(nodes: RunNode[], now: number): string[] {
+  const rows = [
+    ["NODE", "ROLE", "AGENT", "STATUS", "UPDATED", "AGE", "TURNS", "DURATION", "COST", "TOKENS", "LAST"],
+    ...nodes.map((node) => [
+      node.nodeId,
+      node.role,
+      node.agent,
+      node.status,
+      node.updatedAt,
+      formatAge(node.updatedAt, now),
+      formatNumber(node.metrics?.turns),
+      formatDuration(node.metrics?.durationMs),
+      formatCost(node.metrics?.totalCostUsd),
+      formatCompactNumber(node.metrics?.totalTokens),
+      truncate(oneLine(node.lastMessage ?? ""), 60) || "-",
+    ]),
+  ];
+  const widths = rows[0].map((_, index) => Math.max(...rows.map((row) => row[index]?.length ?? 0)));
+  return rows.map((row) => row.map((value, index) => value.padEnd(widths[index] ?? 0)).join("  ").trimEnd());
 }
 
 function renderMessage(event: RunEvent): string {
-  return `${event.nodeId ?? "cli"} -> ${event.targetNodeId ?? "unknown"}  ${truncate(event.message ?? "", 100)}`;
+  return `${event.createdAt}  ${event.nodeId ?? "cli"} -> ${event.targetNodeId ?? "unknown"}  ${truncate(event.message ?? "", 100)}`;
 }
 
 function dependencyEdges(nodes: RunNode[]): Array<[string, string]> {
@@ -72,5 +107,60 @@ function dependencyEdges(nodes: RunNode[]): Array<[string, string]> {
 }
 
 function truncate(value: string, maxLength: number): string {
-  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
+  const normalized = oneLine(value);
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function statusSummary(nodes: RunNode[]): string {
+  const counts = new Map<string, number>();
+  for (const node of nodes) {
+    counts.set(node.status, (counts.get(node.status) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([status, count]) => `${count} ${status}`)
+    .join(", ");
+}
+
+function formatAge(value: string, now: number): string {
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return "-";
+  return formatDuration(Math.max(0, now - time));
+}
+
+function formatDuration(value: number | undefined): string {
+  if (value === undefined) return "-";
+  const seconds = Math.round(value / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m${String(remainingSeconds).padStart(2, "0")}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h${String(remainingMinutes).padStart(2, "0")}m`;
+}
+
+function formatNumber(value: number | undefined): string {
+  return value === undefined ? "-" : String(value);
+}
+
+function formatCompactNumber(value: number | undefined): string {
+  if (value === undefined) return "-";
+  if (value >= 1_000_000) return `${trimTrailingZero(value / 1_000_000)}m`;
+  if (value >= 1_000) return `${trimTrailingZero(value / 1_000)}k`;
+  return String(value);
+}
+
+function formatCost(value: number | undefined): string {
+  if (value === undefined) return "-";
+  if (value === 0) return "$0";
+  return `$${value < 0.01 ? value.toFixed(4) : value.toFixed(2)}`;
+}
+
+function trimTrailingZero(value: number): string {
+  return value.toFixed(1).replace(/\.0$/, "");
 }

--- a/src/run-view.ts
+++ b/src/run-view.ts
@@ -1,0 +1,76 @@
+import type { RunEvent, RunNode, RunRecord } from "./runs.js";
+
+export function renderRunList(runs: RunRecord[]): string {
+  if (runs.length === 0) {
+    return "No headless runs\n";
+  }
+  const rows = runs.map((run) => {
+    const nodes = Object.values(run.nodes);
+    const busy = nodes.filter((node) => node.status === "busy").length;
+    const mode = nodes[0]?.coordination ?? "unknown";
+    return `${run.runId}\t${mode}\t${nodes.length} nodes\t${busy} busy\t${run.updatedAt}`;
+  });
+  return `${["RUN\tMODE\tNODES\tBUSY\tUPDATED", ...rows].join("\n")}\n`;
+}
+
+export function renderRunView(run: RunRecord): string {
+  const nodes = Object.values(run.nodes).sort((left, right) => left.nodeId.localeCompare(right.nodeId));
+  const mode = nodes.find((node) => node.nodeId === "orchestrator")?.coordination ?? nodes[0]?.coordination ?? "unknown";
+  const lines = [`${run.runId}  ${mode}  ${nodes.length} nodes`, "", "Graph"];
+  lines.push(...renderGraph(nodes));
+  const extraEdges = dependencyEdges(nodes).filter(([from, to]) => from !== "orchestrator" && to !== "orchestrator");
+  if (extraEdges.length > 0) {
+    lines.push("", "Extra edges");
+    lines.push(...extraEdges.map(([from, to]) => `${from} -> ${to}`));
+  }
+  const messages = run.events.filter((event) => event.type === "message_sent").slice(-8);
+  if (messages.length > 0) {
+    lines.push("", "Recent messages");
+    lines.push(...messages.map(renderMessage));
+  }
+  lines.push("", "Commands");
+  for (const node of nodes) {
+    lines.push(`message ${node.nodeId}: headless run message ${run.runId} ${node.nodeId} --prompt "..."`);
+    if (node.tmuxSessionName) {
+      lines.push(`attach ${node.nodeId}:  tmux attach-session -t ${node.tmuxSessionName}`);
+    }
+    if (node.logs) {
+      lines.push(`logs ${node.nodeId}:    tail -f ${node.logs.stdout}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function renderGraph(nodes: RunNode[]): string[] {
+  if (nodes.length === 0) {
+    return ["(empty)"];
+  }
+  const root = nodes.find((node) => node.nodeId === "orchestrator") ?? nodes[0];
+  const children = nodes.filter((node) => node.nodeId !== root.nodeId);
+  return [renderNode(root), ...children.map((node, index) => `${index === children.length - 1 ? "`-" : "|-"} ${renderNode(node)}`)];
+}
+
+function renderNode(node: RunNode): string {
+  const depends = node.dependsOn.length > 0 ? ` depends: ${node.dependsOn.join(",")}` : "";
+  const last = node.lastMessage ? ` last: ${truncate(node.lastMessage, 80)}` : "";
+  const planned = node.unplanned ? " unplanned" : "";
+  return `${node.nodeId} [${node.status}]${depends}${planned}${last}`;
+}
+
+function renderMessage(event: RunEvent): string {
+  return `${event.nodeId ?? "cli"} -> ${event.targetNodeId ?? "unknown"}  ${truncate(event.message ?? "", 100)}`;
+}
+
+function dependencyEdges(nodes: RunNode[]): Array<[string, string]> {
+  const edges: Array<[string, string]> = [];
+  for (const node of nodes) {
+    for (const dependency of node.dependsOn) {
+      edges.push([dependency, node.nodeId]);
+    }
+  }
+  return edges;
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
+}

--- a/src/run-view.ts
+++ b/src/run-view.ts
@@ -1,54 +1,95 @@
 import type { RunEvent, RunNode, RunRecord } from "./runs.js";
+import type { RunStatus } from "./roles.js";
+import { cell, renderTable, type TableCell, type TableColor } from "./table.js";
 
 export function renderRunList(runs: RunRecord[]): string {
   if (runs.length === 0) {
     return "No headless runs\n";
   }
   const now = Date.now();
-  const rows = runs.map((run) => {
-    const nodes = Object.values(run.nodes);
-    const active = nodes.filter((node) => node.status === "busy" || node.status === "starting").length;
-    const mode = nodes[0]?.coordination ?? "unknown";
-    return `${run.runId}\t${mode}\t${nodes.length} nodes\t${active} active\t${run.updatedAt}\t${formatAge(run.updatedAt, now)}`;
+  return renderTable({
+    columns: ["RUN", "MODE", "NODES", "ACTIVE", "STATUS", "UPDATED", "AGE"],
+    rows: runs.map((run) => {
+      const nodes = Object.values(run.nodes);
+      const active = nodes.filter((node) => node.status === "busy" || node.status === "starting").length;
+      const mode = nodes[0]?.coordination ?? "unknown";
+      const summary = statusSummary(nodes);
+      return [
+        run.runId,
+        mode,
+        `${nodes.length} nodes`,
+        cell(`${active} active`, active > 0 ? "yellow" : "dim"),
+        cell(summary, statusSummaryColor(summary)),
+        run.updatedAt,
+        formatAge(run.updatedAt, now),
+      ];
+    }),
   });
-  return `${["RUN\tMODE\tNODES\tACTIVE\tUPDATED\tAGE", ...rows].join("\n")}\n`;
 }
 
 export function renderRunView(run: RunRecord): string {
   const nodes = Object.values(run.nodes).sort((left, right) => left.nodeId.localeCompare(right.nodeId));
   const mode = nodes.find((node) => node.nodeId === "orchestrator")?.coordination ?? nodes[0]?.coordination ?? "unknown";
   const now = Date.now();
+  const summary = statusSummary(nodes);
   const lines = [
-    `${run.runId}  ${mode}  ${nodes.length} nodes  status: ${statusSummary(nodes)}`,
-    `created: ${run.createdAt}  updated: ${run.updatedAt}  age: ${formatAge(run.createdAt, now)}  updated: ${formatAge(run.updatedAt, now)} ago`,
+    "Summary",
+    renderTable({
+      columns: ["Field", "Value"],
+      rows: [
+        ["Run", run.runId],
+        ["Mode", mode],
+        ["Nodes", `${nodes.length} nodes`],
+        ["Status", cell(summary, statusSummaryColor(summary))],
+        ["Created", run.createdAt],
+        ["Updated", run.updatedAt],
+        ["Age", formatAge(run.createdAt, now)],
+        ["Updated age", `${formatAge(run.updatedAt, now)} ago`],
+      ],
+    }).trimEnd(),
     "",
     "Graph",
+    renderTable({
+      columns: ["Node"],
+      rows: renderGraph(nodes, now).map((line) => [cell(line, graphLineColor(line))]),
+    }).trimEnd(),
   ];
-  lines.push(...renderGraph(nodes, now));
   const extraEdges = dependencyEdges(nodes).filter(([from, to]) => from !== "orchestrator" && to !== "orchestrator");
   if (extraEdges.length > 0) {
     lines.push("", "Extra edges");
-    lines.push(...extraEdges.map(([from, to]) => `${from} -> ${to}`));
+    lines.push(
+      renderTable({
+        columns: ["From", "To"],
+        rows: extraEdges,
+      }).trimEnd(),
+    );
   }
   if (nodes.length > 0) {
     lines.push("", "Node details");
-    lines.push(...renderNodeTable(nodes, now));
+    lines.push(
+      renderTable({
+        columns: ["NODE", "ROLE", "AGENT", "STATUS", "UPDATED", "AGE", "LAST"],
+        rows: renderNodeRows(nodes, now),
+      }).trimEnd(),
+    );
   }
   const messages = run.events.filter((event) => event.type === "message_sent").slice(-8);
   if (messages.length > 0) {
     lines.push("", "Recent messages");
-    lines.push(...messages.map(renderMessage));
+    lines.push(
+      renderTable({
+        columns: ["TIME", "FROM", "TO", "MESSAGE"],
+        rows: messages.map(renderMessageRow),
+      }).trimEnd(),
+    );
   }
   lines.push("", "Commands");
-  for (const node of nodes) {
-    lines.push(`message ${node.nodeId}: headless run message ${run.runId} ${node.nodeId} --prompt "..."`);
-    if (node.tmuxSessionName) {
-      lines.push(`attach ${node.nodeId}:  tmux attach-session -t ${node.tmuxSessionName}`);
-    }
-    if (node.logs) {
-      lines.push(`logs ${node.nodeId}:    tail -f ${node.logs.stdout}`);
-    }
-  }
+  lines.push(
+    renderTable({
+      columns: ["NODE", "COMMAND"],
+      rows: commandRows(run.runId, nodes),
+    }).trimEnd(),
+  );
   return `${lines.join("\n")}\n`;
 }
 
@@ -71,25 +112,74 @@ function renderNode(node: RunNode, now: number): string {
   return `${node.nodeId} [${node.status} ${formatAge(node.updatedAt, now)} ago]${depends}${planned}${last}`;
 }
 
-function renderNodeTable(nodes: RunNode[], now: number): string[] {
-  const rows = [
-    ["NODE", "ROLE", "AGENT", "STATUS", "UPDATED", "AGE", "LAST"],
-    ...nodes.map((node) => [
-      node.nodeId,
-      node.role,
-      node.agent,
-      node.status,
-      node.updatedAt,
-      formatAge(node.updatedAt, now),
-      truncate(oneLine(node.lastMessage ?? ""), 60) || "-",
-    ]),
-  ];
-  const widths = rows[0].map((_, index) => Math.max(...rows.map((row) => row[index]?.length ?? 0)));
-  return rows.map((row) => row.map((value, index) => value.padEnd(widths[index] ?? 0)).join("  ").trimEnd());
+function renderNodeRows(nodes: RunNode[], now: number): Array<Array<string | TableCell>> {
+  return nodes.map((node) => [
+    node.nodeId,
+    node.role,
+    node.agent,
+    cell(node.status, statusColor(node.status)),
+    node.updatedAt,
+    formatAge(node.updatedAt, now),
+    truncate(oneLine(node.lastMessage ?? ""), 60) || "-",
+  ]);
 }
 
-function renderMessage(event: RunEvent): string {
-  return `${event.createdAt}  ${event.nodeId ?? "cli"} -> ${event.targetNodeId ?? "unknown"}  ${truncate(event.message ?? "", 100)}`;
+function renderMessageRow(event: RunEvent): string[] {
+  return [
+    event.createdAt,
+    event.nodeId ?? "cli",
+    event.targetNodeId ?? "unknown",
+    truncate(event.message ?? "", 100),
+  ];
+}
+
+function commandRows(runId: string, nodes: RunNode[]): string[][] {
+  const rows: string[][] = [];
+  for (const node of nodes) {
+    rows.push([node.nodeId, `headless run message ${runId} ${node.nodeId} --prompt "..."`]);
+    if (node.tmuxSessionName) {
+      rows.push([node.nodeId, `tmux attach-session -t ${node.tmuxSessionName}`]);
+    }
+    if (node.logs) {
+      rows.push([node.nodeId, `tail -f ${node.logs.stdout}`]);
+    }
+  }
+  return rows;
+}
+
+function graphLineColor(line: string): TableColor | undefined {
+  for (const status of ["failed", "busy", "starting", "done", "idle", "planned", "unknown"] as const) {
+    if (line.includes(`[${status} `)) {
+      return statusColor(status);
+    }
+  }
+  return undefined;
+}
+
+function statusColor(status: RunStatus): TableColor | undefined {
+  switch (status) {
+    case "done":
+      return "green";
+    case "busy":
+    case "starting":
+      return "yellow";
+    case "failed":
+    case "unknown":
+      return "red";
+    case "idle":
+      return "cyan";
+    case "planned":
+      return "dim";
+  }
+}
+
+function statusSummaryColor(summary: string): TableColor | undefined {
+  if (summary.includes("failed") || summary.includes("unknown")) return "red";
+  if (summary.includes("busy") || summary.includes("starting")) return "yellow";
+  if (summary.includes("done")) return "green";
+  if (summary.includes("idle")) return "cyan";
+  if (summary.includes("planned")) return "dim";
+  return undefined;
 }
 
 function dependencyEdges(nodes: RunNode[]): Array<[string, string]> {

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -1,0 +1,338 @@
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+import type { CoordinationMode, Role, RunStatus } from "./roles.js";
+import type { AgentName, AllowMode, Env, ReasoningEffort } from "./types.js";
+
+export interface RunNode {
+  runId: string;
+  nodeId: string;
+  role: Role;
+  agent: AgentName;
+  coordination: CoordinationMode;
+  status: RunStatus;
+  lastMessage?: string;
+  dependsOn: string[];
+  planned: boolean;
+  unplanned: boolean;
+  allow?: AllowMode;
+  model?: string;
+  reasoningEffort?: ReasoningEffort;
+  workDir?: string;
+  sessionAlias?: string;
+  tmuxSessionName?: string;
+  logs?: {
+    stdout: string;
+    stderr: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RunEvent {
+  type:
+    | "run_started"
+    | "node_registered"
+    | "node_started"
+    | "message_sent"
+    | "status_changed"
+    | "node_output"
+    | "node_failed"
+    | "node_completed";
+  runId: string;
+  nodeId?: string;
+  parentNodeId?: string;
+  targetNodeId?: string;
+  role?: Role;
+  agent?: AgentName;
+  coordination?: CoordinationMode;
+  status?: RunStatus;
+  message?: string;
+  dependsOn?: string[];
+  createdAt: string;
+}
+
+export interface RunRecord {
+  version: 1;
+  runId: string;
+  createdAt: string;
+  updatedAt: string;
+  nodes: Record<string, RunNode>;
+  events: RunEvent[];
+}
+
+export interface RegisterNodeInput {
+  runId: string;
+  nodeId: string;
+  role: Role;
+  agent: AgentName;
+  coordination: CoordinationMode;
+  status?: RunStatus;
+  dependsOn?: string[];
+  planned?: boolean;
+  allow?: AllowMode;
+  model?: string;
+  reasoningEffort?: ReasoningEffort;
+  workDir?: string;
+  sessionAlias?: string;
+  tmuxSessionName?: string;
+}
+
+export function validateRunId(value: string | undefined, label: string): string {
+  if (!value || !/^[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error(`invalid ${label}; use letters, numbers, dots, dashes, or underscores`);
+  }
+  return value;
+}
+
+export function runDirectory(env: Env, runId: string): string {
+  const override = env.HEADLESS_RUN_DIR;
+  if (override) {
+    return basename(override) === runId ? override : override;
+  }
+  if (!env.HOME) {
+    throw new Error("HOME is required for --run");
+  }
+  return join(env.HOME, ".headless", "runs", runId);
+}
+
+export function runStoreRoot(env: Env): string {
+  if (env.HEADLESS_RUN_DIR) {
+    return dirname(env.HEADLESS_RUN_DIR);
+  }
+  if (!env.HOME) {
+    throw new Error("HOME is required for headless run");
+  }
+  return join(env.HOME, ".headless", "runs");
+}
+
+export function nodeDirectory(env: Env, runId: string, nodeId: string): string {
+  return join(runDirectory(env, runId), "nodes", nodeId);
+}
+
+export function nodeLockPath(env: Env, runId: string, nodeId: string): string {
+  return join(nodeDirectory(env, runId, nodeId), "session.lock");
+}
+
+export function readRun(env: Env, runId: string): RunRecord | undefined {
+  const path = join(runDirectory(env, runId), "run.json");
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<RunRecord>;
+    if (parsed.version !== 1 || parsed.runId !== runId || !parsed.nodes || !parsed.events) {
+      return undefined;
+    }
+    return {
+      version: 1,
+      runId,
+      createdAt: parsed.createdAt ?? new Date().toISOString(),
+      updatedAt: parsed.updatedAt ?? new Date().toISOString(),
+      nodes: parsed.nodes,
+      events: parsed.events,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function listRuns(env: Env): RunRecord[] {
+  const root = runStoreRoot(env);
+  if (!existsSync(root)) {
+    return [];
+  }
+  return readdirSync(root)
+    .map((entry) => readRun({ ...env, HEADLESS_RUN_DIR: join(root, entry) }, entry))
+    .filter((run): run is RunRecord => Boolean(run))
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+export function registerNode(env: Env, input: RegisterNodeInput): RunNode {
+  validateRunId(input.runId, "run");
+  validateRunId(input.nodeId, "node");
+  const run = readRun(env, input.runId) ?? emptyRun(input.runId);
+  const now = new Date().toISOString();
+  const existing = run.nodes[input.nodeId];
+  const node: RunNode = {
+    runId: input.runId,
+    nodeId: input.nodeId,
+    role: input.role,
+    agent: input.agent,
+    coordination: input.coordination,
+    status: input.status ?? existing?.status ?? "planned",
+    lastMessage: existing?.lastMessage,
+    dependsOn: unique(input.dependsOn ?? existing?.dependsOn ?? []),
+    planned: input.planned ?? existing?.planned ?? false,
+    unplanned: !(input.planned ?? existing?.planned ?? false),
+    allow: input.allow ?? existing?.allow,
+    model: input.model ?? existing?.model,
+    reasoningEffort: input.reasoningEffort ?? existing?.reasoningEffort,
+    workDir: input.workDir ?? existing?.workDir,
+    sessionAlias: input.sessionAlias ?? existing?.sessionAlias,
+    tmuxSessionName: input.tmuxSessionName ?? existing?.tmuxSessionName,
+    logs: existing?.logs ?? logPaths(env, input.runId, input.nodeId),
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+  run.nodes[input.nodeId] = node;
+  addEvent(run, {
+    type: existing ? "node_started" : "node_registered",
+    runId: input.runId,
+    nodeId: input.nodeId,
+    role: input.role,
+    agent: input.agent,
+    coordination: input.coordination,
+    status: node.status,
+    dependsOn: node.dependsOn,
+    createdAt: now,
+  });
+  writeRun(env, run);
+  return node;
+}
+
+export function updateNodeStatus(
+  env: Env,
+  runId: string,
+  nodeId: string,
+  status: RunStatus,
+  message?: string,
+): RunNode {
+  const run = requireRun(env, runId);
+  const node = requireNode(run, nodeId);
+  const now = new Date().toISOString();
+  node.status = status;
+  node.updatedAt = now;
+  if (message) {
+    node.lastMessage = message;
+  }
+  addEvent(run, {
+    type: status === "failed" ? "node_failed" : status === "done" || status === "idle" ? "node_completed" : "status_changed",
+    runId,
+    nodeId,
+    status,
+    message,
+    createdAt: now,
+  });
+  writeRun(env, run);
+  return node;
+}
+
+export function recordMessage(
+  env: Env,
+  runId: string,
+  fromNodeId: string,
+  targetNodeId: string,
+  message: string,
+): void {
+  const run = requireRun(env, runId);
+  const now = new Date().toISOString();
+  if (!run.nodes[targetNodeId]) {
+    throw new Error(`unknown node in run ${runId}: ${targetNodeId}`);
+  }
+  const sourceNode = run.nodes[fromNodeId];
+  const messageOwner = sourceNode ?? run.nodes[targetNodeId];
+  messageOwner.lastMessage = message;
+  messageOwner.updatedAt = now;
+  addEvent(run, {
+    type: "message_sent",
+    runId,
+    nodeId: fromNodeId,
+    targetNodeId,
+    message,
+    createdAt: now,
+  });
+  writeRun(env, run);
+}
+
+export function acquireNodeLock(env: Env, runId: string, nodeId: string): () => void {
+  const lockPath = nodeLockPath(env, runId, nodeId);
+  mkdirSync(dirname(lockPath), { recursive: true });
+  let fd: number;
+  try {
+    fd = openSync(lockPath, "wx");
+  } catch {
+    throw new Error(`node is locked: ${nodeId}`);
+  }
+  writeFileSync(fd, `${process.pid}\n`);
+  return () => {
+    closeSync(fd);
+    rmSync(lockPath, { force: true });
+  };
+}
+
+export function writeRun(env: Env, run: RunRecord): void {
+  const dir = runDirectory(env, run.runId);
+  mkdirSync(dir, { recursive: true });
+  for (const node of Object.values(run.nodes)) {
+    mkdirSync(nodeDirectory(env, run.runId, node.nodeId), { recursive: true });
+  }
+  run.updatedAt = new Date().toISOString();
+  const path = join(dir, "run.json");
+  const tmpPath = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmpPath, `${JSON.stringify(run, null, 2)}\n`);
+  renameSync(tmpPath, path);
+  const eventsPath = join(dir, "events.jsonl");
+  const event = run.events.at(-1);
+  if (event) {
+    appendFileSync(eventsPath, `${JSON.stringify(event)}\n`);
+  }
+}
+
+function requireRun(env: Env, runId: string): RunRecord {
+  const run = readRun(env, runId);
+  if (!run) {
+    throw new Error(`unknown run: ${runId}`);
+  }
+  return run;
+}
+
+function requireNode(run: RunRecord, nodeId: string): RunNode {
+  const node = run.nodes[nodeId];
+  if (!node) {
+    throw new Error(`unknown node in run ${run.runId}: ${nodeId}`);
+  }
+  return node;
+}
+
+function emptyRun(runId: string): RunRecord {
+  const now = new Date().toISOString();
+  return {
+    version: 1,
+    runId,
+    createdAt: now,
+    updatedAt: now,
+    nodes: {},
+    events: [{ type: "run_started", runId, createdAt: now }],
+  };
+}
+
+function addEvent(run: RunRecord, event: RunEvent): void {
+  run.events.push(event);
+  if (run.events.length > 200) {
+    run.events = run.events.slice(-200);
+  }
+}
+
+function logPaths(env: Env, runId: string, nodeId: string): { stdout: string; stderr: string } {
+  const dir = nodeDirectory(env, runId, nodeId);
+  return {
+    stdout: join(dir, "latest.stdout.log"),
+    stderr: join(dir, "latest.stderr.log"),
+  };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -36,8 +36,22 @@ export interface RunNode {
     stdout: string;
     stderr: string;
   };
+  metrics?: RunNodeMetrics;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface RunNodeMetrics {
+  turns?: number;
+  durationMs?: number;
+  apiDurationMs?: number;
+  totalCostUsd?: number;
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  totalTokens?: number;
 }
 
 export interface RunEvent {
@@ -206,6 +220,7 @@ export function registerNode(env: Env, input: RegisterNodeInput): RunNode {
     sessionAlias: input.sessionAlias ?? existing?.sessionAlias,
     tmuxSessionName: input.tmuxSessionName ?? existing?.tmuxSessionName,
     logs: existing?.logs ?? logPaths(env, input.runId, input.nodeId),
+    metrics: existing?.metrics,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
   };
@@ -231,6 +246,7 @@ export function updateNodeStatus(
   nodeId: string,
   status: RunStatus,
   message?: string,
+  metrics?: RunNodeMetrics,
 ): RunNode {
   const run = requireRun(env, runId);
   const node = requireNode(run, nodeId);
@@ -239,6 +255,9 @@ export function updateNodeStatus(
   node.updatedAt = now;
   if (message) {
     node.lastMessage = message;
+  }
+  if (metrics && Object.keys(metrics).length > 0) {
+    node.metrics = { ...node.metrics, ...metrics };
   }
   addEvent(run, {
     type: status === "failed" ? "node_failed" : status === "done" || status === "idle" ? "node_completed" : "status_changed",

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -1,5 +1,6 @@
 import {
   appendFileSync,
+  chmodSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -14,6 +15,9 @@ import { basename, dirname, join } from "node:path";
 
 import type { CoordinationMode, Role, RunStatus } from "./roles.js";
 import type { AgentName, AllowMode, Env, ReasoningEffort } from "./types.js";
+
+const privateDirMode = 0o700;
+const privateFileMode = 0o600;
 
 export interface RunNode {
   runId: string;
@@ -154,8 +158,8 @@ export function appendNodeLog(
     return;
   }
   const path = nodeLogPath(env, runId, nodeId, stream);
-  mkdirSync(dirname(path), { recursive: true });
-  appendFileSync(path, text);
+  ensurePrivateDir(dirname(path));
+  appendPrivateFile(path, text);
 }
 
 export function readRun(env: Env, runId: string): RunRecord | undefined {
@@ -336,10 +340,11 @@ export function recordMessage(
 
 export function acquireNodeLock(env: Env, runId: string, nodeId: string): () => void {
   const lockPath = nodeLockPath(env, runId, nodeId);
-  mkdirSync(dirname(lockPath), { recursive: true });
+  ensurePrivateDir(dirname(lockPath));
   let fd: number;
   try {
-    fd = openSync(lockPath, "wx");
+    fd = openSync(lockPath, "wx", privateFileMode);
+    chmodSync(lockPath, privateFileMode);
   } catch {
     throw new Error(`node is locked: ${nodeId}`);
   }
@@ -352,19 +357,21 @@ export function acquireNodeLock(env: Env, runId: string, nodeId: string): () => 
 
 export function writeRun(env: Env, run: RunRecord): void {
   const dir = runDirectory(env, run.runId);
-  mkdirSync(dir, { recursive: true });
+  ensurePrivateDir(dir);
   for (const node of Object.values(run.nodes)) {
-    mkdirSync(nodeDirectory(env, run.runId, node.nodeId), { recursive: true });
+    ensurePrivateDir(nodeDirectory(env, run.runId, node.nodeId));
   }
   run.updatedAt = new Date().toISOString();
   const path = join(dir, "run.json");
   const tmpPath = `${path}.tmp-${process.pid}`;
-  writeFileSync(tmpPath, `${JSON.stringify(run, null, 2)}\n`);
+  writeFileSync(tmpPath, `${JSON.stringify(run, null, 2)}\n`, { mode: privateFileMode });
+  chmodSync(tmpPath, privateFileMode);
   renameSync(tmpPath, path);
+  chmodSync(path, privateFileMode);
   const eventsPath = join(dir, "events.jsonl");
   const event = run.events.at(-1);
   if (event) {
-    appendFileSync(eventsPath, `${JSON.stringify(event)}\n`);
+    appendPrivateFile(eventsPath, `${JSON.stringify(event)}\n`);
   }
 }
 
@@ -379,13 +386,14 @@ function withRunLock<T>(env: Env, runId: string, callback: () => T): T {
 
 function acquireRunLock(env: Env, runId: string): () => void {
   const dir = runDirectory(env, runId);
-  mkdirSync(dir, { recursive: true });
+  ensurePrivateDir(dir);
   const lockPath = join(dir, "run.lock");
   const deadline = Date.now() + 30000;
   let fd: number;
   while (true) {
     try {
-      fd = openSync(lockPath, "wx");
+      fd = openSync(lockPath, "wx", privateFileMode);
+      chmodSync(lockPath, privateFileMode);
       break;
     } catch {
       if (Date.now() >= deadline) {
@@ -446,6 +454,16 @@ function logPaths(env: Env, runId: string, nodeId: string): { stdout: string; st
     stdout: join(dir, "latest.stdout.log"),
     stderr: join(dir, "latest.stderr.log"),
   };
+}
+
+function ensurePrivateDir(path: string): void {
+  mkdirSync(path, { recursive: true, mode: privateDirMode });
+  chmodSync(path, privateDirMode);
+}
+
+function appendPrivateFile(path: string, text: string): void {
+  appendFileSync(path, text, { mode: privateFileMode });
+  chmodSync(path, privateFileMode);
 }
 
 function unique(values: string[]): string[] {

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -125,6 +125,25 @@ export function nodeLockPath(env: Env, runId: string, nodeId: string): string {
   return join(nodeDirectory(env, runId, nodeId), "session.lock");
 }
 
+export function nodeLogPath(env: Env, runId: string, nodeId: string, stream: "stdout" | "stderr"): string {
+  return readRun(env, runId)?.nodes[nodeId]?.logs?.[stream] ?? logPaths(env, runId, nodeId)[stream];
+}
+
+export function appendNodeLog(
+  env: Env,
+  runId: string,
+  nodeId: string,
+  stream: "stdout" | "stderr",
+  text: string,
+): void {
+  if (!text) {
+    return;
+  }
+  const path = nodeLogPath(env, runId, nodeId, stream);
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, text);
+}
+
 export function readRun(env: Env, runId: string): RunRecord | undefined {
   const path = join(runDirectory(env, runId), "run.json");
   if (!existsSync(path)) {
@@ -165,13 +184,17 @@ export function registerNode(env: Env, input: RegisterNodeInput): RunNode {
   const run = readRun(env, input.runId) ?? emptyRun(input.runId);
   const now = new Date().toISOString();
   const existing = run.nodes[input.nodeId];
+  const status =
+    existing?.status === "busy" && input.status === "starting"
+      ? "busy"
+      : (input.status ?? existing?.status ?? "planned");
   const node: RunNode = {
     runId: input.runId,
     nodeId: input.nodeId,
     role: input.role,
     agent: input.agent,
     coordination: input.coordination,
-    status: input.status ?? existing?.status ?? "planned",
+    status,
     lastMessage: existing?.lastMessage,
     dependsOn: unique(input.dependsOn ?? existing?.dependsOn ?? []),
     planned: input.planned ?? existing?.planned ?? false,

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -108,7 +108,7 @@ export interface RegisterNodeInput {
 }
 
 export function validateRunId(value: string | undefined, label: string): string {
-  if (!value || !/^[A-Za-z0-9_.-]+$/.test(value)) {
+  if (!value || value === "." || value === ".." || !/^[A-Za-z0-9_.-]+$/.test(value)) {
     throw new Error(`invalid ${label}; use letters, numbers, dots, dashes, or underscores`);
   }
   return value;

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -195,49 +195,51 @@ export function listRuns(env: Env): RunRecord[] {
 export function registerNode(env: Env, input: RegisterNodeInput): RunNode {
   validateRunId(input.runId, "run");
   validateRunId(input.nodeId, "node");
-  const run = readRun(env, input.runId) ?? emptyRun(input.runId);
-  const now = new Date().toISOString();
-  const existing = run.nodes[input.nodeId];
-  const status =
-    existing?.status === "busy" && input.status === "starting"
-      ? "busy"
-      : (input.status ?? existing?.status ?? "planned");
-  const node: RunNode = {
-    runId: input.runId,
-    nodeId: input.nodeId,
-    role: input.role,
-    agent: input.agent,
-    coordination: input.coordination,
-    status,
-    lastMessage: existing?.lastMessage,
-    dependsOn: unique(input.dependsOn ?? existing?.dependsOn ?? []),
-    planned: input.planned ?? existing?.planned ?? false,
-    unplanned: !(input.planned ?? existing?.planned ?? false),
-    allow: input.allow ?? existing?.allow,
-    model: input.model ?? existing?.model,
-    reasoningEffort: input.reasoningEffort ?? existing?.reasoningEffort,
-    workDir: input.workDir ?? existing?.workDir,
-    sessionAlias: input.sessionAlias ?? existing?.sessionAlias,
-    tmuxSessionName: input.tmuxSessionName ?? existing?.tmuxSessionName,
-    logs: existing?.logs ?? logPaths(env, input.runId, input.nodeId),
-    metrics: existing?.metrics,
-    createdAt: existing?.createdAt ?? now,
-    updatedAt: now,
-  };
-  run.nodes[input.nodeId] = node;
-  addEvent(run, {
-    type: existing ? "node_started" : "node_registered",
-    runId: input.runId,
-    nodeId: input.nodeId,
-    role: input.role,
-    agent: input.agent,
-    coordination: input.coordination,
-    status: node.status,
-    dependsOn: node.dependsOn,
-    createdAt: now,
+  return withRunLock(env, input.runId, () => {
+    const run = readRun(env, input.runId) ?? emptyRun(input.runId);
+    const now = new Date().toISOString();
+    const existing = run.nodes[input.nodeId];
+    const status =
+      existing?.status === "busy" && input.status === "starting"
+        ? "busy"
+        : (input.status ?? existing?.status ?? "planned");
+    const node: RunNode = {
+      runId: input.runId,
+      nodeId: input.nodeId,
+      role: input.role,
+      agent: input.agent,
+      coordination: input.coordination,
+      status,
+      lastMessage: existing?.lastMessage,
+      dependsOn: unique(input.dependsOn ?? existing?.dependsOn ?? []),
+      planned: input.planned ?? existing?.planned ?? false,
+      unplanned: !(input.planned ?? existing?.planned ?? false),
+      allow: input.allow ?? existing?.allow,
+      model: input.model ?? existing?.model,
+      reasoningEffort: input.reasoningEffort ?? existing?.reasoningEffort,
+      workDir: input.workDir ?? existing?.workDir,
+      sessionAlias: input.sessionAlias ?? existing?.sessionAlias,
+      tmuxSessionName: input.tmuxSessionName ?? existing?.tmuxSessionName,
+      logs: existing?.logs ?? logPaths(env, input.runId, input.nodeId),
+      metrics: existing?.metrics,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    run.nodes[input.nodeId] = node;
+    addEvent(run, {
+      type: existing ? "node_started" : "node_registered",
+      runId: input.runId,
+      nodeId: input.nodeId,
+      role: input.role,
+      agent: input.agent,
+      coordination: input.coordination,
+      status: node.status,
+      dependsOn: node.dependsOn,
+      createdAt: now,
+    });
+    writeRun(env, run);
+    return node;
   });
-  writeRun(env, run);
-  return node;
 }
 
 export function updateNodeStatus(
@@ -248,52 +250,58 @@ export function updateNodeStatus(
   message?: string,
   metrics?: RunNodeMetrics,
 ): RunNode {
-  const run = requireRun(env, runId);
-  const node = requireNode(run, nodeId);
-  const now = new Date().toISOString();
-  node.status = status;
-  node.updatedAt = now;
-  if (message) {
-    node.lastMessage = message;
-  }
-  if (metrics && Object.keys(metrics).length > 0) {
-    node.metrics = { ...node.metrics, ...metrics };
-  }
-  addEvent(run, {
-    type: status === "failed" ? "node_failed" : status === "done" || status === "idle" ? "node_completed" : "status_changed",
-    runId,
-    nodeId,
-    status,
-    message,
-    createdAt: now,
+  validateRunId(runId, "run");
+  return withRunLock(env, runId, () => {
+    const run = requireRun(env, runId);
+    const node = requireNode(run, nodeId);
+    const now = new Date().toISOString();
+    node.status = status;
+    node.updatedAt = now;
+    if (message) {
+      node.lastMessage = message;
+    }
+    if (metrics && Object.keys(metrics).length > 0) {
+      node.metrics = { ...node.metrics, ...metrics };
+    }
+    addEvent(run, {
+      type: status === "failed" ? "node_failed" : status === "done" || status === "idle" ? "node_completed" : "status_changed",
+      runId,
+      nodeId,
+      status,
+      message,
+      createdAt: now,
+    });
+    writeRun(env, run);
+    return node;
   });
-  writeRun(env, run);
-  return node;
 }
 
 export function completeIdleRunNodes(env: Env, runId: string, orchestratorNodeId: string, orchestratorMessage?: string): void {
-  const run = requireRun(env, runId);
-  const now = new Date().toISOString();
-  for (const node of Object.values(run.nodes)) {
-    const shouldComplete = node.nodeId === orchestratorNodeId || node.status === "idle";
-    if (!shouldComplete) {
-      continue;
+  validateRunId(runId, "run");
+  withRunLock(env, runId, () => {
+    const run = requireRun(env, runId);
+    const now = new Date().toISOString();
+    for (const node of Object.values(run.nodes)) {
+      const shouldComplete = node.nodeId === orchestratorNodeId || node.status === "idle";
+      if (!shouldComplete) {
+        continue;
+      }
+      node.status = "done";
+      node.updatedAt = now;
+      if (node.nodeId === orchestratorNodeId && orchestratorMessage) {
+        node.lastMessage = orchestratorMessage;
+      }
+      addEvent(run, {
+        type: "node_completed",
+        runId,
+        nodeId: node.nodeId,
+        status: "done",
+        message: node.nodeId === orchestratorNodeId ? orchestratorMessage : undefined,
+        createdAt: now,
+      });
     }
-    node.status = "done";
-    node.updatedAt = now;
-    if (node.nodeId === orchestratorNodeId && orchestratorMessage) {
-      node.lastMessage = orchestratorMessage;
-    }
-    addEvent(run, {
-      type: "node_completed",
-      runId,
-      nodeId: node.nodeId,
-      status: "done",
-      message: node.nodeId === orchestratorNodeId ? orchestratorMessage : undefined,
-      createdAt: now,
-    });
-  }
-  writeRun(env, run);
+    writeRun(env, run);
+  });
 }
 
 export function recordMessage(
@@ -303,24 +311,27 @@ export function recordMessage(
   targetNodeId: string,
   message: string,
 ): void {
-  const run = requireRun(env, runId);
-  const now = new Date().toISOString();
-  if (!run.nodes[targetNodeId]) {
-    throw new Error(`unknown node in run ${runId}: ${targetNodeId}`);
-  }
-  const sourceNode = run.nodes[fromNodeId];
-  const messageOwner = sourceNode ?? run.nodes[targetNodeId];
-  messageOwner.lastMessage = message;
-  messageOwner.updatedAt = now;
-  addEvent(run, {
-    type: "message_sent",
-    runId,
-    nodeId: fromNodeId,
-    targetNodeId,
-    message,
-    createdAt: now,
+  validateRunId(runId, "run");
+  withRunLock(env, runId, () => {
+    const run = requireRun(env, runId);
+    const now = new Date().toISOString();
+    if (!run.nodes[targetNodeId]) {
+      throw new Error(`unknown node in run ${runId}: ${targetNodeId}`);
+    }
+    const sourceNode = run.nodes[fromNodeId];
+    const messageOwner = sourceNode ?? run.nodes[targetNodeId];
+    messageOwner.lastMessage = message;
+    messageOwner.updatedAt = now;
+    addEvent(run, {
+      type: "message_sent",
+      runId,
+      nodeId: fromNodeId,
+      targetNodeId,
+      message,
+      createdAt: now,
+    });
+    writeRun(env, run);
   });
-  writeRun(env, run);
 }
 
 export function acquireNodeLock(env: Env, runId: string, nodeId: string): () => void {
@@ -355,6 +366,43 @@ export function writeRun(env: Env, run: RunRecord): void {
   if (event) {
     appendFileSync(eventsPath, `${JSON.stringify(event)}\n`);
   }
+}
+
+function withRunLock<T>(env: Env, runId: string, callback: () => T): T {
+  const release = acquireRunLock(env, runId);
+  try {
+    return callback();
+  } finally {
+    release();
+  }
+}
+
+function acquireRunLock(env: Env, runId: string): () => void {
+  const dir = runDirectory(env, runId);
+  mkdirSync(dir, { recursive: true });
+  const lockPath = join(dir, "run.lock");
+  const deadline = Date.now() + 30000;
+  let fd: number;
+  while (true) {
+    try {
+      fd = openSync(lockPath, "wx");
+      break;
+    } catch {
+      if (Date.now() >= deadline) {
+        throw new Error(`run is locked: ${runId}`);
+      }
+      sleepSync(10);
+    }
+  }
+  writeFileSync(fd, `${process.pid}\n`);
+  return () => {
+    closeSync(fd);
+    rmSync(lockPath, { force: true });
+  };
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
 function requireRun(env: Env, runId: string): RunRecord {

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -271,6 +271,31 @@ export function updateNodeStatus(
   return node;
 }
 
+export function completeIdleRunNodes(env: Env, runId: string, orchestratorNodeId: string, orchestratorMessage?: string): void {
+  const run = requireRun(env, runId);
+  const now = new Date().toISOString();
+  for (const node of Object.values(run.nodes)) {
+    const shouldComplete = node.nodeId === orchestratorNodeId || node.status === "idle";
+    if (!shouldComplete) {
+      continue;
+    }
+    node.status = "done";
+    node.updatedAt = now;
+    if (node.nodeId === orchestratorNodeId && orchestratorMessage) {
+      node.lastMessage = orchestratorMessage;
+    }
+    addEvent(run, {
+      type: "node_completed",
+      runId,
+      nodeId: node.nodeId,
+      status: "done",
+      message: node.nodeId === orchestratorNodeId ? orchestratorMessage : undefined,
+      createdAt: now,
+    });
+  }
+  writeRun(env, run);
+}
+
 export function recordMessage(
   env: Env,
   runId: string,

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,0 +1,162 @@
+import type { Env } from "./types.js";
+
+export type TableColor = "green" | "red" | "yellow" | "cyan" | "magenta" | "dim";
+
+export interface TableCell {
+  text: string;
+  color?: TableColor;
+}
+
+export interface TableInput {
+  columns: string[];
+  rows: Array<Array<string | TableCell>>;
+}
+
+export interface TableOptions {
+  color?: boolean;
+  env?: Env;
+  maxWidth?: number;
+  terminalWidth?: number;
+}
+
+const defaultMaxWidth = 100;
+const ansiCodes: Record<TableColor, string> = {
+  green: "32",
+  red: "31",
+  yellow: "33",
+  cyan: "36",
+  magenta: "35",
+  dim: "2",
+};
+
+export function renderTable(input: TableInput, options: TableOptions = {}): string {
+  if (input.columns.length === 0) {
+    return "";
+  }
+
+  const columnCount = input.columns.length;
+  const rows = [input.columns.map((text) => ({ text })), ...normalizeRows(input.rows, columnCount)];
+  const widths = fitWidths(naturalWidths(rows, columnCount), resolvedMaxWidth(options));
+  const border = renderBorder(widths);
+  const separator = renderBorder(widths);
+  const color = shouldUseColor(options);
+  const lines = [
+    border,
+    renderRow(rows[0] ?? [], widths, false),
+    separator,
+    ...rows.slice(1).map((row) => renderRow(row, widths, color)),
+    border,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+export function cell(text: string, color?: TableColor): TableCell {
+  return color ? { text, color } : { text };
+}
+
+function normalizeRows(rows: Array<Array<string | TableCell>>, columnCount: number): TableCell[][] {
+  return rows.map((row) =>
+    Array.from({ length: columnCount }, (_, index) => {
+      const value = row[index];
+      if (typeof value === "string") {
+        return { text: oneLine(value) };
+      }
+      return { text: oneLine(value?.text ?? ""), color: value?.color };
+    }),
+  );
+}
+
+function naturalWidths(rows: TableCell[][], columnCount: number): number[] {
+  return Array.from({ length: columnCount }, (_, index) =>
+    Math.max(1, ...rows.map((row) => displayLength(row[index]?.text ?? ""))),
+  );
+}
+
+function fitWidths(natural: number[], maxWidth: number): number[] {
+  const widths = [...natural];
+  const minimums = natural.map((width) => Math.min(width, 3));
+  while (totalWidth(widths) > maxWidth) {
+    let widestIndex = -1;
+    for (const [index, width] of widths.entries()) {
+      if (width <= (minimums[index] ?? 1)) {
+        continue;
+      }
+      if (widestIndex === -1 || width > (widths[widestIndex] ?? 0)) {
+        widestIndex = index;
+      }
+    }
+    if (widestIndex === -1) {
+      break;
+    }
+    widths[widestIndex] -= 1;
+  }
+  return widths;
+}
+
+function totalWidth(widths: number[]): number {
+  return widths.reduce((sum, width) => sum + width, 0) + widths.length * 3 + 1;
+}
+
+function renderBorder(widths: number[]): string {
+  return `+${widths.map((width) => "-".repeat(width + 2)).join("+")}+`;
+}
+
+function renderRow(row: TableCell[], widths: number[], color: boolean): string {
+  const cells = widths.map((width, index) => {
+    const source = row[index] ?? { text: "" };
+    const text = truncate(source.text, width);
+    const padding = " ".repeat(Math.max(0, width - displayLength(text)));
+    return ` ${paint(text, source.color, color)}${padding} `;
+  });
+  return `|${cells.join("|")}|`;
+}
+
+function paint(text: string, color: TableColor | undefined, enabled: boolean): string {
+  if (!enabled || !color) {
+    return text;
+  }
+  return `\x1b[${ansiCodes[color]}m${text}\x1b[0m`;
+}
+
+function truncate(value: string, width: number): string {
+  if (displayLength(value) <= width) {
+    return value;
+  }
+  if (width <= 0) {
+    return "";
+  }
+  if (width <= 3) {
+    return value.slice(0, width);
+  }
+  return `${value.slice(0, width - 3)}...`;
+}
+
+function displayLength(value: string): number {
+  return value.length;
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function resolvedMaxWidth(options: TableOptions): number {
+  if (options.maxWidth !== undefined) {
+    return Math.max(10, Math.floor(options.maxWidth));
+  }
+  const terminalWidth = options.terminalWidth ?? process.stdout.columns;
+  if (Number.isFinite(terminalWidth) && terminalWidth > 0) {
+    return Math.max(10, Math.min(defaultMaxWidth, Math.floor(terminalWidth)));
+  }
+  return defaultMaxWidth;
+}
+
+function shouldUseColor(options: TableOptions): boolean {
+  const env = options.env ?? process.env;
+  if (env.NO_COLOR !== undefined) {
+    return false;
+  }
+  if (options.color !== undefined) {
+    return options.color;
+  }
+  return process.stdout.isTTY === true;
+}

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,0 +1,79 @@
+import { isAgentName } from "./agents.js";
+import { isRole, type Role } from "./roles.js";
+import type { AgentName } from "./types.js";
+
+export interface ParsedTeamSpec {
+  agent?: AgentName;
+  role: Role;
+  count: number;
+}
+
+export interface TeamNodeSpec {
+  agent: AgentName;
+  role: Role;
+  nodeId: string;
+  planned: true;
+}
+
+export function parseTeamSpec(value: string): ParsedTeamSpec {
+  const match = /^(?:(?<agent>[A-Za-z0-9_-]+)\/)?(?<role>[A-Za-z0-9_-]+)(?:=(?<count>[0-9]+))?$/.exec(value);
+  if (!match?.groups) {
+    throw new Error(`invalid team spec: ${value}`);
+  }
+  const agent = match.groups.agent;
+  if (agent !== undefined && !isAgentName(agent)) {
+    throw new Error(`unsupported team agent: ${agent}`);
+  }
+  const role = match.groups.role;
+  if (!isRole(role)) {
+    throw new Error(`unsupported team role: ${role}`);
+  }
+  const count = match.groups.count === undefined ? 1 : Number.parseInt(match.groups.count, 10);
+  if (!Number.isFinite(count) || count <= 0) {
+    throw new Error(`team count must be positive: ${value}`);
+  }
+  return { agent, role, count };
+}
+
+export function expandTeamSpecs(orchestratorAgent: AgentName, values: string[]): TeamNodeSpec[] {
+  const parsed = values.map(parseTeamSpec);
+  const roleAgents = new Map<Role, Set<AgentName>>();
+  for (const spec of parsed) {
+    const agent = spec.agent ?? orchestratorAgent;
+    const agents = roleAgents.get(spec.role) ?? new Set<AgentName>();
+    agents.add(agent);
+    roleAgents.set(spec.role, agents);
+  }
+
+  const seenByRoleAgent = new Map<string, number>();
+  const result: TeamNodeSpec[] = [];
+  for (const spec of parsed) {
+    const agent = spec.agent ?? orchestratorAgent;
+    const mixedAgentRole = (roleAgents.get(spec.role)?.size ?? 0) > 1;
+    const key = `${spec.role}/${agent}`;
+    const start = seenByRoleAgent.get(key) ?? 0;
+    for (let index = 1; index <= spec.count; index += 1) {
+      const ordinal = start + index;
+      result.push({
+        agent,
+        role: spec.role,
+        nodeId: generatedNodeName(spec.role, agent, spec.count, ordinal, mixedAgentRole),
+        planned: true,
+      });
+    }
+    seenByRoleAgent.set(key, start + spec.count);
+  }
+  return result;
+}
+
+function generatedNodeName(
+  role: Role,
+  agent: AgentName,
+  countInSpec: number,
+  ordinal: number,
+  mixedAgentRole: boolean,
+): string {
+  const agentPart = mixedAgentRole ? `-${agent}` : "";
+  const needsOrdinal = countInSpec > 1 || ordinal > 1;
+  return needsOrdinal ? `${role}${agentPart}-${ordinal}` : `${role}${agentPart}`;
+}

--- a/tests/allow.test.ts
+++ b/tests/allow.test.ts
@@ -23,6 +23,7 @@ test("builds read-only commands for supported agents", () => {
       "read-only",
       "--ask-for-approval",
       "never",
+      "--search",
       "exec",
       "--model",
       "gpt-5.5",
@@ -45,6 +46,8 @@ test("builds read-only commands for supported agents", () => {
       "--verbose",
       "--permission-mode",
       "plan",
+      "--allowedTools",
+      "Read,Grep,Glob,LS,WebFetch,WebSearch",
     ],
   });
 
@@ -73,7 +76,7 @@ test("builds read-only commands for supported agents", () => {
     args: ["run", "--format", "json", "--model", "openai/gpt-5.4", "hello"],
     env: {
       OPENCODE_CONFIG_CONTENT:
-        '{"permission":{"edit":"deny","bash":"deny","webfetch":"deny","websearch":"deny","codesearch":"deny","task":"deny"}}',
+        '{"permission":{"read":"allow","edit":"deny","bash":"deny","webfetch":"allow","websearch":"allow","codesearch":"allow","task":"deny"}}',
     },
   });
 
@@ -175,11 +178,19 @@ test("defaults to yolo commands for supported agents", () => {
 test("builds read-only interactive commands for tmux mode", () => {
   assert.deepEqual(buildInteractiveAgentCommand("codex", { prompt: "hello", allow: "read-only" }, {}), {
     command: "codex",
-    args: ["--sandbox", "read-only", "--ask-for-approval", "never", "--model", "gpt-5.5", "hello"],
+    args: ["--sandbox", "read-only", "--ask-for-approval", "never", "--search", "--model", "gpt-5.5", "hello"],
   });
   assert.deepEqual(buildInteractiveAgentCommand("claude", { prompt: "hello", allow: "read-only" }, {}), {
     command: "claude",
-    args: ["--model", "claude-opus-4-6", "--permission-mode", "plan", "hello"],
+    args: [
+      "--model",
+      "claude-opus-4-6",
+      "--permission-mode",
+      "plan",
+      "--allowedTools",
+      "Read,Grep,Glob,LS,WebFetch,WebSearch",
+      "hello",
+    ],
   });
   assert.deepEqual(buildInteractiveAgentCommand("gemini", { prompt: "hello", allow: "read-only" }, {}), {
     command: "gemini",
@@ -190,7 +201,7 @@ test("builds read-only interactive commands for tmux mode", () => {
     args: ["--model", "openai/gpt-5.4"],
     env: {
       OPENCODE_CONFIG_CONTENT:
-        '{"permission":{"edit":"deny","bash":"deny","webfetch":"deny","websearch":"deny","codesearch":"deny","task":"deny"}}',
+        '{"permission":{"read":"allow","edit":"deny","bash":"deny","webfetch":"allow","websearch":"allow","codesearch":"allow","task":"deny"}}',
     },
   });
 });
@@ -308,7 +319,7 @@ test("CLI tmux print-command includes allow mode flags", async () => {
   });
 
   assert.equal(code, 0);
-  assert.match(stdout.join(""), /codex --sandbox read-only --ask-for-approval never --model gpt-5\.5 hello/);
+  assert.match(stdout.join(""), /codex --sandbox read-only --ask-for-approval never --search --model gpt-5\.5 hello/);
 });
 
 test("CLI execution passes command environment overrides", async () => {

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -63,13 +63,14 @@ test("CLI --check prints installed status and numeric versions for all agents", 
 
     const output = stdout.join("");
     assert.equal(code, 0);
-    assert.match(output, /^Agent\s+Status\s+Auth\s+Version\s+Binary/m);
-    assert.match(output, /^codex\s+✓\s+-\s+1\.2\.3\s+codex$/m);
-    assert.match(output, /^gemini\s+✓\s+-\s+0\.39\.1\s+gemini$/m);
-    assert.match(output, /^opencode\s+✓\s+-\s+1\.4\.10\s+opencode$/m);
-    assert.match(output, /^pi\s+✓\s+-\s+4\.5\.6\s+pi-agent$/m);
-    assert.match(output, /^claude\s+✗\s+-\s+-\s+claude$/m);
-    assert.match(output, /^cursor\s+✗\s+-\s+-\s+agent$/m);
+    assert.match(output, /^\+[-+]+\+$/m);
+    assert.match(output, /^\| Agent\s+\| Status\s+\| Auth\s+\| Version\s+\| Binary\s+\|$/m);
+    assert.match(output, /^\| codex\s+\| ✓\s+\| -\s+\| 1\.2\.3\s+\| codex\s+\|$/m);
+    assert.match(output, /^\| gemini\s+\| ✓\s+\| -\s+\| 0\.39\.1\s+\| gemini\s+\|$/m);
+    assert.match(output, /^\| opencode\s+\| ✓\s+\| -\s+\| 1\.4\.10\s+\| opencode\s+\|$/m);
+    assert.match(output, /^\| pi\s+\| ✓\s+\| -\s+\| 4\.5\.6\s+\| pi-agent\s+\|$/m);
+    assert.match(output, /^\| claude\s+\| ✗\s+\| -\s+\| -\s+\| claude\s+\|$/m);
+    assert.match(output, /^\| cursor\s+\| ✗\s+\| -\s+\| -\s+\| agent\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -97,7 +98,7 @@ test("CLI --check uses cursor env binary and strips hash suffixes", async () => 
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^cursor\s+✓\s+-\s+2026\.04\.17\s+cursor-agent$/m);
+    assert.match(stdout.join(""), /^\| cursor\s+\| ✓\s+\| -\s+\| 2026\.04\.17\s+\| cursor-agent\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -125,7 +126,7 @@ test("CLI --check keeps installed status when version probe fails", async () => 
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^cursor\s+✓\s+-\s+unknown\s+cursor-agent$/m);
+    assert.match(stdout.join(""), /^\| cursor\s+\| ✓\s+\| -\s+\| unknown\s+\| cursor-agent\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -157,7 +158,7 @@ test("CLI --check retries transient empty version output", async () => {
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^cursor\s+✓\s+-\s+9\.8\.7\s+cursor-agent$/m);
+    assert.match(stdout.join(""), /^\| cursor\s+\| ✓\s+\| -\s+\| 9\.8\.7\s+\| cursor-agent\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -186,8 +187,8 @@ test("CLI --check reports docker and default image status", async () => {
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^Docker\s+Status\s+Version\s+Default image$/m);
-    assert.match(stdout.join(""), /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/roberttlange\/headless:latest \(present\)$/m);
+    assert.match(stdout.join(""), /^\| Docker\s+\| Status\s+\| Version\s+\| Default image\s+\|$/m);
+    assert.match(stdout.join(""), /^\| docker\s+\| ✓\s+\| 27\.1\.2\s+\| ghcr\.io\/roberttlange\/headless:latest \(present\)\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -203,9 +204,9 @@ test("CLI --check reports API auth from environment variables", async () => {
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^codex\s+✗\s+api\s+-\s+codex$/m);
-    assert.match(stdout.join(""), /^opencode\s+✗\s+api\s+-\s+opencode$/m);
-    assert.match(stdout.join(""), /^pi\s+✗\s+api\s+-\s+pi$/m);
+    assert.match(stdout.join(""), /^\| codex\s+\| ✗\s+\| api\s+\| -\s+\| codex\s+\|$/m);
+    assert.match(stdout.join(""), /^\| opencode\s+\| ✗\s+\| api\s+\| -\s+\| opencode\s+\|$/m);
+    assert.match(stdout.join(""), /^\| pi\s+\| ✗\s+\| api\s+\| -\s+\| pi\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -225,7 +226,7 @@ test("CLI --check reports OAuth auth from local seed files", async () => {
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^codex\s+✗\s+oauth\s+-\s+codex$/m);
+    assert.match(stdout.join(""), /^\| codex\s+\| ✗\s+\| oauth\s+\| -\s+\| codex\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -245,7 +246,7 @@ test("CLI --check reports combined API and OAuth auth", async () => {
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^codex\s+✗\s+api\+oauth\s+-\s+codex$/m);
+    assert.match(stdout.join(""), /^\| codex\s+\| ✗\s+\| api\+oauth\s+\| -\s+\| codex\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -266,7 +267,7 @@ test("CLI --check reports Pi API auth from AWS credentials for Bedrock provider"
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^pi\s+✗\s+api\s+-\s+pi$/m);
+    assert.match(stdout.join(""), /^\| pi\s+\| ✗\s+\| api\s+\| -\s+\| pi\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -282,7 +283,7 @@ test("CLI --check does not report Pi AWS auth for the default OpenAI provider", 
     });
 
     assert.equal(code, 0);
-    assert.match(stdout.join(""), /^pi\s+✗\s+-\s+-\s+pi$/m);
+    assert.match(stdout.join(""), /^\| pi\s+\| ✗\s+\| -\s+\| -\s+\| pi\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1218,7 +1218,7 @@ test("CLI docker doctor reports image status and local build guidance", async ()
 
     const output = stdout.join("");
     assert.equal(code, 0);
-    assert.match(output, /^docker\s+✓\s+27\.1\.2\s+ghcr\.io\/roberttlange\/headless:latest \(missing\)$/m);
+    assert.match(output, /^\| docker\s+\| ✓\s+\| 27\.1\.2\s+\| ghcr\.io\/roberttlange\/headless:latest \(missing\)\s+\|$/m);
     assert.match(output, /Plain `headless --docker` will let Docker pull the default image automatically\./);
     assert.match(output, /For local development, run: headless docker build/);
   } finally {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -308,8 +308,6 @@ test("builds native session commands for supported agents", () => {
       "-p",
       "--session-id",
       "11111111-1111-4111-8111-111111111111",
-      "--name",
-      "work",
       "hello",
       "--output-format",
       "stream-json",

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1792,6 +1792,17 @@ test("CLI help lists usage output option", async () => {
   assert.match(stdout.join(""), /--usage/);
 });
 
+test("CLI --version prints package version", async () => {
+  const stdout: string[] = [];
+  const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as { version: string };
+  const code = await runCli(["--version"], {
+    stdout: (text) => stdout.push(text),
+  });
+
+  assert.equal(code, 0);
+  assert.equal(stdout.join(""), `${packageJson.version}\n`);
+});
+
 test("CLI --tmux launches an interactive tmux session and sends the prompt", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
@@ -2659,6 +2670,18 @@ test("CLI entrypoint runs when invoked as a script", () => {
 
   assert.equal(run.status, 0);
   assert.match(run.stdout, /Usage: headless \[agent\]/);
+});
+
+test("CLI entrypoint prints version", () => {
+  const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as { version: string };
+  const run = spawnSync(
+    process.execPath,
+    ["--import", "tsx", join(repoRoot, "src", "cli.ts"), "--version"],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(run.status, 0);
+  assert.equal(run.stdout, `${packageJson.version}\n`);
 });
 
 test("CLI help lists all Modal options", async () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import { buildAgentCommand, buildInteractiveAgentCommand, getAgentConfig, listAgents } from "../src/agents.ts";
 import { runCli } from "../src/cli.ts";
+import { parseHeadlessConfig } from "../src/config.ts";
 import { DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
 import type { AgentName } from "../src/types.ts";
@@ -650,6 +651,163 @@ test("CLI falls back to built-in defaults when ~/.headless/config.toml is missin
       stdout.join(""),
       "opencode run --format json --model openai/gpt-5.4 --dangerously-skip-permissions hello\n",
     );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("config parser accepts role sections and validates role fields", () => {
+  assert.deepEqual(
+    parseHeadlessConfig(
+      [
+        "[roles.explorer]",
+        'allow = "read-only"',
+        'reasoning_effort = "high"',
+        'base_instruction_prompt = """',
+        "Configured explorer prompt.",
+        '"""',
+        "",
+      ].join("\n"),
+    ).roles.explorer,
+    {
+      allow: "read-only",
+      reasoningEffort: "high",
+      baseInstructionPrompt: "Configured explorer prompt.",
+    },
+  );
+
+  assert.throws(() => parseHeadlessConfig("[roles.scout]\nallow = \"read-only\"\n"), /unsupported headless config role/);
+  assert.throws(() => parseHeadlessConfig("[roles.explorer]\nunknown = \"value\"\n"), /unsupported headless role config key/);
+  assert.throws(() => parseHeadlessConfig("[roles.explorer]\nallow = \"maybe\"\n"), /unsupported headless config allow/);
+  assert.throws(
+    () => parseHeadlessConfig("[roles.explorer]\nreasoning_effort = \"max\"\n"),
+    /unsupported headless config reasoning_effort/,
+  );
+});
+
+test("CLI applies configured role defaults and replaces the built-in role prompt", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    mkdirSync(join(home, ".headless"), { recursive: true });
+    writeFileSync(
+      join(home, ".headless", "config.toml"),
+      [
+        "[roles.explorer]",
+        'allow = "yolo"',
+        'reasoning_effort = "high"',
+        'base_instruction_prompt = """',
+        "Configured explorer prompt.",
+        '"""',
+        "",
+      ].join("\n"),
+    );
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--role", "explorer", "--prompt", "hello", "--print-command"], {
+      env: { ...process.env, HOME: home },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    const output = stdout.join("");
+    assert.match(output, /codex --dangerously-bypass-approvals-and-sandbox exec --model gpt-5\.5/);
+    assert.match(output, /-c 'model_reasoning_effort="high"'/);
+    assert.match(output, /Configured explorer prompt/);
+    assert.match(output, /User prompt:/);
+    assert.doesNotMatch(output, /Stay read-only/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI flags override configured role allow and reasoning effort", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    mkdirSync(join(home, ".headless"), { recursive: true });
+    writeFileSync(
+      join(home, ".headless", "config.toml"),
+      ["[roles.explorer]", 'model = "gpt-role"', 'allow = "read-only"', 'reasoning_effort = "high"', ""].join("\n"),
+    );
+
+    const stdout: string[] = [];
+    const code = await runCli(
+      [
+        "codex",
+        "--role",
+        "explorer",
+        "--model",
+        "gpt-cli",
+        "--allow",
+        "yolo",
+        "--reasoning-effort",
+        "low",
+        "--prompt",
+        "hello",
+        "--print-command",
+      ],
+      { env: { ...process.env, HOME: home }, stdout: (text) => stdout.push(text) },
+    );
+
+    assert.equal(code, 0);
+    const output = stdout.join("");
+    assert.match(output, /codex --dangerously-bypass-approvals-and-sandbox exec --model gpt-cli/);
+    assert.match(output, /-c 'model_reasoning_effort="low"'/);
+    assert.doesNotMatch(output, /--sandbox read-only/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("environment model overrides stay above role config", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    mkdirSync(join(home, ".headless"), { recursive: true });
+    writeFileSync(
+      join(home, ".headless", "config.toml"),
+      ["[agents.codex]", 'model = "gpt-agent"', "", "[roles.worker]", 'model = "gpt-role"', ""].join("\n"),
+    );
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--role", "worker", "--prompt", "hello", "--print-command"], {
+      env: { ...process.env, HOME: home, CODEX_MODEL: "gpt-env" },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /codex --dangerously-bypass-approvals-and-sandbox exec --model gpt-env/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("role config model is optional and falls back to agent config", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    mkdirSync(join(home, ".headless"), { recursive: true });
+    writeFileSync(
+      join(home, ".headless", "config.toml"),
+      [
+        "[agents.opencode]",
+        'model = "openai/gpt-agent"',
+        "",
+        "[roles.worker]",
+        'reasoning_effort = "high"',
+        "",
+      ].join("\n"),
+    );
+
+    const stdout: string[] = [];
+    const code = await runCli(["opencode", "--role", "worker", "--prompt", "hello", "--print-command"], {
+      env: { ...process.env, HOME: home },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /opencode run --format json --model openai\/gpt-agent --variant high/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
-test("pre-push hook defaults local integration tests to Codex only", () => {
+test("pre-push hook defaults local integration tests to Claude only", () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-hook-test-"));
   try {
     const binDir = join(dir, "bin");
@@ -38,7 +38,7 @@ test("pre-push hook defaults local integration tests to Codex only", () => {
     const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => line.split("\t"));
     assert.deepEqual(calls, [
       ["run build", "", "", ""],
-      ["run test:integration:local", join(repoRoot, "dist", "cli.js"), "codex", "0"],
+      ["run test:integration:local", join(repoRoot, "dist", "cli.js"), "claude", "0"],
     ]);
   } finally {
     rmSync(dir, { force: true, recursive: true });

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -18,7 +18,7 @@ test("pre-push hook defaults local integration tests to Codex only", () => {
       join(binDir, "npm"),
       [
         "#!/bin/sh",
-        "printf '%s\\t%s\\t%s\\n' \"$*\" \"${HEADLESS_BIN:-}\" \"${HEADLESS_INTEGRATION_AGENTS:-}\" >> \"$HEADLESS_HOOK_CAPTURE\"",
+        "printf '%s\\t%s\\t%s\\t%s\\n' \"$*\" \"${HEADLESS_BIN:-}\" \"${HEADLESS_INTEGRATION_AGENTS:-}\" \"${HEADLESS_INTEGRATION_FULL_SWEEP:-}\" >> \"$HEADLESS_HOOK_CAPTURE\"",
         "exit 0",
         "",
       ].join("\n"),
@@ -37,8 +37,8 @@ test("pre-push hook defaults local integration tests to Codex only", () => {
     assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
     const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => line.split("\t"));
     assert.deepEqual(calls, [
-      ["run build", "", ""],
-      ["run test:integration:local", join(repoRoot, "dist", "cli.js"), "codex"],
+      ["run build", "", "", ""],
+      ["run test:integration:local", join(repoRoot, "dist", "cli.js"), "codex", "0"],
     ]);
   } finally {
     rmSync(dir, { force: true, recursive: true });
@@ -55,7 +55,7 @@ test("pre-push hook can opt into all local integration agents", () => {
       join(binDir, "npm"),
       [
         "#!/bin/sh",
-        "printf '%s\\t%s\\t%s\\n' \"$*\" \"${HEADLESS_BIN:-}\" \"${HEADLESS_INTEGRATION_AGENTS:-}\" >> \"$HEADLESS_HOOK_CAPTURE\"",
+        "printf '%s\\t%s\\t%s\\t%s\\n' \"$*\" \"${HEADLESS_BIN:-}\" \"${HEADLESS_INTEGRATION_AGENTS:-}\" \"${HEADLESS_INTEGRATION_FULL_SWEEP:-}\" >> \"$HEADLESS_HOOK_CAPTURE\"",
         "exit 0",
         "",
       ].join("\n"),
@@ -75,8 +75,8 @@ test("pre-push hook can opt into all local integration agents", () => {
     assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
     const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => line.split("\t"));
     assert.deepEqual(calls, [
-      ["run build", "", ""],
-      ["run test:integration:local", join(repoRoot, "dist", "cli.js"), "all"],
+      ["run build", "", "", ""],
+      ["run test:integration:local", join(repoRoot, "dist", "cli.js"), "all", "1"],
     ]);
   } finally {
     rmSync(dir, { force: true, recursive: true });

--- a/tests/integration-local.test.ts
+++ b/tests/integration-local.test.ts
@@ -15,6 +15,7 @@ import test from "node:test";
 
 const agents = ["claude", "codex", "cursor", "gemini", "opencode", "pi"] as const;
 const selectedAgents = parseSelectedAgents(process.env.HEADLESS_INTEGRATION_AGENTS);
+const fullIntegrationSweep = process.env.HEADLESS_INTEGRATION_FULL_SWEEP === "1";
 const commandTimeoutMs = Number.parseInt(process.env.HEADLESS_INTEGRATION_TIMEOUT_MS ?? "300000", 10);
 const dockerTimeoutMs = Number.parseInt(process.env.HEADLESS_INTEGRATION_DOCKER_TIMEOUT_MS ?? "900000", 10);
 const modalTimeoutMs = Number.parseInt(process.env.HEADLESS_INTEGRATION_MODAL_TIMEOUT_MS ?? "1200000", 10);
@@ -133,6 +134,23 @@ function prompt(nonce: string): string {
   return `Read-only check. Reply with this nonce and no file edits: ${nonce}`;
 }
 
+function orchestratePrompt(runId: string, nonce: string): string {
+  const headlessCommand = process.env.HEADLESS_BIN ?? "headless";
+  const nodes = agents.map((agent) => `explorer-${agent}`).join(", ");
+  return [
+    "Build auth.",
+    "",
+    `This is a full-agent Headless orchestration integration test. Nonce: ${nonce}.`,
+    "Do not edit files.",
+    `Use this exact Headless command prefix for every coordination command: ${headlessCommand}`,
+    `Launch every declared explorer node: ${nodes}.`,
+    `For each node, run: ${headlessCommand} run message ${runId} <node> --prompt "Read README.md and reply with the nonce ${nonce}, your node name, and no file edits." --async`,
+    `After launching all nodes, run: ${headlessCommand} run wait ${runId}`,
+    `Then run: ${headlessCommand} run view ${runId}`,
+    `Your final response must include: orchestration complete ${nonce}`,
+  ].join("\n");
+}
+
 function tempWorkdir(label: string): string {
   const dir = mkdtempSync(join(tmpdir(), `headless-${label}-`));
   writeFileSync(join(dir, "README.md"), `# ${label}\n\nTemporary Headless local integration workspace.\n`);
@@ -168,6 +186,10 @@ async function tempGitWorkdir(label: string): Promise<string> {
 
 function sessionsPath(): string {
   return join(process.env.HOME ?? homedir(), ".headless", "sessions.json");
+}
+
+function runPath(runId: string): string {
+  return join(process.env.HOME ?? homedir(), ".headless", "runs", runId);
 }
 
 function snapshotSessionStore(): () => void {
@@ -341,6 +363,59 @@ test("selected backends start and send to --tmux --session aliases", { timeout: 
     }
   }
 });
+
+test(
+  "full sweep orchestrates all agent explorers",
+  { timeout: commandTimeoutMs * (agents.length + 2) },
+  async (t) => {
+    if (!fullIntegrationSweep) {
+      t.skip("set HEADLESS_INTEGRATION_FULL_SWEEP=1 via HEADLESS_HOOK_ALL_AGENTS=1 to run full orchestration");
+      return;
+    }
+    assert.deepEqual([...selectedAgents].sort(), [...agents].sort(), "full orchestration requires all agents");
+
+    const dir = tempWorkdir("full-orchestrate");
+    const runId = `${suiteNonce}-full-orchestrate`.replace(/[^A-Za-z0-9_.-]/g, "-");
+    const nonce = `${runId}-nonce`;
+    try {
+      prepareAgentWorkdir("cursor", dir);
+      const result = await headless(
+        [
+          "codex",
+          "--work-dir",
+          dir,
+          "--role",
+          "orchestrator",
+          "--run",
+          runId,
+          "--node",
+          "orchestrator",
+          "--coordination",
+          "oneshot",
+          ...agents.flatMap((agent) => ["--team", `${agent}/explorer`]),
+          "--prompt",
+          orchestratePrompt(runId, nonce),
+        ],
+        { timeoutMs: commandTimeoutMs * (agents.length + 1) },
+      );
+      assertNonce(result, `orchestration complete ${nonce}`, "full-agent orchestrator");
+
+      assertSuccess(await headless(["run", "wait", runId], { timeoutMs: commandTimeoutMs }), "full-agent run wait");
+      const runRecord = JSON.parse(readFileSync(join(runPath(runId), "run.json"), "utf8")) as {
+        nodes: Record<string, { status: string; lastMessage?: string }>;
+      };
+      for (const agent of agents) {
+        const node = runRecord.nodes[`explorer-${agent}`];
+        assert.ok(node, `missing explorer-${agent} node`);
+        assert.equal(node.status, "idle", `explorer-${agent} did not finish`);
+        assert.match(node.lastMessage ?? "", new RegExp(escapeRegExp(nonce)), `explorer-${agent} did not report nonce`);
+      }
+    } finally {
+      rmSync(runPath(runId), { force: true, recursive: true });
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);
 
 test("Codex completes through Docker", { timeout: dockerTimeoutMs }, async () => {
   const dir = tempWorkdir("codex-docker");

--- a/tests/integration-local.test.ts
+++ b/tests/integration-local.test.ts
@@ -414,7 +414,7 @@ test(
       for (const agent of orchestrationAgents) {
         const node = runRecord.nodes[`explorer-${agent}`];
         assert.ok(node, `missing explorer-${agent} node`);
-        assert.equal(node.status, "idle", `explorer-${agent} did not finish`);
+        assert.equal(node.status, "done", `explorer-${agent} did not complete`);
         assert.match(node.lastMessage ?? "", new RegExp(escapeRegExp(nonce)), `explorer-${agent} did not report nonce`);
       }
     } finally {

--- a/tests/integration-local.test.ts
+++ b/tests/integration-local.test.ts
@@ -245,11 +245,11 @@ test("preflight verifies global Headless, selected backends, Docker, Modal, and 
   for (const agent of selectedAgents) {
     assert.match(
       check.stdout,
-      new RegExp(`^${agent}\\s+✓\\s+`, "m"),
+      new RegExp(`^\\|\\s+${agent}\\s+\\|\\s+✓\\s+\\|`, "m"),
       `missing ${agent} backend in \`headless --check\`; install and authenticate all six backends`,
     );
   }
-  assert.match(check.stdout, /^docker\s+✓\s+/m, "Docker must be installed and running");
+  assert.match(check.stdout, /^\|\s+docker\s+\|\s+✓\s+\|/m, "Docker must be installed and running");
 
   const docker = await run("docker", ["info"], { timeoutMs: 30000 });
   assertSuccess(docker, "docker info");

--- a/tests/integration-local.test.ts
+++ b/tests/integration-local.test.ts
@@ -126,6 +126,16 @@ function assertNonce(result: CommandResult, nonce: string, label: string): void 
   );
 }
 
+function assertAgentsAvailable(output: string, requiredAgents: readonly (typeof agents)[number][], label: string): void {
+  for (const agent of requiredAgents) {
+    assert.match(
+      output,
+      new RegExp(`^\\|\\s+${agent}\\s+\\|\\s+✓\\s+\\|`, "m"),
+      `missing ${agent} backend in \`${label}\`; install and authenticate all required backends`,
+    );
+  }
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -134,9 +144,9 @@ function prompt(nonce: string): string {
   return `Read-only check. Reply with this nonce and no file edits: ${nonce}`;
 }
 
-function orchestratePrompt(runId: string, nonce: string): string {
+function orchestratePrompt(runId: string, nonce: string, orchestrationAgents: readonly (typeof agents)[number][] = agents): string {
   const headlessCommand = process.env.HEADLESS_BIN ?? "headless";
-  const nodes = agents.map((agent) => `explorer-${agent}`).join(", ");
+  const nodes = orchestrationAgents.map((agent) => `explorer-${agent}`).join(", ");
   return [
     "Build auth.",
     "",
@@ -242,13 +252,7 @@ test("preflight verifies global Headless, selected backends, Docker, Modal, and 
 
   const check = await headless(["--check"], { timeoutMs: 120000 });
   assertSuccess(check, "headless --check");
-  for (const agent of selectedAgents) {
-    assert.match(
-      check.stdout,
-      new RegExp(`^\\|\\s+${agent}\\s+\\|\\s+✓\\s+\\|`, "m"),
-      `missing ${agent} backend in \`headless --check\`; install and authenticate all six backends`,
-    );
-  }
+  assertAgentsAvailable(check.stdout, selectedAgents, "headless --check");
   assert.match(check.stdout, /^\|\s+docker\s+\|\s+✓\s+\|/m, "Docker must be installed and running");
 
   const docker = await run("docker", ["info"], { timeoutMs: 30000 });
@@ -372,7 +376,10 @@ test(
       t.skip("set HEADLESS_INTEGRATION_FULL_SWEEP=1 via HEADLESS_HOOK_ALL_AGENTS=1 to run full orchestration");
       return;
     }
-    assert.deepEqual([...selectedAgents].sort(), [...agents].sort(), "full orchestration requires all agents");
+    const orchestrationAgents = agents;
+    const check = await headless(["--check"], { timeoutMs: 120000 });
+    assertSuccess(check, "headless --check before full-agent orchestration");
+    assertAgentsAvailable(check.stdout, orchestrationAgents, "headless --check before full-agent orchestration");
 
     const dir = tempWorkdir("full-orchestrate");
     const runId = `${suiteNonce}-full-orchestrate`.replace(/[^A-Za-z0-9_.-]/g, "-");
@@ -392,11 +399,11 @@ test(
           "orchestrator",
           "--coordination",
           "oneshot",
-          ...agents.flatMap((agent) => ["--team", `${agent}/explorer`]),
+          ...orchestrationAgents.flatMap((agent) => ["--team", `${agent}/explorer`]),
           "--prompt",
-          orchestratePrompt(runId, nonce),
+          orchestratePrompt(runId, nonce, orchestrationAgents),
         ],
-        { timeoutMs: commandTimeoutMs * (agents.length + 1) },
+        { timeoutMs: commandTimeoutMs * (orchestrationAgents.length + 1) },
       );
       assertNonce(result, `orchestration complete ${nonce}`, "full-agent orchestrator");
 
@@ -404,7 +411,7 @@ test(
       const runRecord = JSON.parse(readFileSync(join(runPath(runId), "run.json"), "utf8")) as {
         nodes: Record<string, { status: string; lastMessage?: string }>;
       };
-      for (const agent of agents) {
+      for (const agent of orchestrationAgents) {
         const node = runRecord.nodes[`explorer-${agent}`];
         assert.ok(node, `missing explorer-${agent} node`);
         assert.equal(node.status, "idle", `explorer-${agent} did not finish`);

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { extractAgentError, extractFinalMessage, extractUsageSummary, priceUsageSummary } from "../src/output.ts";
+import { extractRunNodeMetrics } from "../src/run-metrics.ts";
 
 test("extracts final Codex assistant message from JSONL trace", () => {
   const trace = [
@@ -254,6 +255,33 @@ test("extracts Claude usage and preserves native cost", () => {
     },
     pricingSource: "native",
     pricingStatus: "native",
+  });
+});
+
+test("extracts run node metrics from Claude result traces", () => {
+  const trace = JSON.stringify({
+    type: "result",
+    duration_ms: 123456,
+    duration_api_ms: 100000,
+    num_turns: 3,
+    total_cost_usd: 0.18331675,
+    usage: {
+      input_tokens: 3,
+      cache_creation_input_tokens: 29231,
+      cache_read_input_tokens: 0,
+      output_tokens: 8,
+    },
+  });
+
+  assert.deepEqual(extractRunNodeMetrics("claude", trace), {
+    turns: 3,
+    durationMs: 123456,
+    apiDurationMs: 100000,
+    totalCostUsd: 0.18331675,
+    inputTokens: 3,
+    cacheWriteTokens: 29231,
+    outputTokens: 8,
+    totalTokens: 29242,
   });
 });
 

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -430,6 +430,37 @@ test("run message --async records busy status, logs output, and marks completion
   }
 });
 
+test("run message --async print-command uses a non-login shell to preserve PATH", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { ...process.env, HOME: join(dir, "home") };
+    const stdout: string[] = [];
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "explorer-1",
+      role: "explorer",
+      agent: "claude",
+      coordination: "session",
+      status: "idle",
+      planned: true,
+      sessionAlias: "explorer-1",
+    });
+
+    assert.equal(
+      await runCli(["run", "message", "auth", "explorer-1", "--prompt", "continue", "--async", "--print-command"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    const output = stdout.join("");
+    assert.match(output, /^sh -c /);
+    assert.doesNotMatch(output, /^sh -lc /);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("Docker run coordination mounts the host run directory", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -795,6 +795,61 @@ test("run message --async records busy status, logs output, and marks completion
   }
 });
 
+test("run message --async logs child stderr before marking failure", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const fakeHeadless = join(binDir, "headless");
+    mkdirSync(home);
+    await writeExecutable(
+      fakeHeadless,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const args = process.argv.slice(2);",
+        "if (args[0] === 'run' && args[1] === 'mark') {",
+        "  const runId = args[2]; const nodeId = args[3]; const status = args[5];",
+        "  const file = path.join(process.env.HOME, '.headless', 'runs', runId, 'run.json');",
+        "  const run = JSON.parse(fs.readFileSync(file, 'utf8'));",
+        "  run.nodes[nodeId].status = status; run.nodes[nodeId].updatedAt = new Date().toISOString();",
+        "  fs.writeFileSync(file, JSON.stringify(run, null, 2) + '\\n');",
+        "  process.exit(0);",
+        "}",
+        "process.stderr.write('child boom before logging\\n');",
+        "process.exit(9);",
+        "",
+      ].join("\n"),
+    );
+    const env = { ...process.env, HEADLESS_CLI_BIN: fakeHeadless, HOME: home };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "pi",
+      coordination: "oneshot",
+      status: "idle",
+      planned: true,
+    });
+
+    assert.equal(
+      await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue", "--async"], {
+        env,
+        stdout: () => undefined,
+      }),
+      0,
+    );
+    await waitFor(() => readRun(env, "auth")?.nodes["worker-1"].status === "failed");
+    const stderrLog = readRun(env, "auth")?.nodes["worker-1"].logs?.stderr ?? "";
+    const stderrText = readFileSync(stderrLog, "utf8");
+    assert.match(stderrText, /child boom before logging/);
+    assert.match(stderrText, /async child exited with code 9/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("run message --async uses HEADLESS_BIN for detached child invocations", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {
@@ -880,6 +935,7 @@ test("run message --async print-command uses a non-login shell to preserve PATH"
     );
     const output = stdout.join("");
     assert.match(output, /^sh -c /);
+    assert.match(output, /trap /);
     assert.doesNotMatch(output, /^sh -lc /);
     assert.equal(readRun(env, "auth")?.nodes["explorer-1"].status, "idle");
     assert.equal(readRun(env, "auth")?.nodes["explorer-1"].lastMessage, undefined);

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -97,7 +97,7 @@ test("role defaults apply only when --allow is absent", async () => {
     }),
     0,
   );
-  assert.match(stdout.join(""), /codex --sandbox read-only --ask-for-approval never exec/);
+  assert.match(stdout.join(""), /codex --sandbox read-only --ask-for-approval never --search exec/);
 
   stdout.length = 0;
   assert.equal(

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { runCli } from "../src/cli.ts";
-import { acquireNodeLock, readRun, registerNode } from "../src/runs.ts";
+import { acquireNodeLock, readRun, registerNode, updateNodeStatus } from "../src/runs.ts";
 import { expandTeamSpecs, parseTeamSpec } from "../src/teams.ts";
 
 async function writeExecutable(path: string, source: string): Promise<void> {
@@ -132,6 +132,7 @@ test("orchestrator run registers declared team and injects run context", async (
         "const fs = require('node:fs');",
         "fs.writeFileSync(process.env.HEADLESS_STDIN_CAPTURE, fs.readFileSync(0, 'utf8'));",
         "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }));",
+        "console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1000, cached_input_tokens: 400, output_tokens: 100, reasoning_output_tokens: 25 } }));",
         "console.log(JSON.stringify({ type: 'agent_message', text: 'orchestrator final' }));",
         "",
       ].join("\n"),
@@ -167,6 +168,12 @@ test("orchestrator run registers declared team and injects run context", async (
     assert.equal(stdout.join(""), "orchestrator final\n");
     const run = readRun(env, "auth");
     assert.equal(run?.nodes.orchestrator.status, "idle");
+    assert.deepEqual(
+      run?.events.filter((event) => event.nodeId === "orchestrator" && event.type === "status_changed").map((event) => event.status),
+      ["busy"],
+    );
+    assert.equal(run?.nodes.orchestrator.metrics?.totalTokens, 1100);
+    assert.equal(run?.nodes.orchestrator.metrics?.outputTokens, 100);
     assert.equal(run?.nodes["worker-1"].status, "planned");
     assert.equal(run?.nodes["worker-2"].status, "planned");
     assert.equal(run?.nodes.reviewer.role, "reviewer");
@@ -220,15 +227,37 @@ test("run list, view, mark, and wait operate on local run state", async () => {
       dependsOn: ["orchestrator"],
       planned: true,
     });
+    updateNodeStatus(env, "auth", "orchestrator", "idle", "ready", {
+      turns: 3,
+      durationMs: 123456,
+      apiDurationMs: 100000,
+      totalCostUsd: 0.42,
+      inputTokens: 600,
+      cacheReadTokens: 400,
+      cacheWriteTokens: 0,
+      outputTokens: 100,
+      reasoningOutputTokens: 25,
+      totalTokens: 1100,
+    });
 
     const stdout: string[] = [];
     assert.equal(await runCli(["run", "list"], { env, stdout: (text) => stdout.push(text) }), 0);
-    assert.match(stdout.join(""), /auth\s+session\s+2 nodes/);
+    assert.match(stdout.join(""), /auth\s+session\s+2 nodes\s+0 active/);
+    assert.match(stdout.join(""), /UPDATED/);
+    assert.match(stdout.join(""), /AGE/);
 
     stdout.length = 0;
     assert.equal(await runCli(["run", "view", "auth"], { env, stdout: (text) => stdout.push(text) }), 0);
-    assert.match(stdout.join(""), /Graph/);
-    assert.match(stdout.join(""), /worker-1 \[planned\] depends: orchestrator/);
+    const view = stdout.join("");
+    assert.match(view, /created: .* updated: .* age:/);
+    assert.match(view, /status: 1 idle, 1 planned/);
+    assert.match(view, /Graph/);
+    assert.match(view, /orchestrator \[idle .* ago\] last: ready/);
+    assert.match(view, /worker-1 \[planned .* ago\] depends: orchestrator/);
+    assert.match(view, /Node details/);
+    assert.match(view, /NODE\s+ROLE\s+AGENT\s+STATUS\s+UPDATED\s+AGE\s+TURNS\s+DURATION\s+COST\s+TOKENS\s+LAST/);
+    assert.match(view, /orchestrator\s+orchestrator\s+codex\s+idle\s+.*\s+3\s+2m03s\s+\$0\.42\s+1\.1k\s+ready/);
+    assert.match(view, /worker-1\s+worker\s+codex\s+planned\s+.*\s+-\s+-\s+-\s+-/);
 
     stdout.length = 0;
     assert.equal(

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -504,6 +504,38 @@ test("run message routes tmux nodes through tmux buffers", async () => {
   }
 });
 
+test("tmux run launch failure marks the node failed", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    mkdirSync(home);
+    await writeExecutable(
+      join(binDir, "tmux"),
+      [
+        "#!/usr/bin/env node",
+        "process.stderr.write('tmux launch failed\\n');",
+        "process.exit(1);",
+        "",
+      ].join("\n"),
+    );
+    const env = { ...process.env, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` };
+    const stderr: string[] = [];
+
+    const code = await runCli(
+      ["codex", "--tmux", "--role", "worker", "--run", "auth", "--node", "worker-1", "--prompt", "hello"],
+      { env, stdout: () => undefined, stderr: (text) => stderr.push(text) },
+    );
+
+    assert.equal(code, 1);
+    assert.match(stderr.join(""), /tmux launch failed/);
+    assert.equal(readRun(env, "auth")?.nodes["worker-1"].status, "failed");
+    assert.match(readRun(env, "auth")?.nodes["worker-1"].lastMessage ?? "", /tmux command exited with code 1/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("run message --print-command does not execute or mutate session nodes", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -131,6 +131,11 @@ test("orchestrator run registers declared team and injects run context", async (
         "#!/usr/bin/env node",
         "const fs = require('node:fs');",
         "fs.writeFileSync(process.env.HEADLESS_STDIN_CAPTURE, fs.readFileSync(0, 'utf8'));",
+        "const runFile = process.env.HOME + '/.headless/runs/auth/run.json';",
+        "const run = JSON.parse(fs.readFileSync(runFile, 'utf8'));",
+        "run.nodes['worker-1'].status = 'idle';",
+        "run.nodes.reviewer.status = 'idle';",
+        "fs.writeFileSync(runFile, JSON.stringify(run, null, 2) + '\\n');",
         "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }));",
         "console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1000, cached_input_tokens: 400, output_tokens: 100, reasoning_output_tokens: 25 } }));",
         "console.log(JSON.stringify({ type: 'agent_message', text: 'orchestrator final' }));",
@@ -167,15 +172,16 @@ test("orchestrator run registers declared team and injects run context", async (
     assert.equal(code, 0);
     assert.equal(stdout.join(""), "orchestrator final\n");
     const run = readRun(env, "auth");
-    assert.equal(run?.nodes.orchestrator.status, "idle");
+    assert.equal(run?.nodes.orchestrator.status, "done");
     assert.deepEqual(
       run?.events.filter((event) => event.nodeId === "orchestrator" && event.type === "status_changed").map((event) => event.status),
       ["busy"],
     );
     assert.equal(run?.nodes.orchestrator.metrics?.totalTokens, 1100);
     assert.equal(run?.nodes.orchestrator.metrics?.outputTokens, 100);
-    assert.equal(run?.nodes["worker-1"].status, "planned");
+    assert.equal(run?.nodes["worker-1"].status, "done");
     assert.equal(run?.nodes["worker-2"].status, "planned");
+    assert.equal(run?.nodes.reviewer.status, "done");
     assert.equal(run?.nodes.reviewer.role, "reviewer");
     const orchestratorLog = readFileSync(run?.nodes.orchestrator.logs?.stdout ?? "", "utf8");
     assert.match(orchestratorLog, /node invocation/);

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -248,23 +248,25 @@ test("run list, view, mark, and wait operate on local run state", async () => {
 
     const stdout: string[] = [];
     assert.equal(await runCli(["run", "list"], { env, stdout: (text) => stdout.push(text) }), 0);
-    assert.match(stdout.join(""), /auth\s+session\s+2 nodes\s+0 active/);
+    assert.match(stdout.join(""), /^\+[-+]+\+$/m);
+    assert.match(stdout.join(""), /^\| auth\s+\| session\s+\| 2 nodes\s+\| 0 active\s+\| 1 idle, 1 planned\s+\|/m);
     assert.match(stdout.join(""), /UPDATED/);
     assert.match(stdout.join(""), /AGE/);
 
     stdout.length = 0;
     assert.equal(await runCli(["run", "view", "auth"], { env, stdout: (text) => stdout.push(text) }), 0);
     const view = stdout.join("");
-    assert.match(view, /created: .* updated: .* age:/);
-    assert.match(view, /status: 1 idle, 1 planned/);
+    assert.match(view, /Summary/);
+    assert.match(view, /^\| Status\s+\| 1 idle, 1 planned\s+\|$/m);
+    assert.match(view, /^\| Created\s+\| .* \|$/m);
     assert.match(view, /Graph/);
     assert.match(view, /orchestrator \[idle .* ago\] last: ready/);
     assert.match(view, /worker-1 \[planned .* ago\] depends: orchestrator/);
     assert.match(view, /Node details/);
-    assert.match(view, /NODE\s+ROLE\s+AGENT\s+STATUS\s+UPDATED\s+AGE\s+LAST/);
+    assert.match(view, /^\| NODE\s+\| ROLE\s+\| AGENT\s+\| STATUS\s+\| UPDATED\s+\| AGE\s+\| LAST\s+\|$/m);
     assert.doesNotMatch(view, /TURNS|DURATION|COST|TOKENS/);
-    assert.match(view, /orchestrator\s+orchestrator\s+codex\s+idle\s+.*\s+ready/);
-    assert.match(view, /worker-1\s+worker\s+codex\s+planned\s+.*\s+-/);
+    assert.match(view, /^\| orchestrator\s+\| orchestrator\s+\| codex\s+\| idle\s+\| .* \| .* \| ready\s+\|$/m);
+    assert.match(view, /^\| worker-1\s+\| worker\s+\| codex\s+\| planned\s+\| .* \| .* \| -\s+\|$/m);
 
     stdout.length = 0;
     assert.equal(

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -690,6 +690,42 @@ test("run message --print-command does not execute or mutate session nodes", asy
   }
 });
 
+test("run message does not record delivery when a session node is locked", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { ...process.env, HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "idle",
+      planned: true,
+      sessionAlias: "worker-1",
+    });
+    const release = acquireNodeLock(env, "auth", "worker-1");
+    try {
+      const stderr: string[] = [];
+      const code = await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue"], {
+        env,
+        stdout: () => undefined,
+        stderr: (text) => stderr.push(text),
+      });
+
+      assert.equal(code, 2);
+      assert.match(stderr.join(""), /node is locked: worker-1/);
+      const run = readRun(env, "auth");
+      assert.equal(run?.nodes["worker-1"].lastMessage, undefined);
+      assert.equal(run?.events.some((event) => event.type === "message_sent"), false);
+    } finally {
+      release();
+    }
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("run message --async records busy status, logs output, and marks completion", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -144,8 +144,10 @@ test("orchestrator run registers declared team and injects run context", async (
     );
 
     const stdout: string[] = [];
+    const stderr: string[] = [];
     const env = {
       ...process.env,
+      HEADLESS_RUN_STATUS_INTERVAL_MS: "1",
       HEADLESS_STDIN_CAPTURE: stdinCapture,
       HOME: home,
       PATH: `${binDir}:${process.env.PATH ?? ""}`,
@@ -166,11 +168,14 @@ test("orchestrator run registers declared team and injects run context", async (
         "--prompt",
         "Build auth",
       ],
-      { env, stdout: (text) => stdout.push(text) },
+      { env, stdout: (text) => stdout.push(text), stderr: (text) => stderr.push(text) },
     );
 
     assert.equal(code, 0);
     assert.equal(stdout.join(""), "orchestrator final\n");
+    assert.match(stderr.join(""), /^\d{4}-\d{2}-\d{2}T.* INFO  headless run auth started orchestrator \(4 nodes,/m);
+    assert.match(stderr.join(""), /^\d{4}-\d{2}-\d{2}T.* INFO  headless run auth orchestrator starting -> busy/m);
+    assert.match(stderr.join(""), /^\d{4}-\d{2}-\d{2}T.* OK    headless run auth idle \(0 active;/m);
     const run = readRun(env, "auth");
     assert.equal(run?.nodes.orchestrator.status, "done");
     assert.deepEqual(
@@ -194,6 +199,46 @@ test("orchestrator run registers declared team and injects run context", async (
     assert.match(prompt, /status becomes busy, logs are written/);
     assert.match(prompt, /headless run wait auth/);
     assert.match(prompt, /declared team:/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("orchestrator run status reporter stays off for json runs", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    mkdirSync(home);
+    await writeExecutable(
+      join(binDir, "codex"),
+      [
+        "#!/usr/bin/env node",
+        "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }));",
+        "console.log(JSON.stringify({ type: 'agent_message', text: 'orchestrator final' }));",
+        "",
+      ].join("\n"),
+    );
+
+    const env = {
+      ...process.env,
+      HEADLESS_RUN_STATUS_INTERVAL_MS: "1",
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    const stderr: string[] = [];
+    const stdout: string[] = [];
+
+    const code = await runCli(
+      ["codex", "--role", "orchestrator", "--run", "json-run", "--coordination", "oneshot", "--prompt", "Build auth", "--json"],
+      {
+        env,
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+      },
+    );
+    assert.equal(code, 0, stderr.join(""));
+    assert.doesNotMatch(stderr.join(""), /headless run json-run/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -444,6 +444,61 @@ test("run message routes tmux nodes through tmux buffers", async () => {
   }
 });
 
+test("run message --print-command does not execute or mutate session nodes", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "codex-args.jsonl");
+    mkdirSync(home);
+    await writeExecutable(
+      join(binDir, "codex"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+        "console.log(JSON.stringify({ type: 'agent_message', text: 'executed' }));",
+        "",
+      ].join("\n"),
+    );
+    const env = {
+      ...process.env,
+      HEADLESS_CAPTURE: captureFile,
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "idle",
+      lastMessage: undefined,
+      planned: true,
+      sessionAlias: "worker-1",
+    });
+    const before = readRun(env, "auth")?.nodes["worker-1"];
+
+    const stdout: string[] = [];
+    assert.equal(
+      await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue", "--print-command"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+
+    assert.match(stdout.join(""), /^headless codex --role worker --coordination session --run auth --node worker-1 --prompt continue/);
+    const after = readRun(env, "auth")?.nodes["worker-1"];
+    assert.equal(after?.status, before?.status);
+    assert.equal(after?.lastMessage, before?.lastMessage);
+    assert.equal(existsSync(captureFile), false);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("run message --async records busy status, logs output, and marks completion", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {
@@ -539,6 +594,8 @@ test("run message --async print-command uses a non-login shell to preserve PATH"
     const output = stdout.join("");
     assert.match(output, /^sh -c /);
     assert.doesNotMatch(output, /^sh -lc /);
+    assert.equal(readRun(env, "auth")?.nodes["explorer-1"].status, "idle");
+    assert.equal(readRun(env, "auth")?.nodes["explorer-1"].lastMessage, undefined);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -23,6 +24,31 @@ async function waitFor(assertion: () => boolean): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
   assert.equal(assertion(), true);
+}
+
+async function runStatusUpdater(env: NodeJS.ProcessEnv, runId: string, nodeId: string, barrierFile: string): Promise<number> {
+  return await new Promise((resolve) => {
+    const source = [
+      "import { existsSync } from 'node:fs';",
+      "import { updateNodeStatus } from './src/runs.ts';",
+      "while (!existsSync(process.env.HEADLESS_BARRIER_FILE)) {",
+      "  await new Promise((resolve) => setTimeout(resolve, 5));",
+      "}",
+      "updateNodeStatus(process.env, process.env.HEADLESS_TEST_RUN_ID, process.env.HEADLESS_TEST_NODE_ID, 'idle');",
+    ].join("\n");
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "-e", source], {
+      cwd: process.cwd(),
+      env: {
+        ...env,
+        HEADLESS_BARRIER_FILE: barrierFile,
+        HEADLESS_TEST_NODE_ID: nodeId,
+        HEADLESS_TEST_RUN_ID: runId,
+      },
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    child.on("close", (code) => resolve(code ?? 1));
+    child.on("error", () => resolve(127));
+  });
 }
 
 test("parses team specs and generated node names", () => {
@@ -84,6 +110,40 @@ test("run store registers nodes, records dependencies, and rejects concurrent lo
     assert.throws(() => acquireNodeLock(env, "auth", "worker-1"), /node is locked/);
     release();
     acquireNodeLock(env, "auth", "worker-1")();
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run store preserves concurrent status updates from async children", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { ...process.env, HOME: join(dir, "home") };
+    const runId = "race";
+    const nodeCount = 32;
+    const barrierFile = join(dir, "release-workers");
+    for (let index = 0; index < nodeCount; index += 1) {
+      registerNode(env, {
+        runId,
+        nodeId: `worker-${index}`,
+        role: "worker",
+        agent: "codex",
+        coordination: "oneshot",
+        status: "busy",
+        planned: true,
+      });
+    }
+
+    const updaters = Array.from({ length: nodeCount }, (_, index) =>
+      runStatusUpdater(env, runId, `worker-${index}`, barrierFile),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    writeFileSync(barrierFile, "go\n");
+
+    assert.deepEqual(await Promise.all(updaters), Array(nodeCount).fill(0));
+    const run = readRun(env, runId);
+    const idle = Object.values(run?.nodes ?? {}).filter((node) => node.status === "idle").length;
+    assert.equal(idle, nodeCount);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
 import { runCli } from "../src/cli.ts";
-import { acquireNodeLock, readRun, registerNode, updateNodeStatus } from "../src/runs.ts";
+import { acquireNodeLock, appendNodeLog, nodeLockPath, readRun, registerNode, updateNodeStatus } from "../src/runs.ts";
 import { expandTeamSpecs, parseTeamSpec } from "../src/teams.ts";
 
 async function writeExecutable(path: string, source: string): Promise<void> {
@@ -24,6 +24,10 @@ async function waitFor(assertion: () => boolean): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
   assert.equal(assertion(), true);
+}
+
+function modeOf(path: string): number {
+  return statSync(path).mode & 0o777;
 }
 
 async function runStatusUpdater(env: NodeJS.ProcessEnv, runId: string, nodeId: string, barrierFile: string): Promise<number> {
@@ -111,6 +115,42 @@ test("run store registers nodes, records dependencies, and rejects concurrent lo
     release();
     acquireNodeLock(env, "auth", "worker-1")();
   } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run store writes private run files, logs, and locks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  const previousUmask = process.umask(0);
+  try {
+    const env = { HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "planned",
+      planned: true,
+    });
+    appendNodeLog(env, "auth", "worker-1", "stdout", "private output\n");
+
+    const runDir = join(env.HOME, ".headless", "runs", "auth");
+    const nodeDir = join(runDir, "nodes", "worker-1");
+    assert.equal(modeOf(runDir), 0o700);
+    assert.equal(modeOf(nodeDir), 0o700);
+    assert.equal(modeOf(join(runDir, "run.json")), 0o600);
+    assert.equal(modeOf(join(runDir, "events.jsonl")), 0o600);
+    assert.equal(modeOf(join(nodeDir, "latest.stdout.log")), 0o600);
+
+    const release = acquireNodeLock(env, "auth", "worker-1");
+    try {
+      assert.equal(modeOf(nodeLockPath(env, "auth", "worker-1")), 0o600);
+    } finally {
+      release();
+    }
+  } finally {
+    process.umask(previousUmask);
     rmSync(dir, { force: true, recursive: true });
   }
 });

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -155,6 +155,39 @@ test("run store writes private run files, logs, and locks", () => {
   }
 });
 
+test("run store rejects dot segment run and node names", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { HOME: join(dir, "home") };
+    const node = {
+      role: "worker" as const,
+      agent: "codex" as const,
+      coordination: "session" as const,
+      status: "planned" as const,
+      planned: true,
+    };
+
+    assert.throws(
+      () => registerNode(env, { ...node, runId: ".", nodeId: "worker-1" }),
+      /invalid run/,
+    );
+    assert.throws(
+      () => registerNode(env, { ...node, runId: "..", nodeId: "worker-1" }),
+      /invalid run/,
+    );
+    assert.throws(
+      () => registerNode(env, { ...node, runId: "auth", nodeId: "." }),
+      /invalid node/,
+    );
+    assert.throws(
+      () => registerNode(env, { ...node, runId: "auth", nodeId: ".." }),
+      /invalid node/,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("run store preserves concurrent status updates from async children", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -390,6 +390,26 @@ test("orchestrator run rejects read-only mode because it must update run state",
   assert.match(stderr.join(""), /orchestrator with --run cannot use --allow read-only/);
 });
 
+test("run launch setup failures mark registered nodes failed", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { ...process.env, HOME: join(dir, "home"), PATH: dirname(process.execPath) };
+    const stderr: string[] = [];
+
+    const code = await runCli(
+      ["codex", "--role", "worker", "--run", "auth", "--node", "worker-1", "--prompt", "hello", "--docker"],
+      { env, stdout: () => undefined, stderr: (text) => stderr.push(text) },
+    );
+
+    assert.equal(code, 2);
+    assert.match(stderr.join(""), /docker not found on PATH/);
+    assert.equal(readRun(env, "auth")?.nodes["worker-1"].status, "failed");
+    assert.match(readRun(env, "auth")?.nodes["worker-1"].lastMessage ?? "", /docker not found on PATH/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("run list, view, mark, and wait operate on local run state", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -255,9 +255,10 @@ test("run list, view, mark, and wait operate on local run state", async () => {
     assert.match(view, /orchestrator \[idle .* ago\] last: ready/);
     assert.match(view, /worker-1 \[planned .* ago\] depends: orchestrator/);
     assert.match(view, /Node details/);
-    assert.match(view, /NODE\s+ROLE\s+AGENT\s+STATUS\s+UPDATED\s+AGE\s+TURNS\s+DURATION\s+COST\s+TOKENS\s+LAST/);
-    assert.match(view, /orchestrator\s+orchestrator\s+codex\s+idle\s+.*\s+3\s+2m03s\s+\$0\.42\s+1\.1k\s+ready/);
-    assert.match(view, /worker-1\s+worker\s+codex\s+planned\s+.*\s+-\s+-\s+-\s+-/);
+    assert.match(view, /NODE\s+ROLE\s+AGENT\s+STATUS\s+UPDATED\s+AGE\s+LAST/);
+    assert.doesNotMatch(view, /TURNS|DURATION|COST|TOKENS/);
+    assert.match(view, /orchestrator\s+orchestrator\s+codex\s+idle\s+.*\s+ready/);
+    assert.match(view, /worker-1\s+worker\s+codex\s+planned\s+.*\s+-/);
 
     stdout.length = 0;
     assert.equal(

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -499,6 +499,10 @@ test("run message routes tmux nodes through tmux buffers", async () => {
     );
     const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
     assert.deepEqual(calls[0], ["set-buffer", "-b", "headless-codex-worker-1-send", "continue"]);
+    const run = readRun(env, "auth");
+    assert.equal(run?.events.filter((event) => event.type === "message_sent").length, 1);
+    assert.equal(run?.events.find((event) => event.type === "message_sent")?.targetNodeId, "worker-1");
+    assert.equal(run?.nodes["worker-1"].lastMessage, "continue");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -298,7 +298,9 @@ test("orchestrator run status reporter stays off for json runs", async () => {
       },
     );
     assert.equal(code, 0, stderr.join(""));
+    assert.match(stdout.join(""), /"orchestrator final"/);
     assert.doesNotMatch(stderr.join(""), /headless run json-run/);
+    assert.equal(readRun(env, "json-run")?.nodes.orchestrator.lastMessage, "orchestrator final");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -153,6 +153,7 @@ test("orchestrator run registers declared team and injects run context", async (
     assert.equal(run?.nodes.reviewer.role, "reviewer");
     const prompt = readFileSync(stdinCapture, "utf8");
     assert.match(prompt, /Role: orchestrator/);
+    assert.match(prompt, /launch each planned child/);
     assert.match(prompt, /Coordination commands:/);
     assert.match(prompt, /Run headless --help for full command syntax/);
     assert.match(prompt, /status becomes busy, logs are written/);
@@ -161,6 +162,17 @@ test("orchestrator run registers declared team and injects run context", async (
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
+});
+
+test("orchestrator run rejects read-only mode because it must update run state", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(
+    ["codex", "--role", "orchestrator", "--run", "auth", "--allow", "read-only", "--prompt", "hello"],
+    { stderr: (text) => stderr.push(text) },
+  );
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /orchestrator with --run cannot use --allow read-only/);
 });
 
 test("run list, view, mark, and wait operate on local run state", async () => {
@@ -209,6 +221,25 @@ test("run list, view, mark, and wait operate on local run state", async () => {
     stdout.length = 0;
     assert.equal(await runCli(["run", "wait", "auth"], { env, stdout: (text) => stdout.push(text) }), 0);
     assert.equal(stdout.join(""), "run idle: auth\n");
+
+    registerNode(env, {
+      runId: "self-wait",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "starting",
+      planned: true,
+    });
+    stdout.length = 0;
+    assert.equal(
+      await runCli(["run", "wait", "self-wait"], {
+        env: { ...env, HEADLESS_RUN_NODE: "orchestrator" },
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "run idle: self-wait\n");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -60,6 +60,25 @@ test("run store registers nodes, records dependencies, and rejects concurrent lo
     assert.equal(run?.nodes["worker-1"].dependsOn[0], "explorer");
     assert.equal(run?.nodes["worker-1"].logs?.stdout.endsWith("latest.stdout.log"), true);
     assert.equal(existsSync(join(env.HOME, ".headless", "runs", "auth", "run.json")), true);
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "busy",
+      planned: true,
+    });
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "starting",
+      planned: true,
+    });
+    assert.equal(readRun(env, "auth")?.nodes["worker-1"].status, "busy");
 
     const release = acquireNodeLock(env, "auth", "worker-1");
     assert.throws(() => acquireNodeLock(env, "auth", "worker-1"), /node is locked/);
@@ -151,6 +170,9 @@ test("orchestrator run registers declared team and injects run context", async (
     assert.equal(run?.nodes["worker-1"].status, "planned");
     assert.equal(run?.nodes["worker-2"].status, "planned");
     assert.equal(run?.nodes.reviewer.role, "reviewer");
+    const orchestratorLog = readFileSync(run?.nodes.orchestrator.logs?.stdout ?? "", "utf8");
+    assert.match(orchestratorLog, /node invocation/);
+    assert.match(orchestratorLog, /orchestrator final/);
     const prompt = readFileSync(stdinCapture, "utf8");
     assert.match(prompt, /Role: orchestrator/);
     assert.match(prompt, /launch each planned child/);
@@ -287,6 +309,10 @@ test("run message resumes stored session nodes", async () => {
       0,
     );
     assert.equal(stdout.join(""), "resumed final\n");
+    const run = readRun(env, "auth");
+    const workerLog = readFileSync(run?.nodes["worker-1"].logs?.stdout ?? "", "utf8");
+    assert.match(workerLog, /started final/);
+    assert.match(workerLog, /resumed final/);
     const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
     assert.equal(calls[1].includes("resume"), true);
     assert.equal(calls[1].includes("thread-1"), true);
@@ -352,6 +378,7 @@ test("run message --async records busy status, logs output, and marks completion
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
         "if (args[0] === 'run' && args[1] === 'mark') {",
+        "  console.log('marked fake');",
         "  const runId = args[2]; const nodeId = args[3]; const status = args[5];",
         "  const file = path.join(process.env.HOME, '.headless', 'runs', runId, 'run.json');",
         "  const run = JSON.parse(fs.readFileSync(file, 'utf8'));",
@@ -359,7 +386,14 @@ test("run message --async records busy status, logs output, and marks completion
         "  fs.writeFileSync(file, JSON.stringify(run, null, 2) + '\\n');",
         "  process.exit(0);",
         "}",
-        "console.log('async child output');",
+        "const runIndex = args.indexOf('--run'); const nodeIndex = args.indexOf('--node');",
+        "if (runIndex !== -1 && nodeIndex !== -1) {",
+        "  const runId = args[runIndex + 1]; const nodeId = args[nodeIndex + 1];",
+        "  const dir = path.join(process.env.HOME, '.headless', 'runs', runId, 'nodes', nodeId);",
+        "  fs.mkdirSync(dir, { recursive: true });",
+        "  fs.appendFileSync(path.join(dir, 'latest.stdout.log'), 'async child output\\n');",
+        "}",
+        "console.log('async child output should not be wrapper-redirected');",
         "",
       ].join("\n"),
     );
@@ -373,6 +407,8 @@ test("run message --async records busy status, logs output, and marks completion
       status: "idle",
       planned: true,
     });
+    const initialStdoutLog = readRun(env, "auth")?.nodes["worker-1"].logs?.stdout ?? "";
+    writeFileSync(initialStdoutLog, "previous output\\n");
 
     assert.equal(
       await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue", "--async"], {
@@ -385,6 +421,10 @@ test("run message --async records busy status, logs output, and marks completion
     await waitFor(() => readRun(env, "auth")?.nodes["worker-1"].status === "idle");
     const stdoutLog = readRun(env, "auth")?.nodes["worker-1"].logs?.stdout ?? "";
     await waitFor(() => existsSync(stdoutLog) && readFileSync(stdoutLog, "utf8").includes("async child output"));
+    const stdoutText = readFileSync(stdoutLog, "utf8");
+    assert.match(stdoutText, /previous output/);
+    assert.doesNotMatch(stdoutText, /marked fake/);
+    assert.doesNotMatch(stdoutText, /wrapper-redirected/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 
 import { runCli } from "../src/cli.ts";
@@ -563,6 +563,66 @@ test("run message --async records busy status, logs output, and marks completion
     assert.match(stdoutText, /previous output/);
     assert.doesNotMatch(stdoutText, /marked fake/);
     assert.doesNotMatch(stdoutText, /wrapper-redirected/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run message --async uses HEADLESS_BIN for detached child invocations", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const fakeHeadless = join(binDir, "headless-under-test");
+    const captureFile = join(dir, "headless-args.jsonl");
+    mkdirSync(home);
+    await writeExecutable(
+      fakeHeadless,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
+        "if (args[0] === 'run' && args[1] === 'mark') {",
+        "  const runId = args[2]; const nodeId = args[3]; const status = args[5];",
+        "  const file = path.join(process.env.HOME, '.headless', 'runs', runId, 'run.json');",
+        "  const run = JSON.parse(fs.readFileSync(file, 'utf8'));",
+        "  run.nodes[nodeId].status = status; run.nodes[nodeId].updatedAt = new Date().toISOString();",
+        "  fs.writeFileSync(file, JSON.stringify(run, null, 2) + '\\n');",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    const env = {
+      ...process.env,
+      HEADLESS_BIN: fakeHeadless,
+      HEADLESS_CAPTURE: captureFile,
+      HEADLESS_CLI_BIN: undefined,
+      HOME: home,
+      PATH: `${dirname(process.execPath)}:/bin:/usr/bin`,
+    };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "pi",
+      coordination: "oneshot",
+      status: "idle",
+      planned: true,
+    });
+
+    assert.equal(
+      await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue", "--async"], {
+        env,
+        stdout: () => undefined,
+      }),
+      0,
+    );
+    await waitFor(() => readRun(env, "auth")?.nodes["worker-1"].status === "idle");
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(calls[0].slice(0, 7), ["pi", "--role", "worker", "--coordination", "oneshot", "--run", "auth"]);
+    assert.deepEqual(calls.at(-1), ["run", "mark", "auth", "worker-1", "--status", "idle"]);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -1,0 +1,391 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { runCli } from "../src/cli.ts";
+import { acquireNodeLock, readRun, registerNode } from "../src/runs.ts";
+import { expandTeamSpecs, parseTeamSpec } from "../src/teams.ts";
+
+async function writeExecutable(path: string, source: string): Promise<void> {
+  await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, source);
+    await chmod(path, 0o755);
+  });
+}
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  assert.equal(assertion(), true);
+}
+
+test("parses team specs and generated node names", () => {
+  assert.deepEqual(parseTeamSpec("worker=2"), { agent: undefined, role: "worker", count: 2 });
+  assert.deepEqual(parseTeamSpec("claude/reviewer"), { agent: "claude", role: "reviewer", count: 1 });
+  assert.deepEqual(
+    expandTeamSpecs("codex", ["worker=2", "claude/reviewer", "codex/reviewer"]),
+    [
+      { agent: "codex", role: "worker", nodeId: "worker-1", planned: true },
+      { agent: "codex", role: "worker", nodeId: "worker-2", planned: true },
+      { agent: "claude", role: "reviewer", nodeId: "reviewer-claude", planned: true },
+      { agent: "codex", role: "reviewer", nodeId: "reviewer-codex", planned: true },
+    ],
+  );
+  assert.throws(() => parseTeamSpec("worker=0"), /team count must be positive/);
+  assert.throws(() => parseTeamSpec("unknown/worker"), /unsupported team agent/);
+});
+
+test("run store registers nodes, records dependencies, and rejects concurrent locks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "planned",
+      dependsOn: ["explorer"],
+      planned: true,
+      sessionAlias: "worker-1",
+    });
+    const run = readRun(env, "auth");
+    assert.equal(run?.nodes["worker-1"].dependsOn[0], "explorer");
+    assert.equal(run?.nodes["worker-1"].logs?.stdout.endsWith("latest.stdout.log"), true);
+    assert.equal(existsSync(join(env.HOME, ".headless", "runs", "auth", "run.json")), true);
+
+    const release = acquireNodeLock(env, "auth", "worker-1");
+    assert.throws(() => acquireNodeLock(env, "auth", "worker-1"), /node is locked/);
+    release();
+    acquireNodeLock(env, "auth", "worker-1")();
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("role defaults apply only when --allow is absent", async () => {
+  const stdout: string[] = [];
+  assert.equal(
+    await runCli(["codex", "--role", "explorer", "--prompt", "hello", "--print-command"], {
+      stdout: (text) => stdout.push(text),
+    }),
+    0,
+  );
+  assert.match(stdout.join(""), /codex --sandbox read-only --ask-for-approval never exec/);
+
+  stdout.length = 0;
+  assert.equal(
+    await runCli(["codex", "--role", "explorer", "--allow", "yolo", "--prompt", "hello", "--print-command"], {
+      stdout: (text) => stdout.push(text),
+    }),
+    0,
+  );
+  assert.match(stdout.join(""), /codex --dangerously-bypass-approvals-and-sandbox exec/);
+
+  stdout.length = 0;
+  assert.equal(
+    await runCli(["codex", "--role", "worker", "--prompt", "hello", "--print-command"], {
+      stdout: (text) => stdout.push(text),
+    }),
+    0,
+  );
+  assert.match(stdout.join(""), /codex --dangerously-bypass-approvals-and-sandbox exec/);
+});
+
+test("orchestrator run registers declared team and injects run context", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const stdinCapture = join(dir, "stdin.txt");
+    mkdirSync(home);
+    await writeExecutable(
+      join(binDir, "codex"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "fs.writeFileSync(process.env.HEADLESS_STDIN_CAPTURE, fs.readFileSync(0, 'utf8'));",
+        "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }));",
+        "console.log(JSON.stringify({ type: 'agent_message', text: 'orchestrator final' }));",
+        "",
+      ].join("\n"),
+    );
+
+    const stdout: string[] = [];
+    const env = {
+      ...process.env,
+      HEADLESS_STDIN_CAPTURE: stdinCapture,
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    const code = await runCli(
+      [
+        "codex",
+        "--role",
+        "orchestrator",
+        "--run",
+        "auth",
+        "--node",
+        "orchestrator",
+        "--team",
+        "worker=2",
+        "--team",
+        "claude/reviewer",
+        "--prompt",
+        "Build auth",
+      ],
+      { env, stdout: (text) => stdout.push(text) },
+    );
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "orchestrator final\n");
+    const run = readRun(env, "auth");
+    assert.equal(run?.nodes.orchestrator.status, "idle");
+    assert.equal(run?.nodes["worker-1"].status, "planned");
+    assert.equal(run?.nodes["worker-2"].status, "planned");
+    assert.equal(run?.nodes.reviewer.role, "reviewer");
+    const prompt = readFileSync(stdinCapture, "utf8");
+    assert.match(prompt, /Role: orchestrator/);
+    assert.match(prompt, /Coordination commands:/);
+    assert.match(prompt, /Run headless --help for full command syntax/);
+    assert.match(prompt, /status becomes busy, logs are written/);
+    assert.match(prompt, /headless run wait auth/);
+    assert.match(prompt, /declared team:/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run list, view, mark, and wait operate on local run state", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { ...process.env, HOME: join(dir, "home"), HEADLESS_RUN_WAIT_INTERVAL_MS: "1" };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "idle",
+      planned: true,
+    });
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "planned",
+      dependsOn: ["orchestrator"],
+      planned: true,
+    });
+
+    const stdout: string[] = [];
+    assert.equal(await runCli(["run", "list"], { env, stdout: (text) => stdout.push(text) }), 0);
+    assert.match(stdout.join(""), /auth\s+session\s+2 nodes/);
+
+    stdout.length = 0;
+    assert.equal(await runCli(["run", "view", "auth"], { env, stdout: (text) => stdout.push(text) }), 0);
+    assert.match(stdout.join(""), /Graph/);
+    assert.match(stdout.join(""), /worker-1 \[planned\] depends: orchestrator/);
+
+    stdout.length = 0;
+    assert.equal(
+      await runCli(["run", "mark", "auth", "worker-1", "--status", "done"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(readRun(env, "auth")?.nodes["worker-1"].status, "done");
+
+    stdout.length = 0;
+    assert.equal(await runCli(["run", "wait", "auth"], { env, stdout: (text) => stdout.push(text) }), 0);
+    assert.equal(stdout.join(""), "run idle: auth\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run message resumes stored session nodes", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "codex-args.jsonl");
+    mkdirSync(home);
+    await writeExecutable(
+      join(binDir, "codex"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
+        "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }));",
+        "console.log(JSON.stringify({ type: 'agent_message', text: args.includes('resume') ? 'resumed final' : 'started final' }));",
+        "",
+      ].join("\n"),
+    );
+    const env = {
+      ...process.env,
+      HEADLESS_CAPTURE: captureFile,
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    assert.equal(
+      await runCli(
+        ["codex", "--role", "worker", "--run", "auth", "--node", "worker-1", "--coordination", "session", "--prompt", "start"],
+        { env, stdout: () => undefined },
+      ),
+      0,
+    );
+
+    const stdout: string[] = [];
+    assert.equal(
+      await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "resumed final\n");
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(calls[1].includes("resume"), true);
+    assert.equal(calls[1].includes("thread-1"), true);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run message routes tmux nodes through tmux buffers", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "tmux.jsonl");
+    await writeExecutable(
+      join(binDir, "tmux"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+        "",
+      ].join("\n"),
+    );
+    const env = { ...process.env, HEADLESS_TMUX_CAPTURE: captureFile, HOME: join(dir, "home"), PATH: `${binDir}:${process.env.PATH ?? ""}` };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "tmux",
+      status: "busy",
+      planned: true,
+      tmuxSessionName: "headless-codex-worker-1",
+    });
+
+    assert.equal(
+      await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue"], {
+        env,
+        stdout: () => undefined,
+      }),
+      0,
+    );
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(calls[0], ["set-buffer", "-b", "headless-codex-worker-1-send", "continue"]);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run message --async records busy status, logs output, and marks completion", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const fakeHeadless = join(binDir, "headless");
+    const captureFile = join(dir, "headless-args.jsonl");
+    mkdirSync(home);
+    await writeExecutable(
+      fakeHeadless,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
+        "if (args[0] === 'run' && args[1] === 'mark') {",
+        "  const runId = args[2]; const nodeId = args[3]; const status = args[5];",
+        "  const file = path.join(process.env.HOME, '.headless', 'runs', runId, 'run.json');",
+        "  const run = JSON.parse(fs.readFileSync(file, 'utf8'));",
+        "  run.nodes[nodeId].status = status; run.nodes[nodeId].updatedAt = new Date().toISOString();",
+        "  fs.writeFileSync(file, JSON.stringify(run, null, 2) + '\\n');",
+        "  process.exit(0);",
+        "}",
+        "console.log('async child output');",
+        "",
+      ].join("\n"),
+    );
+    const env = { ...process.env, HEADLESS_CAPTURE: captureFile, HEADLESS_CLI_BIN: fakeHeadless, HOME: home };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "pi",
+      coordination: "oneshot",
+      status: "idle",
+      planned: true,
+    });
+
+    assert.equal(
+      await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue", "--async"], {
+        env,
+        stdout: () => undefined,
+      }),
+      0,
+    );
+    assert.equal(readRun(env, "auth")?.nodes["worker-1"].status, "busy");
+    await waitFor(() => readRun(env, "auth")?.nodes["worker-1"].status === "idle");
+    const stdoutLog = readRun(env, "auth")?.nodes["worker-1"].logs?.stdout ?? "";
+    await waitFor(() => existsSync(stdoutLog) && readFileSync(stdoutLog, "utf8").includes("async child output"));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Docker run coordination mounts the host run directory", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { ...process.env, HOME: join(dir, "home") };
+    const stdout: string[] = [];
+    assert.equal(
+      await runCli(
+        [
+          "codex",
+          "--role",
+          "orchestrator",
+          "--run",
+          "auth",
+          "--node",
+          "orchestrator",
+          "--prompt",
+          "hello",
+          "--docker",
+          "--print-command",
+        ],
+        { env, stdout: (text) => stdout.push(text) },
+      ),
+      0,
+    );
+    assert.match(stdout.join(""), /--volume .*\/\.headless\/runs\/auth:\/headless-runs\/auth/);
+    assert.match(stdout.join(""), /--env HEADLESS_RUN_DIR=\/headless-runs\/auth/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -173,9 +173,9 @@ test("orchestrator run registers declared team and injects run context", async (
 
     assert.equal(code, 0);
     assert.equal(stdout.join(""), "orchestrator final\n");
-    assert.match(stderr.join(""), /^\d{4}-\d{2}-\d{2}T.* INFO  headless run auth started orchestrator \(4 nodes,/m);
-    assert.match(stderr.join(""), /^\d{4}-\d{2}-\d{2}T.* INFO  headless run auth orchestrator starting -> busy/m);
-    assert.match(stderr.join(""), /^\d{4}-\d{2}-\d{2}T.* OK    headless run auth idle \(0 active;/m);
+    assert.match(stderr.join(""), /^\d{2}:\d{2}:\d{2} INFO  auth started orchestrator \(4 nodes,/m);
+    assert.match(stderr.join(""), /^\d{2}:\d{2}:\d{2} INFO  auth orchestrator starting -> busy/m);
+    assert.match(stderr.join(""), /^\d{2}:\d{2}:\d{2} OK    auth idle \(0 active;/m);
     const run = readRun(env, "auth");
     assert.equal(run?.nodes.orchestrator.status, "done");
     assert.deepEqual(

--- a/tests/run-status.test.ts
+++ b/tests/run-status.test.ts
@@ -44,9 +44,9 @@ test("run status reporter emits initial summary and status transitions once", ()
     reporter.poll();
     reporter.poll();
 
-    assert.equal(lines.filter((line) => line.includes("INFO  headless run auth started orchestrator")).length, 1);
-    assert.equal(lines.filter((line) => line.includes("INFO  headless run auth orchestrator starting -> busy")).length, 1);
-    assert.match(lines.join(""), /^2026-04-29T12:00:00\.000Z INFO  headless run auth/m);
+    assert.equal(lines.filter((line) => line.includes("INFO  auth started orchestrator")).length, 1);
+    assert.equal(lines.filter((line) => line.includes("INFO  auth orchestrator starting -> busy")).length, 1);
+    assert.match(lines.join(""), /^\d{2}:\d{2}:\d{2} INFO  auth/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -88,7 +88,7 @@ test("run status reporter emits message routes without prompt text", () => {
     recordMessage(env, "auth", "orchestrator", "worker-1", "secret prompt text");
     reporter.poll();
 
-    assert.match(lines.join(""), /2026-04-29T12:00:00\.000Z INFO  headless run auth message orchestrator -> worker-1/);
+    assert.match(lines.join(""), /\d{2}:\d{2}:\d{2} INFO  auth message orchestrator -> worker-1/);
     assert.doesNotMatch(lines.join(""), /secret prompt text/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
@@ -131,7 +131,7 @@ test("run status reporter emits final idle summary on stop", () => {
     updateNodeStatus(env, "auth", "orchestrator", "idle");
     reporter.stop();
 
-    assert.match(lines.join(""), /2026-04-29T12:00:00\.000Z OK    headless run auth idle \(0 active; 2 idle\)/);
+    assert.match(lines.join(""), /\d{2}:\d{2}:\d{2} OK    auth idle \(0 active; 2 idle\)/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -199,7 +199,7 @@ test("NO_COLOR disables run status colors", () => {
     reporter.poll();
 
     assert.doesNotMatch(lines.join(""), /\x1b\[/);
-    assert.match(lines.join(""), /2026-04-29T12:00:00\.000Z INFO  headless run auth started orchestrator/);
+    assert.match(lines.join(""), /\d{2}:\d{2}:\d{2} INFO  auth started orchestrator/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -210,4 +210,38 @@ test("run status interval parser falls back for invalid values", () => {
   assert.equal(parseRunStatusIntervalMs("25"), 25);
   assert.equal(parseRunStatusIntervalMs("-1"), 1000);
   assert.equal(parseRunStatusIntervalMs("bad"), 1000);
+});
+
+test("run status reporter truncates long log lines within configured columns", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-status-test-"));
+  try {
+    const env = { HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "very-long-authentication-orchestration-run",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "starting",
+      planned: true,
+    });
+
+    const lines: string[] = [];
+    const reporter = createRunStatusReporter({
+      columns: 48,
+      now: () => new Date("2026-04-29T12:00:00.000Z"),
+      env,
+      intervalMs: 1000,
+      runId: "very-long-authentication-orchestration-run",
+      write: (text) => lines.push(text),
+    });
+
+    reporter.poll();
+
+    const line = lines.join("").trimEnd();
+    assert.ok(line.length <= 48);
+    assert.match(line, /\.\.\.$/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
 });

--- a/tests/run-status.test.ts
+++ b/tests/run-status.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createRunStatusReporter, parseRunStatusIntervalMs } from "../src/run-status.ts";
+import { recordMessage, registerNode, updateNodeStatus } from "../src/runs.ts";
+
+test("run status reporter emits initial summary and status transitions once", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-status-test-"));
+  try {
+    const env = { HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "starting",
+      planned: true,
+    });
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "planned",
+      planned: true,
+    });
+
+    const lines: string[] = [];
+    const reporter = createRunStatusReporter({
+      now: () => new Date("2026-04-29T12:00:00.000Z"),
+      env,
+      intervalMs: 1000,
+      runId: "auth",
+      write: (text) => lines.push(text),
+    });
+
+    reporter.poll();
+    updateNodeStatus(env, "auth", "orchestrator", "busy");
+    reporter.poll();
+    reporter.poll();
+
+    assert.equal(lines.filter((line) => line.includes("INFO  headless run auth started orchestrator")).length, 1);
+    assert.equal(lines.filter((line) => line.includes("INFO  headless run auth orchestrator starting -> busy")).length, 1);
+    assert.match(lines.join(""), /^2026-04-29T12:00:00\.000Z INFO  headless run auth/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run status reporter emits message routes without prompt text", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-status-test-"));
+  try {
+    const env = { HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "busy",
+      planned: true,
+    });
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "planned",
+      planned: true,
+    });
+
+    const lines: string[] = [];
+    const reporter = createRunStatusReporter({
+      now: () => new Date("2026-04-29T12:00:00.000Z"),
+      env,
+      intervalMs: 1000,
+      runId: "auth",
+      write: (text) => lines.push(text),
+    });
+
+    reporter.poll();
+    recordMessage(env, "auth", "orchestrator", "worker-1", "secret prompt text");
+    reporter.poll();
+
+    assert.match(lines.join(""), /2026-04-29T12:00:00\.000Z INFO  headless run auth message orchestrator -> worker-1/);
+    assert.doesNotMatch(lines.join(""), /secret prompt text/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run status reporter emits final idle summary on stop", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-status-test-"));
+  try {
+    const env = { HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "busy",
+      planned: true,
+    });
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "session",
+      status: "idle",
+      planned: true,
+    });
+
+    const lines: string[] = [];
+    const reporter = createRunStatusReporter({
+      now: () => new Date("2026-04-29T12:00:00.000Z"),
+      env,
+      intervalMs: 1000,
+      runId: "auth",
+      write: (text) => lines.push(text),
+    });
+
+    reporter.poll();
+    updateNodeStatus(env, "auth", "orchestrator", "idle");
+    reporter.stop();
+
+    assert.match(lines.join(""), /2026-04-29T12:00:00\.000Z OK    headless run auth idle \(0 active; 2 idle\)/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run status reporter colors log levels and statuses when enabled", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-status-test-"));
+  try {
+    const env = { HOME: join(dir, "home") };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "starting",
+      planned: true,
+    });
+
+    const lines: string[] = [];
+    const reporter = createRunStatusReporter({
+      color: true,
+      now: () => new Date("2026-04-29T12:00:00.000Z"),
+      env,
+      intervalMs: 1000,
+      runId: "auth",
+      write: (text) => lines.push(text),
+    });
+
+    reporter.poll();
+    updateNodeStatus(env, "auth", "orchestrator", "busy");
+    reporter.poll();
+
+    assert.match(lines.join(""), /\x1b\[36mINFO\x1b\[0m/);
+    assert.match(lines.join(""), /\x1b\[33mstarting\x1b\[0m -> \x1b\[33mbusy\x1b\[0m/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("NO_COLOR disables run status colors", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-status-test-"));
+  try {
+    const env = { HOME: join(dir, "home"), NO_COLOR: "1" };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "orchestrator",
+      role: "orchestrator",
+      agent: "codex",
+      coordination: "session",
+      status: "starting",
+      planned: true,
+    });
+
+    const lines: string[] = [];
+    const reporter = createRunStatusReporter({
+      color: true,
+      now: () => new Date("2026-04-29T12:00:00.000Z"),
+      env,
+      intervalMs: 1000,
+      runId: "auth",
+      write: (text) => lines.push(text),
+    });
+
+    reporter.poll();
+
+    assert.doesNotMatch(lines.join(""), /\x1b\[/);
+    assert.match(lines.join(""), /2026-04-29T12:00:00\.000Z INFO  headless run auth started orchestrator/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run status interval parser falls back for invalid values", () => {
+  assert.equal(parseRunStatusIntervalMs(undefined), 1000);
+  assert.equal(parseRunStatusIntervalMs("25"), 25);
+  assert.equal(parseRunStatusIntervalMs("-1"), 1000);
+  assert.equal(parseRunStatusIntervalMs("bad"), 1000);
+});

--- a/tests/table.test.ts
+++ b/tests/table.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderTable } from "../src/table.ts";
+
+test("table renderer omits ANSI escapes when color is disabled", () => {
+  const output = renderTable(
+    {
+      columns: ["Status"],
+      rows: [[{ text: "✓", color: "green" }]],
+    },
+    { color: false },
+  );
+
+  assert.doesNotMatch(output, /\x1b\[/);
+  assert.match(output, /^\| ✓\s+\|$/m);
+});
+
+test("table renderer emits ANSI colors when explicitly enabled", () => {
+  const output = renderTable(
+    {
+      columns: ["Status"],
+      rows: [[{ text: "✓", color: "green" }]],
+    },
+    { color: true, env: {} },
+  );
+
+  assert.match(output, /\x1b\[32m✓\x1b\[0m/);
+});
+
+test("NO_COLOR disables table colors", () => {
+  const output = renderTable(
+    {
+      columns: ["Status"],
+      rows: [[{ text: "✗", color: "red" }]],
+    },
+    { color: true, env: { NO_COLOR: "1" } },
+  );
+
+  assert.doesNotMatch(output, /\x1b\[/);
+  assert.match(output, /^\| ✗\s+\|$/m);
+});
+
+test("table renderer truncates long fields within configured width", () => {
+  const output = renderTable(
+    {
+      columns: ["Name", "Value"],
+      rows: [["short", "x".repeat(80)]],
+    },
+    { color: false, maxWidth: 40 },
+  );
+
+  for (const line of output.trimEnd().split("\n")) {
+    assert.ok(line.length <= 40, `${line.length}: ${line}`);
+  }
+  assert.match(output, /\.\.\./);
+});


### PR DESCRIPTION
## What changed
- Add a shared terminal table renderer and use it for `headless --check`, `headless run list`, and `headless run view`.
- Stream compact timestamped orchestrator status logs to stderr during local/Docker runs, with TTY colors and `NO_COLOR` support.
- Expand full local orchestration integration coverage to require the six-agent explorer set.
- Fix the full orchestration assertion to expect completed explorers in the terminal `done` state.

## Why
- Makes run/check output easier to scan in normal terminals.
- Gives high-level progress visibility while orchestrated runs are active without polluting stdout.
- Ensures the full integration sweep exercises all configured backends.

## Verification
- `npm run check` passed: 188/188.
- `HEADLESS_INTEGRATION_AGENTS=all HEADLESS_INTEGRATION_FULL_SWEEP=1 npm run test:integration:local` passed: 10/10.
- Pre-push hook passed default Codex local integration: 9 passed, 1 skipped full sweep.
- Global reinstall verified with `npm install -g .`.

## Logs
- Full all-agent integration: `/tmp/headless-integration-full-agents-after-fix.log`
