### PR TITLE
feat: add ACP agent harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added ACP (`agentclientprotocol`) harness support via `@agentclientprotocol/sdk`, including registry-backed `--acp-agent` resolution, custom `--acp-command` launches such as `atlas alta agent run`, ACP registry overrides, setup checks, and README/usage examples.
+- Thanks to Andy MacDonald (@andymac4182) for contributing the ACP harness.
 
 ## 0.3.0 - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added ACP (`agentclientprotocol`) harness support via `@agentclientprotocol/sdk`, including registry-backed `--acp-agent` resolution, custom `--acp-command` launches such as `atlas alta agent run`, ACP registry overrides, setup checks, and README/usage examples.
+
 ## 0.3.0 - 2026-05-01
 
 - Added API/OAuth credential signal reporting to `headless --check` for supported agent backends.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Headless CLI</h1>
 
 <p align="center">
-  One CLI entrypoint for running Claude, Codex, Cursor, Gemini, Pi, and OpenCode in headless mode.
+  One CLI entrypoint for running Claude, Codex, Cursor, Gemini, Pi, OpenCode, and ACP-compatible agents in headless mode.
 </p>
 
 <p align="center">
@@ -52,6 +52,10 @@ printf "Review this diff" | headless pi --model claude-opus
 # Preview the native backend command.
 headless gemini --prompt "Summarize the codebase" --print-command
 
+# Run an ACP-compatible agent from the registry or a custom ACP server command.
+headless acp --acp-agent auggie --prompt "Inspect this repository"
+headless acp --acp-command "atlas alta agent run" --prompt "Fix the failing tests"
+
 # Stream native JSON, debug traces, or append normalized usage.
 headless pi --prompt "Summarize this repo" --json
 headless codex --prompt "Fix the failing tests" --debug
@@ -71,7 +75,7 @@ headless attach --all
 headless --check
 ```
 
-When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`.
+When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`. ACP-compatible agents are explicit-only: use `headless acp --acp-agent ...` or `headless acp --acp-command ...`.
 
 ## Multi-Agent Orchestration
 
@@ -96,6 +100,7 @@ Roles include `orchestrator`, `explorer`, `worker`, and `reviewer`. Team specs a
 | [Gemini CLI](https://geminicli.com/docs/cli/cli-reference/) | `npm install -g @google/gemini-cli` | `gemini` |
 | [OpenCode](https://opencode.ai/docs/cli/) | `curl -fsSL https://opencode.ai/install \| bash` or `npm install -g opencode-ai` | `opencode` |
 | [Pi](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/rpc.md) | `npm install -g @mariozechner/pi-coding-agent` | `pi`, or set `PI_CODING_AGENT_BIN` |
+| [ACP](https://agentclientprotocol.com/) | Use `--acp-agent <id>` to resolve from the ACP registry, or `--acp-command <cmd>` for a custom ACP server | `headless acp-client ...` adapter |
 
 Install the agent CLIs you want Headless to drive.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ printf "Review this diff" | headless pi --model claude-opus
 
 | Agent | Command shape |
 | --- | --- |
+| `acp` | `headless acp-client -- <acp-server-command>`, selected with `--acp-agent` or `--acp-command` |
 | `claude` | `claude -p ... --output-format stream-json --verbose --dangerously-skip-permissions` |
 | `codex` | `codex exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check ...` |
 | `cursor` | `agent -p --trust --force --output-format stream-json --model gpt-5.5-medium ...` |
@@ -23,9 +24,35 @@ printf "Review this diff" | headless pi --model claude-opus
 | `opencode` | `opencode run --format json --model openai/gpt-5.4 --dangerously-skip-permissions ...` |
 | `pi` | `pi --no-session --mode json --provider openai-codex --model gpt-5.5 --tools read,bash,edit,write ...` |
 
-When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`.
+When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`. ACP-compatible agents are explicit-only: use `headless acp --acp-agent ...` or `headless acp --acp-command ...`.
 
 When `--model` is omitted, Headless defaults Codex to `gpt-5.5`, Claude to `claude-opus-4-6`, Cursor to the `gpt-5.5` family with medium effort, Gemini to `gemini-3.1-pro-preview`, OpenCode to `openai/gpt-5.4`, and Pi to `openai-codex/gpt-5.5`.
+
+## ACP Agents
+
+ACP support uses [Agent Client Protocol](https://agentclientprotocol.com/) to run any compatible ACP server behind the normal Headless prompt/output flow. Unlike built-in concrete agents, `acp` requires an explicit backend via `--acp-agent`, `--acp-command`, or their environment equivalents.
+
+Resolve an agent from the public ACP registry by id or name:
+
+```bash
+headless acp --acp-agent auggie --prompt "Inspect this repository"
+```
+
+Headless fetches `https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json` when `--acp-agent` is used. Override the source with a URL or local registry file:
+
+```bash
+headless acp --acp-agent example-acp --acp-registry https://example.com/registry.json --prompt "Summarize this repo"
+headless acp --acp-agent example-acp --acp-registry-file ./registry.json --prompt "Run the focused tests"
+```
+
+Use a custom ACP server command when the command is not in the registry or when you want full control over the launch command:
+
+```bash
+headless acp --acp-command "atlas alta agent run" --prompt "Fix the failing tests"
+printf "Review this diff" | headless acp --acp-command "atlas alta agent run"
+```
+
+Environment equivalents are also supported: `HEADLESS_ACP_AGENT`, `HEADLESS_ACP_COMMAND`, `HEADLESS_ACP_REGISTRY_URL`, `HEADLESS_ACP_REGISTRY_FILE`, and `HEADLESS_ACP_REGISTRY_JSON`.
 
 ## Permissions and Reasoning
 
@@ -140,7 +167,7 @@ mkdir -p ~/.headless
 cp config.toml.example ~/.headless/config.toml
 ```
 
-Supported sections are `[agents.claude]`, `[agents.codex]`, `[agents.cursor]`, `[agents.gemini]`, `[agents.opencode]`, and `[agents.pi]`. Supported keys are `model` and `reasoning_effort`.
+Supported sections are `[agents.claude]`, `[agents.codex]`, `[agents.cursor]`, `[agents.gemini]`, `[agents.opencode]`, and `[agents.pi]`. Supported keys are `model` and `reasoning_effort`. ACP backend selection is controlled by `--acp-agent`, `--acp-command`, and the ACP environment variables rather than model defaults.
 
 Precedence:
 
@@ -186,6 +213,10 @@ Options:
 - `--model`, `--agent-model`: model override passed to the agent CLI.
 - `--reasoning-effort`, `--effort`: normalized reasoning effort, one of `low`, `medium`, `high`, or `xhigh`.
 - `--allow`: permission mode, either `read-only` or `yolo`.
+- `--acp-agent`: with `acp`, resolve an ACP server from the registry by id or name.
+- `--acp-command`: with `acp`, run a custom ACP server command such as `atlas alta agent run`.
+- `--acp-registry`: with `--acp-agent`, use a custom ACP registry URL.
+- `--acp-registry-file`: with `--acp-agent`, read registry JSON from a local file.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--docker`: run the agent inside Docker for one-shot headless execution.
 - `--modal`: run the agent in a Modal CPU sandbox for one-shot headless execution.
@@ -213,6 +244,11 @@ See [orchestration.md](orchestration.md) for `--role`, `--run`, `--node`, `--tea
 - `PI_CODING_AGENT_PROVIDER`: Pi provider override used when the Pi model value does not include `provider/model`.
 - `PI_CODING_AGENT_MODEL`: Pi model override when `--model` is omitted. Accepts `provider/model` or a bare model paired with `PI_CODING_AGENT_PROVIDER`.
 - `PI_CODING_AGENT_MODELS`: passed to Pi as `--models`.
+- `HEADLESS_ACP_AGENT`: ACP registry id or name to resolve when running `headless acp`.
+- `HEADLESS_ACP_COMMAND`: custom ACP server command, for example `atlas alta agent run`.
+- `HEADLESS_ACP_REGISTRY_URL`: ACP registry URL override.
+- `HEADLESS_ACP_REGISTRY_FILE`: local ACP registry JSON file.
+- `HEADLESS_ACP_REGISTRY_JSON`: inline ACP registry JSON, mainly useful for tests or wrappers.
 - `HEADLESS_RUN_DIR`: concrete directory for the active run store, mainly used by Docker run coordination.
 
 Docker and Modal modes also pass common agent/provider credential variables when present, including `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, Cursor/Pi credential variables, common AWS variables, and OpenAI-compatible endpoint variables. Use `--docker-env` or `--modal-env` for anything else. Modal mode additionally supports named Modal Secrets with `--modal-secret`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
     },
     "node_modules/@agentclientprotocol/sdk": {
       "version": "0.21.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
       "integrity": "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==",
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -1138,7 +1138,7 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/zod/-/zod-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "modal": "^0.7.4"
+        "@agentclientprotocol/sdk": "^0.21.0",
+        "modal": "^0.7.4",
+        "zod": "^4.2.0"
       },
       "bin": {
         "headless": "dist/cli.js"
@@ -22,6 +24,15 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.21.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
+      "integrity": "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -1123,6 +1134,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "uuid": "^14.0.0"
   },
   "dependencies": {
-    "modal": "^0.7.4"
+    "@agentclientprotocol/sdk": "^0.21.0",
+    "modal": "^0.7.4",
+    "zod": "^4.2.0"
   }
 }

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -1,0 +1,305 @@
+import { spawn, spawnSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { Readable, Writable } from "node:stream";
+
+import * as acp from "@agentclientprotocol/sdk";
+import type { BuiltCommand, Env } from "./types.js";
+
+type JsonRecord = Record<string, unknown>;
+
+interface AcpRegistry {
+  agents?: unknown[];
+}
+
+const defaultRegistryUrl = "https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json";
+
+interface AcpDistributionCommand {
+  command: string;
+  args: string[];
+  env?: Env;
+}
+
+export interface RunAcpClientOptions {
+  agentCommand: BuiltCommand;
+  prompt: string;
+  cwd?: string;
+  env: Env;
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function splitCommandLine(value: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  let escaping = false;
+
+  for (const char of value) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+    if ((char === '"' || char === "'") && (!quote || quote === char)) {
+      quote = quote ? undefined : char;
+      continue;
+    }
+    if (/\s/.test(char) && !quote) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (escaping) current += "\\";
+  if (quote) throw new Error(`unterminated quote in ACP command: ${value}`);
+  if (current) parts.push(current);
+  return parts;
+}
+
+export function commandFromCustom(value: string): AcpDistributionCommand {
+  const parts = splitCommandLine(value.trim());
+  if (parts.length === 0 || !parts[0]) {
+    throw new Error("ACP custom command is empty");
+  }
+  return { command: parts[0], args: parts.slice(1) };
+}
+
+function platformBinaryKey(): string {
+  const os = process.platform === "darwin" ? "darwin" : process.platform === "win32" ? "windows" : "linux";
+  const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
+  return `${os}-${arch}`;
+}
+
+function commandFromDistribution(agent: JsonRecord): AcpDistributionCommand | undefined {
+  const distribution = asRecord(agent.distribution);
+  const npx = asRecord(distribution.npx);
+  if (Object.keys(npx).length > 0) {
+    const packageName = asString(npx.package).trim();
+    if (!packageName) return undefined;
+    return {
+      command: process.platform === "win32" ? "npx.cmd" : "npx",
+      args: ["-y", packageName, ...asStringArray(npx.args)],
+      env: Object.fromEntries(
+        Object.entries(asRecord(npx.env)).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+      ),
+    };
+  }
+
+  const binary = asRecord(distribution.binary);
+  const platformBinary = asRecord(binary[platformBinaryKey()]);
+  const command = asString(platformBinary.cmd).trim();
+  if (command) {
+    return { command, args: asStringArray(platformBinary.args) };
+  }
+  return undefined;
+}
+
+export function resolveAcpDistributionCommand(agentId: string, registry: AcpRegistry): AcpDistributionCommand {
+  const normalized = agentId.trim().toLowerCase();
+  const agents = Array.isArray(registry.agents) ? registry.agents.map(asRecord) : [];
+  const found = agents.find((agent) => {
+    const id = asString(agent.id).trim().toLowerCase();
+    const name = asString(agent.name).trim().toLowerCase();
+    return id === normalized || name === normalized;
+  });
+  if (!found) {
+    throw new Error(`ACP registry agent not found: ${agentId}`);
+  }
+  const command = commandFromDistribution(found);
+  if (!command) {
+    throw new Error(`ACP registry agent has no supported distribution for this platform: ${agentId}`);
+  }
+  return command;
+}
+
+function loadRegistry(env: Env, options: { fetchDefault?: boolean } = {}): AcpRegistry | undefined {
+  const registryJson = env.HEADLESS_ACP_REGISTRY_JSON;
+  if (registryJson) {
+    return JSON.parse(registryJson) as AcpRegistry;
+  }
+  const registryPath = env.HEADLESS_ACP_REGISTRY_FILE;
+  if (registryPath) {
+    return JSON.parse(readFileSync(registryPath, "utf8")) as AcpRegistry;
+  }
+  const registryUrl = env.HEADLESS_ACP_REGISTRY_URL || (options.fetchDefault ? defaultRegistryUrl : undefined);
+  if (!registryUrl) {
+    return undefined;
+  }
+  const curl = spawnSync("curl", ["-fsSL", registryUrl], { encoding: "utf8" });
+  if (curl.status !== 0) {
+    throw new Error(`failed to fetch ACP registry: ${registryUrl}`);
+  }
+  return JSON.parse(curl.stdout) as AcpRegistry;
+}
+
+export function resolveAcpCommand(env: Env): AcpDistributionCommand {
+  const customCommand = env.HEADLESS_ACP_COMMAND;
+  if (customCommand) {
+    return commandFromCustom(customCommand);
+  }
+  const agentId = env.HEADLESS_ACP_AGENT;
+  const registry = agentId ? loadRegistry(env, { fetchDefault: true }) : undefined;
+  if (agentId && registry) {
+    return resolveAcpDistributionCommand(agentId, registry);
+  }
+  throw new Error("acp requires --acp-agent, --acp-command, HEADLESS_ACP_AGENT, or HEADLESS_ACP_COMMAND");
+}
+
+export function resolveBuiltinAcpStdioCommand(env: Env): AcpDistributionCommand {
+  const headlessCommand = commandFromCustom(env.HEADLESS_BIN || "headless");
+  return { command: headlessCommand.command, args: [...headlessCommand.args, "acp-stdio"] };
+}
+
+function acpOutputRecord(type: string, value: JsonRecord): string {
+  return `${JSON.stringify({ type, ...value })}\n`;
+}
+
+function contentText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(contentText).filter(Boolean).join("\n");
+  const record = asRecord(value);
+  if (asString(record.type) === "text") return asString(record.text);
+  return asString(record.text);
+}
+
+class HeadlessAcpClient {
+  private assistantText = "";
+
+  constructor(private readonly stdout: (text: string) => void) {}
+
+  finalAssistantText(): string {
+    return this.assistantText.trim();
+  }
+
+  async requestPermission(params: acp.RequestPermissionRequest): Promise<acp.RequestPermissionResponse> {
+    const option = params.options.find((candidate) => candidate.kind === "allow_once") ?? params.options[0];
+    return option
+      ? { outcome: { outcome: "selected", optionId: option.optionId } }
+      : { outcome: { outcome: "cancelled" } };
+  }
+
+  async sessionUpdate(params: acp.SessionNotification): Promise<void> {
+    const update = params.update;
+    if (update.sessionUpdate === "agent_message_chunk") {
+      const text = contentText(update.content);
+      if (text) {
+        this.assistantText += text;
+        this.stdout(acpOutputRecord("message_delta", { role: "assistant", content: [{ type: "text", text }] }));
+      }
+      return;
+    }
+    if (update.sessionUpdate === "session_info_update") {
+      this.stdout(acpOutputRecord("session", { sessionId: params.sessionId }));
+    }
+  }
+
+  async readTextFile(params: acp.ReadTextFileRequest): Promise<acp.ReadTextFileResponse> {
+    return { content: readFileSync(params.path, "utf8") };
+  }
+
+  async writeTextFile(): Promise<acp.WriteTextFileResponse> {
+    return {};
+  }
+}
+
+function childExit(child: ReturnType<typeof spawn>): Promise<number> {
+  return new Promise((resolve) => {
+    child.on("error", () => resolve(127));
+    child.on("close", (code, signal) => resolve(signal ? 1 : (code ?? 1)));
+  });
+}
+
+export async function runAcpClient(options: RunAcpClientOptions): Promise<number> {
+  const child = spawn(options.agentCommand.command, options.agentCommand.args, {
+    cwd: options.cwd,
+    env: { ...options.env, ...(options.agentCommand.env ?? {}) } as NodeJS.ProcessEnv,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => options.stderr(chunk));
+
+  if (!child.stdin || !child.stdout) {
+    child.kill();
+    return 1;
+  }
+
+  const stream = acp.ndJsonStream(
+    Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+    Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+  );
+  const client = new HeadlessAcpClient(options.stdout);
+  const connection = new acp.ClientSideConnection(() => client, stream);
+
+  try {
+    await connection.initialize({ protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } } });
+    const session = await connection.newSession({ cwd: options.cwd ?? process.cwd(), mcpServers: [] });
+    options.stdout(acpOutputRecord("session", { sessionId: session.sessionId }));
+    const result = await connection.prompt({ sessionId: session.sessionId, prompt: [{ type: "text", text: options.prompt }] });
+    const finalText = client.finalAssistantText();
+    if (finalText) {
+      options.stdout(acpOutputRecord("message", { role: "assistant", content: [{ type: "text", text: finalText }] }));
+    }
+    options.stdout(acpOutputRecord("result", { stopReason: result.stopReason }));
+    child.kill();
+    await childExit(child);
+    return 0;
+  } catch (error) {
+    options.stdout(acpOutputRecord("error", { message: error instanceof Error ? error.message : String(error) }));
+    child.kill();
+    const code = await childExit(child);
+    return code === 0 ? 1 : code;
+  }
+}
+
+export async function runAcpStdioAgent(): Promise<void> {
+  const output = Writable.toWeb(process.stdout);
+  const input = Readable.toWeb(process.stdin);
+  const stream = acp.ndJsonStream(output as WritableStream<Uint8Array>, input as ReadableStream<Uint8Array>);
+  const connection = new acp.AgentSideConnection(() => ({
+    async initialize(params) {
+      return { protocolVersion: params.protocolVersion, agentCapabilities: {} };
+    },
+    async authenticate() {
+      return {};
+    },
+    async newSession(params) {
+      try {
+        if (params.cwd) statSync(params.cwd);
+      } catch {
+        // Match permissive agent behavior; the parent validates work dirs when appropriate.
+      }
+      return { sessionId: "headless-acp-stdio" };
+    },
+    async prompt(params) {
+      const text = params.prompt.map(contentText).filter(Boolean).join("\n");
+      for (const char of text) {
+        await connection.sessionUpdate({
+          sessionId: params.sessionId,
+          update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: char } },
+        });
+      }
+      return { stopReason: "end_turn" };
+    },
+    async cancel() {},
+  }), stream);
+  await connection.closed;
+}

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -108,6 +108,9 @@ function commandFromDistribution(agent: JsonRecord): AcpDistributionCommand | un
   const binary = asRecord(distribution.binary);
   const platformBinary = asRecord(binary[platformBinaryKey()]);
   const command = asString(platformBinary.cmd).trim();
+  if (command && asString(platformBinary.archive).trim()) {
+    throw new Error("ACP registry binary archive distributions are not supported yet; use --acp-command with an installed ACP server");
+  }
   if (command) {
     return { command, args: asStringArray(platformBinary.args) };
   }

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -182,6 +182,10 @@ function contentText(value: unknown): string {
   return asString(record.text);
 }
 
+export const acpClientCapabilities = {
+  fs: { readTextFile: true, writeTextFile: false },
+};
+
 class HeadlessAcpClient {
   private assistantText = "";
 
@@ -224,7 +228,7 @@ class HeadlessAcpClient {
   }
 
   async writeTextFile(): Promise<acp.WriteTextFileResponse> {
-    return {};
+    throw new Error("ACP client file writes are not supported");
   }
 }
 
@@ -257,7 +261,7 @@ export async function runAcpClient(options: RunAcpClientOptions): Promise<number
   const connection = new acp.ClientSideConnection(() => client, stream);
 
   try {
-    await connection.initialize({ protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } } });
+    await connection.initialize({ protocolVersion: acp.PROTOCOL_VERSION, clientCapabilities: acpClientCapabilities });
     const session = await connection.newSession({ cwd: options.cwd ?? process.cwd(), mcpServers: [] });
     options.stdout(acpOutputRecord("session", { sessionId: session.sessionId }));
     const result = await connection.prompt({ sessionId: session.sessionId, prompt: [{ type: "text", text: options.prompt }] });

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -3,7 +3,7 @@ import { readFileSync, statSync } from "node:fs";
 import { Readable, Writable } from "node:stream";
 
 import * as acp from "@agentclientprotocol/sdk";
-import type { BuiltCommand, Env } from "./types.js";
+import type { AllowMode, BuiltCommand, Env } from "./types.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -24,6 +24,7 @@ export interface RunAcpClientOptions {
   prompt: string;
   cwd?: string;
   env: Env;
+  allow?: AllowMode;
   stdout: (text: string) => void;
   stderr: (text: string) => void;
 }
@@ -184,13 +185,19 @@ function contentText(value: unknown): string {
 class HeadlessAcpClient {
   private assistantText = "";
 
-  constructor(private readonly stdout: (text: string) => void) {}
+  constructor(
+    private readonly stdout: (text: string) => void,
+    private readonly allow: AllowMode | undefined,
+  ) {}
 
   finalAssistantText(): string {
     return this.assistantText.trim();
   }
 
   async requestPermission(params: acp.RequestPermissionRequest): Promise<acp.RequestPermissionResponse> {
+    if (this.allow === "read-only") {
+      return { outcome: { outcome: "cancelled" } };
+    }
     const option = params.options.find((candidate) => candidate.kind === "allow_once") ?? params.options[0];
     return option
       ? { outcome: { outcome: "selected", optionId: option.optionId } }
@@ -246,7 +253,7 @@ export async function runAcpClient(options: RunAcpClientOptions): Promise<number
     Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
     Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
   );
-  const client = new HeadlessAcpClient(options.stdout);
+  const client = new HeadlessAcpClient(options.stdout, options.allow);
   const connection = new acp.ClientSideConnection(() => client, stream);
 
   try {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -8,9 +8,10 @@ import type {
   Env,
   ReasoningEffort,
 } from "./types.js";
+import { commandFromCustom, resolveAcpCommand } from "./acp.js";
 import { BUILTIN_AGENT_DEFAULTS } from "./config.js";
 
-const agentOrder: AgentName[] = ["claude", "codex", "cursor", "gemini", "opencode", "pi"];
+const agentOrder: AgentName[] = ["acp", "claude", "codex", "cursor", "gemini", "opencode", "pi"];
 const defaultClaudeModel = BUILTIN_AGENT_DEFAULTS.claude.model;
 const defaultCodexModel = BUILTIN_AGENT_DEFAULTS.codex.model;
 export const DEFAULT_CURSOR_MODEL = BUILTIN_AGENT_DEFAULTS.cursor.model ?? "gpt-5.5";
@@ -122,6 +123,23 @@ function opencodeEnv(allow: AllowMode | undefined): Env | undefined {
 
 function commandWithOptionalEnv(command: string, args: string[], env: Env | undefined): BuiltCommand {
   return env ? { command, args, env } : { command, args };
+}
+
+function buildAcp(options: BuildOptions, env: Env): BuiltCommand {
+  const acpCommand = resolveAcpCommand(env);
+  const commandEnv = { ...(acpCommand.env ?? {}) };
+  const headlessCommand = commandFromCustom(env.HEADLESS_BIN || "headless");
+  const command = headlessCommand.command;
+  const args = [...headlessCommand.args, "acp-client", "--", acpCommand.command, ...acpCommand.args];
+  if (Object.keys(commandEnv).length > 0) {
+    return { command, args, env: commandEnv, stdinText: options.prompt };
+  }
+  return { command, args, stdinText: options.prompt };
+}
+
+function buildInteractiveAcp(_options: BuildOptions, env: Env): BuiltCommand {
+  const acpCommand = resolveAcpCommand(env);
+  return { command: acpCommand.command, args: acpCommand.args, env: acpCommand.env };
 }
 
 function buildClaude(options: BuildOptions): BuiltCommand {
@@ -348,6 +366,15 @@ function buildInteractivePi(options: BuildOptions, env: Env): BuiltCommand {
 }
 
 const harnesses: Record<AgentName, AgentHarness> = {
+  acp: {
+    name: "acp",
+    promptFileMode: "argument",
+    configRelDir: ".config/acp",
+    workspaceConfigRelDir: ".acp",
+    seedPaths: [".config/acp"],
+    buildCommand: buildAcp,
+    buildInteractiveCommand: buildInteractiveAcp,
+  },
   claude: {
     name: "claude",
     promptFileMode: "stdin",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -128,6 +128,9 @@ function commandWithOptionalEnv(command: string, args: string[], env: Env | unde
 function buildAcp(options: BuildOptions, env: Env): BuiltCommand {
   const acpCommand = resolveAcpCommand(env);
   const commandEnv = { ...(acpCommand.env ?? {}) };
+  if (options.allow) {
+    commandEnv.HEADLESS_ACP_ALLOW = options.allow;
+  }
   const headlessCommand = commandFromCustom(env.HEADLESS_BIN || "headless");
   const command = headlessCommand.command;
   const args = [...headlessCommand.args, "acp-client", "--", acpCommand.command, ...acpCommand.args];

--- a/src/check.ts
+++ b/src/check.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { accessSync, constants, statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 
+import { commandFromCustom, resolveAcpCommand } from "./acp.js";
 import { listAgents } from "./agents.js";
 import {
   BUILTIN_AGENT_DEFAULTS,
@@ -40,6 +41,13 @@ interface DockerCheck {
 type AuthLabel = "-" | "api" | "oauth" | "api+oauth";
 
 export function commandForAgent(agent: AgentName, env: Env): string {
+  if (agent === "acp") {
+    try {
+      return resolveAcpCommand(env).command;
+    } catch {
+      return commandFromCustom(env.HEADLESS_ACP_COMMAND || "headless-acp").command;
+    }
+  }
   if (agent === "cursor") {
     return env.CURSOR_CLI_BIN || "agent";
   }
@@ -92,6 +100,7 @@ const commonProviderApiEnvNames = [
 const awsCredentialEnvNames = ["AWS_ACCESS_KEY_ID", "AWS_PROFILE"];
 
 const apiEnvNamesByAgent: Record<AgentName, string[]> = {
+  acp: commonProviderApiEnvNames,
   claude: ["ANTHROPIC_API_KEY"],
   codex: ["CODEX_API_KEY", "OPENAI_API_KEY"],
   cursor: ["CURSOR_API_KEY"],
@@ -101,6 +110,7 @@ const apiEnvNamesByAgent: Record<AgentName, string[]> = {
 };
 
 const oauthEnvNamesByAgent: Record<AgentName, string[]> = {
+  acp: [],
   claude: ["CLAUDE_CODE_OAUTH_TOKEN"],
   codex: [],
   cursor: [],
@@ -110,6 +120,7 @@ const oauthEnvNamesByAgent: Record<AgentName, string[]> = {
 };
 
 const oauthPathsByAgent: Record<AgentName, string[]> = {
+  acp: [".config/acp"],
   claude: [".claude/.credentials.json", ".claude/auth.json"],
   codex: [".codex/auth.json"],
   cursor: [".cursor/cli-config.json"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { spawn } from "node:child_process";
+import { runAcpClient, runAcpStdioAgent } from "./acp.js";
 import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -117,6 +118,10 @@ interface ParsedArgs {
   model?: string;
   reasoningEffort?: ReasoningEffort;
   allow?: AllowMode;
+  acpAgent?: string;
+  acpCommand?: string;
+  acpRegistryFile?: string;
+  acpRegistryUrl?: string;
   workDir?: string;
   tmuxName?: string;
   sessionAlias?: string;
@@ -182,6 +187,10 @@ function usage(): string {
     "  --model <name>        Agent model override.",
     "  --reasoning-effort, --effort <level> Reasoning effort: low, medium, high, or xhigh.",
     "  --allow <mode>        Permission mode: read-only or yolo.",
+    "  --acp-agent <id>      With acp, resolve an ACP server from the registry by id or name.",
+    "  --acp-command <cmd>   With acp, run a custom ACP server command, e.g. 'atlas alta agent run'.",
+    "  --acp-registry <url>  With --acp-agent, use a custom ACP registry URL.",
+    "  --acp-registry-file <path> With --acp-agent, read registry JSON from a local file.",
     "  --role <role>         Role: orchestrator, explorer, worker, or reviewer.",
     "  --coordination <mode> Coordination: session, tmux, or oneshot.",
     "  --run <run>           Register this invocation in a local run.",
@@ -319,6 +328,18 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--allow":
         parsed.allow = parseAllowMode(takeValue(args, arg));
+        break;
+      case "--acp-agent":
+        parsed.acpAgent = takeValue(args, arg);
+        break;
+      case "--acp-command":
+        parsed.acpCommand = takeValue(args, arg);
+        break;
+      case "--acp-registry":
+        parsed.acpRegistryUrl = takeValue(args, arg);
+        break;
+      case "--acp-registry-file":
+        parsed.acpRegistryFile = takeValue(args, arg);
         break;
       case "--role":
         parsed.role = parseRole(takeValue(args, arg));
@@ -1892,11 +1913,37 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
   const stdout = deps.stdout ?? ((text: string) => process.stdout.write(text));
   const stderr = deps.stderr ?? ((text: string) => process.stderr.write(text));
   const stderrIsTTY = deps.stderrIsTTY ?? Boolean(process.stderr.isTTY);
-  const env = deps.env ?? process.env;
+  const env: Env = { ...(deps.env ?? process.env) };
   let registeredRunNode: { runId: string; nodeId: string } | undefined;
+
+  if (argv[0] === "acp-stdio") {
+    await runAcpStdioAgent();
+    return 0;
+  }
+  if (argv[0] === "acp-client") {
+    const separator = argv.indexOf("--", 1);
+    const commandParts = separator >= 0 ? argv.slice(separator + 1) : argv.slice(1);
+    const command = commandParts[0];
+    if (!command) {
+      stderr("headless: ACP adapter missing server command\n");
+      return 2;
+    }
+    const prompt = deps.stdin ?? (await readStdin());
+    return await runAcpClient({
+      agentCommand: { command, args: commandParts.slice(1) },
+      prompt,
+      env,
+      stdout,
+      stderr,
+    });
+  }
 
   try {
     const parsed = parseArgs(argv);
+    if (parsed.acpAgent) env.HEADLESS_ACP_AGENT = parsed.acpAgent;
+    if (parsed.acpCommand) env.HEADLESS_ACP_COMMAND = parsed.acpCommand;
+    if (parsed.acpRegistryFile) env.HEADLESS_ACP_REGISTRY_FILE = parsed.acpRegistryFile;
+    if (parsed.acpRegistryUrl) env.HEADLESS_ACP_REGISTRY_URL = parsed.acpRegistryUrl;
 
     if (parsed.help) {
       stdout(usage());
@@ -2660,7 +2707,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         // Preserve the original CLI error.
       }
     }
-    if (error instanceof CliError) {
+    if (error instanceof CliError || error instanceof Error) {
       stderr(`headless: ${error.message}\n`);
       return 2;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1933,6 +1933,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       agentCommand: { command, args: commandParts.slice(1) },
       prompt,
       env,
+      allow: env.HEADLESS_ACP_ALLOW === "read-only" ? "read-only" : undefined,
       stdout,
       stderr,
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ export interface HeadlessConfig {
 }
 
 export const BUILTIN_AGENT_DEFAULTS: Record<AgentName, AgentDefaults> = {
+  acp: {},
   claude: { model: "claude-opus-4-6" },
   codex: { model: "gpt-5.5" },
   cursor: { model: "gpt-5.5", reasoningEffort: "medium" },
@@ -165,6 +166,7 @@ export function parseHeadlessConfig(content: string): HeadlessConfig {
 
 function parseAgentName(value: string, lineNumber: number): AgentName {
   if (
+    value === "acp" ||
     value === "claude" ||
     value === "codex" ||
     value === "cursor" ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type AgentName = "claude" | "codex" | "cursor" | "gemini" | "opencode" | "pi";
+export type AgentName = "acp" | "claude" | "codex" | "cursor" | "gemini" | "opencode" | "pi";
 
 export type PromptFileMode = "argument" | "stdin";
 

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -71,6 +71,20 @@ test("builds ACP adapter command from custom command", () => {
   });
 });
 
+test("builds ACP adapter command with read-only permission mode", () => {
+  const command = buildAgentCommand("acp", { prompt: "hello", allow: "read-only" }, {
+    HEADLESS_BIN: "headless-dev",
+    HEADLESS_ACP_COMMAND: "atlas alta agent run",
+  });
+
+  assert.deepEqual(command, {
+    command: "headless-dev",
+    args: ["acp-client", "--", "atlas", "alta", "agent", "run"],
+    env: { HEADLESS_ACP_ALLOW: "read-only" },
+    stdinText: "hello",
+  });
+});
+
 test("builds ACP adapter command from registry npx distribution", () => {
   const registry = {
     agents: [

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -25,7 +25,7 @@ async function waitFor(assertion: () => boolean): Promise<void> {
 }
 
 test("lists all supported agents", () => {
-  assert.deepEqual(listAgents(), ["claude", "codex", "cursor", "gemini", "opencode", "pi"]);
+  assert.deepEqual(listAgents(), ["acp", "claude", "codex", "cursor", "gemini", "opencode", "pi"]);
 });
 
 test("default Docker image reference is accepted by Docker", () => {
@@ -56,6 +56,43 @@ test("builds codex command using CODEX_MODEL override", () => {
 
   assert.deepEqual(command.args.slice(2, 4), ["--model", "gpt-next"]);
   assert.equal(command.stdinText, "hello");
+});
+
+test("builds ACP adapter command from custom command", () => {
+  const command = buildAgentCommand("acp", { prompt: "hello" }, {
+    HEADLESS_BIN: "headless-dev",
+    HEADLESS_ACP_COMMAND: "atlas alta agent run",
+  });
+
+  assert.deepEqual(command, {
+    command: "headless-dev",
+    args: ["acp-client", "--", "atlas", "alta", "agent", "run"],
+    stdinText: "hello",
+  });
+});
+
+test("builds ACP adapter command from registry npx distribution", () => {
+  const registry = {
+    agents: [
+      {
+        id: "example-acp",
+        name: "Example ACP",
+        distribution: { npx: { package: "example-acp@1.2.3", args: ["--acp"], env: { EXAMPLE_AUTO_UPDATE: "0" } } },
+      },
+    ],
+  };
+  const command = buildAgentCommand("acp", { prompt: "hello" }, {
+    HEADLESS_BIN: "headless-dev",
+    HEADLESS_ACP_AGENT: "example-acp",
+    HEADLESS_ACP_REGISTRY_JSON: JSON.stringify(registry),
+  });
+
+  assert.deepEqual(command, {
+    command: "headless-dev",
+    args: ["acp-client", "--", process.platform === "win32" ? "npx.cmd" : "npx", "-y", "example-acp@1.2.3", "--acp"],
+    env: { EXAMPLE_AUTO_UPDATE: "0" },
+    stdinText: "hello",
+  });
 });
 
 test("builds reasoning effort flags for supported agents", () => {
@@ -1408,6 +1445,32 @@ test("CLI reports when no installed agent can be auto-selected", async () => {
 
   assert.equal(code, 2);
   assert.match(stderr.join(""), /no supported agent found/);
+});
+
+test("CLI rejects ACP without a registry agent or custom command", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["acp", "--prompt", "hello"], {
+    env: { ...process.env, HEADLESS_ACP_AGENT: undefined, HEADLESS_ACP_COMMAND: undefined },
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /acp requires --acp-agent, --acp-command/);
+});
+
+test("CLI aggregates chunked ACP stdio output", async () => {
+  const stdout: string[] = [];
+  const code = await runCli(["acp", "--prompt", "hello acp"], {
+    env: {
+      ...process.env,
+      HEADLESS_BIN: `${process.execPath} --import tsx ${join(repoRoot, "src", "cli.ts")}`,
+      HEADLESS_ACP_COMMAND: `${process.execPath} --import tsx ${join(repoRoot, "src", "cli.ts")} acp-stdio`,
+    },
+    stdout: (text) => stdout.push(text),
+  });
+
+  assert.equal(code, 0);
+  assert.equal(stdout.join(""), "hello acp\n");
 });
 
 test("CLI prints final assistant message by default", async () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -116,6 +116,33 @@ test("builds ACP adapter command from registry npx distribution", () => {
   });
 });
 
+test("rejects ACP registry binary archive distributions without local install support", () => {
+  const registry = {
+    agents: [
+      {
+        id: "example-binary",
+        distribution: {
+          binary: {
+            "darwin-aarch64": { archive: "https://example.com/example.tar.gz", cmd: "./example-acp" },
+            "darwin-x86_64": { archive: "https://example.com/example.tar.gz", cmd: "./example-acp" },
+            "linux-aarch64": { archive: "https://example.com/example.tar.gz", cmd: "./example-acp" },
+            "linux-x86_64": { archive: "https://example.com/example.tar.gz", cmd: "./example-acp" },
+            "windows-x86_64": { archive: "https://example.com/example.zip", cmd: "example-acp.exe" },
+          },
+        },
+      },
+    ],
+  };
+
+  assert.throws(
+    () => buildAgentCommand("acp", { prompt: "hello" }, {
+      HEADLESS_ACP_AGENT: "example-binary",
+      HEADLESS_ACP_REGISTRY_JSON: JSON.stringify(registry),
+    }),
+    /binary archive distributions are not supported/,
+  );
+});
+
 test("builds reasoning effort flags for supported agents", () => {
   assert.deepEqual(buildAgentCommand("codex", { prompt: "hello", reasoningEffort: "high" }, {}).args, [
     "--dangerously-bypass-approvals-and-sandbox",

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { buildAgentCommand, buildInteractiveAgentCommand, getAgentConfig, listAgents } from "../src/agents.ts";
+import { acpClientCapabilities } from "../src/acp.ts";
 import { runCli } from "../src/cli.ts";
 import { parseHeadlessConfig } from "../src/config.ts";
 import { DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
@@ -82,6 +83,12 @@ test("builds ACP adapter command with read-only permission mode", () => {
     args: ["acp-client", "--", "atlas", "alta", "agent", "run"],
     env: { HEADLESS_ACP_ALLOW: "read-only" },
     stdinText: "hello",
+  });
+});
+
+test("ACP client advertises read-only filesystem capability", () => {
+  assert.deepEqual(acpClientCapabilities, {
+    fs: { readTextFile: true, writeTextFile: false },
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
+    "skipLibCheck": true,
     "strict": true,
     "target": "ES2022"
   },


### PR DESCRIPTION
## Summary
- Add an ACP (`agentclientprotocol`) harness powered by `@agentclientprotocol/sdk`.
- Support registry-backed `--acp-agent` resolution plus custom ACP server commands via `--acp-command`, including `atlas alta agent run`.
- Add ACP registry override flags/env vars and setup-check integration while keeping ACP explicit-only (not auto-selected).
- Aggregate streamed ACP assistant chunks into a final assistant message, with regression coverage.
- Document ACP usage in README, usage guide, and changelog.

## Test plan
- [x] `npm run check` — 220 tests passing
- [x] Real Alta ACP smoke: `headless acp --acp-command "atlas alta agent run" --prompt "Reply with exactly: alta-smoke-ok"` returned `alta-smoke-ok`

## Notes
- `headless acp` now requires an explicit backend through `--acp-agent`, `--acp-command`, `HEADLESS_ACP_AGENT`, or `HEADLESS_ACP_COMMAND`.
- `skipLibCheck` is enabled because the published ACP SDK declarations currently emit duplicate type export errors under this TypeScript configuration.