### PR TITLE
Add headless swarm skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added the bundled `headless-swarm` Codex skill for coordinating visible macOS Ghostty/tmux Headless agent swarms.
 - Changed npm package contents to include bundled skills.
+- Changed Headless tmux session listing to mark sessions waiting after 15 seconds of inactivity by default.
 - Added README instructions for installing the bundled Codex skill with `npx`.
 
 ## 0.3.0 - 2026-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## TBD
+
+- Added the bundled `headless-swarm` Codex skill for coordinating visible macOS Ghostty/tmux Headless agent swarms.
+- Changed npm package contents to include bundled skills.
+- Added README instructions for installing the bundled Codex skill with `npx`.
 
 ## 0.3.0 - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ headless codex --prompt "Hello world"
 
 Requires Node.js 22+.
 
+To install the bundled Codex skill for visual Headless swarms, use `npx` to copy a tagged release into Codex's skill directory:
+
+```bash
+mkdir -p ~/.codex/skills
+HEADLESS_REF=v0.4.0
+npx -y degit@2.8.4 "RobertTLange/headless-cli/skills/headless-swarm#$HEADLESS_REF" ~/.codex/skills/headless-swarm
+```
+
 ## Core Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ headless codex --prompt "Hello world"
 
 Requires Node.js 22+.
 
-To install the bundled Codex skill for visual Headless swarms, use `npx` to copy a tagged release into Codex's skill directory:
+To install the bundled Codex skill for visual Headless swarms, use `npx` to copy it into Codex's skill directory:
 
 ```bash
 mkdir -p ~/.codex/skills
-HEADLESS_REF=v0.4.0
+HEADLESS_REF=main
 npx -y degit@2.8.4 "RobertTLange/headless-cli/skills/headless-swarm#$HEADLESS_REF" ~/.codex/skills/headless-swarm
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,7 +76,7 @@ headless codex --prompt "Fix the tests" --tmux --name work
 headless codex --prompt "Run focused tests" --tmux --session work
 ```
 
-Use `headless --list` to list active tmux sessions created by Headless. Use `headless send <session-name> --prompt "..."` for follow-up messages and `headless rename <session-name> <new-name>` to rename managed sessions.
+Use `headless --list` to list active tmux sessions created by Headless. Sessions are marked `waiting` after 15 seconds without tmux window activity; override this with `HEADLESS_LIST_WAITING_AFTER_MS`. Use `headless send <session-name> --prompt "..."` for follow-up messages and `headless rename <session-name> <new-name>` to rename managed sessions.
 
 ```bash
 headless --list

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "files": [
     "Dockerfile",
     "config.toml.example",
-    "dist"
+    "dist",
+    "skills"
   ],
   "scripts": {
     "build": "tsc && chmod +x dist/cli.js",

--- a/skills/headless-swarm/SKILL.md
+++ b/skills/headless-swarm/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: headless-swarm
+description: Create and control a visual macOS Ghostty split layout of durable Headless tmux agent sessions. Use when an orchestrator agent needs to split the current Ghostty tab into visible subagent panes, send follow-up messages to subagents, capture their visible feedback, or coordinate multi-agent Headless work from one main pane.
+---
+
+# Headless Swarm
+
+Use this skill to coordinate several `headless` subagents from a main orchestrator pane while keeping each subagent visible in Ghostty.
+
+Resolve the bundled helper first; do not assume the current repository has a root-level `scripts/` directory:
+
+```bash
+HELPER="$HOME/.codex/skills/headless-swarm/scripts/headless-splits"
+[ -x "$HELPER" ] || { echo "Install headless-swarm into ~/.codex/skills first" >&2; exit 1; }
+"$HELPER" --help
+```
+
+## Workflow
+
+1. Start from the orchestrator agent running inside Ghostty on macOS.
+2. Create visible subagent splits with `start`.
+3. Send follow-ups with `send` or `send-all`.
+4. Wait for tracked sessions to become idle with `wait`, then retrieve feedback with `capture-all` or `capture`.
+5. Clean up with `cleanup --kill-sessions` when the swarm is no longer needed.
+
+```bash
+"$HELPER" start --agent codex --work-dir "$PWD" --prompt "Investigate the failing tests. Report findings only." worker-1 worker-2 reviewer
+"$HELPER" start --work-dir "$PWD" --prompt "Use your assigned role. Report findings only." codex:code claude:review gemini:docs pi:ux
+"$HELPER" send worker-1 --agent codex --prompt "Focus on src/sessions.ts and report the likely root cause."
+"$HELPER" send-all worker-1 worker-2 --agent codex --prompt "Stop after findings. Do not edit files."
+"$HELPER" status
+"$HELPER" wait --timeout 120
+"$HELPER" capture-all
+```
+
+## Behavior
+
+- Prefer the helper over raw AppleScript, raw `tmux send-keys`, or direct agent CLI calls.
+- Use Headless named tmux sessions as durable endpoints: node `worker-1` with agent `codex` maps to `headless-codex-worker-1`.
+- `start` launches all requested Headless sessions in parallel, then rebuilds the visible tmux aggregator once.
+- For mixed-agent starts, prefix nodes as `agent:node`, for example `codex:code claude:review gemini:docs`. Unprefixed nodes use `--agent`.
+- If the node equals the agent, for example `claude:claude`, the tmux name is normalized to `headless-claude-main` instead of `headless-claude-claude`.
+- Keep the focused orchestrator pane as a full-height left control pane. Subagents appear in one right-side Ghostty pane running a tmux aggregator.
+- Size the nested tmux grid explicitly: 4 agents become 2 x 2, and 8 agents become 2 x 4.
+- On each `start`, rebuild the current Ghostty tab's tracked Headless sessions, then include both existing and newly started sessions in the aggregator.
+- Stale sessions from the current tab's state are pruned before rebuilding the aggregator.
+- Treat the current Ghostty tab as owned by the swarm layout: `start` keeps the orchestrator pane and closes all other panes before creating the right-side aggregator.
+- The aggregator pane is launched with Ghostty's command configuration, not by typing into an interactive shell.
+- Send follow-up work through `headless send` via the helper.
+- Use `status`, `wait`, and `capture-all` for mixed-agent swarms. Use `send agent:node` or `capture agent:node` for one explicit mixed-agent node.
+- Use `cleanup` to remove the tab aggregator and state; add `--kill-sessions` only when the durable Headless sessions should be terminated too.
+
+## Prompting
+
+Give each node a narrow assignment and tell it whether edits are allowed. The helper prefixes prompts with node identity and a reminder that the orchestrator will route follow-ups through Headless.
+
+For prompts longer than a short sentence, prefer `--prompt-file`:
+
+```bash
+"$HELPER" start --agent codex --work-dir "$PWD" --prompt-file /tmp/swarm-task.md worker-1 reviewer
+"$HELPER" send reviewer --agent codex --prompt-file /tmp/review-followup.md
+```
+
+## Recovery
+
+If Ghostty automation fails, verify AppleScript support:
+
+```bash
+osascript -e 'tell application "Ghostty" to get version'
+```
+
+If a visible split closes, reattach manually:
+
+```bash
+headless attach headless-codex-worker-1
+```
+
+If a node is not responding, check status and capture:
+
+```bash
+"$HELPER" status
+"$HELPER" wait --timeout 120
+"$HELPER" capture worker-1 --agent codex
+```

--- a/skills/headless-swarm/SKILL.md
+++ b/skills/headless-swarm/SKILL.md
@@ -1,17 +1,28 @@
 ---
 name: headless-swarm
-description: Create and control a visual macOS Ghostty split layout of durable Headless tmux agent sessions. Use when an orchestrator agent needs to split the current Ghostty tab into visible subagent panes, send follow-up messages to subagents, capture their visible feedback, or coordinate multi-agent Headless work from one main pane.
+description: Create and control a visual macOS Ghostty split layout of durable Headless tmux agent sessions. Use when an orchestrator agent needs to launch visible subagent panes for Codex, Claude, Gemini, Pi, Cursor, or OpenCode, send follow-up messages, capture feedback, or coordinate multi-agent Headless work from one main pane.
 ---
 
 # Headless Swarm
 
-Use this skill to coordinate several `headless` subagents from a main orchestrator pane while keeping each subagent visible in Ghostty.
+Use this skill to coordinate several `headless` subagents from a main orchestrator pane while keeping each subagent visible in Ghostty. The orchestrator can be any agent that can run shell commands; the subagents can be any backend supported by Headless.
 
-Resolve the bundled helper first; do not assume the current repository has a root-level `scripts/` directory:
+Resolve the bundled helper from a trusted installed skill directory. Do not run a helper from the current repository unless the user explicitly installed or selected that copy.
 
 ```bash
-HELPER="$HOME/.codex/skills/headless-swarm/scripts/headless-splits"
-[ -x "$HELPER" ] || { echo "Install headless-swarm into ~/.codex/skills first" >&2; exit 1; }
+for dir in \
+  "${HEADLESS_SWARM_SKILL_DIR:-}" \
+  "$HOME/.agents/skills/headless-swarm" \
+  "$HOME/.codex/skills/headless-swarm" \
+  "$HOME/.claude/skills/headless-swarm" \
+  "$HOME/.pi/skills/headless-swarm" \
+  "$HOME/.gemini/skills/headless-swarm" \
+  "$HOME/.opencode/skills/headless-swarm" \
+do
+  [ -n "$dir" ] && [ -x "$dir/scripts/headless-splits" ] && SKILL_DIR="$dir" && break
+done
+[ -n "${SKILL_DIR:-}" ] || { echo "Install headless-swarm or set HEADLESS_SWARM_SKILL_DIR" >&2; exit 1; }
+HELPER="$SKILL_DIR/scripts/headless-splits"
 "$HELPER" --help
 ```
 
@@ -24,10 +35,9 @@ HELPER="$HOME/.codex/skills/headless-swarm/scripts/headless-splits"
 5. Clean up with `cleanup --kill-sessions` when the swarm is no longer needed.
 
 ```bash
-"$HELPER" start --agent codex --work-dir "$PWD" --prompt "Investigate the failing tests. Report findings only." worker-1 worker-2 reviewer
 "$HELPER" start --work-dir "$PWD" --prompt "Use your assigned role. Report findings only." codex:code claude:review gemini:docs pi:ux
-"$HELPER" send worker-1 --agent codex --prompt "Focus on src/sessions.ts and report the likely root cause."
-"$HELPER" send-all worker-1 worker-2 --agent codex --prompt "Stop after findings. Do not edit files."
+"$HELPER" send claude:review --prompt "Focus on regressions and security risks."
+"$HELPER" send-all codex:code gemini:docs --prompt "Stop after findings. Do not edit files."
 "$HELPER" status
 "$HELPER" wait --timeout 120
 "$HELPER" capture-all
@@ -36,9 +46,9 @@ HELPER="$HOME/.codex/skills/headless-swarm/scripts/headless-splits"
 ## Behavior
 
 - Prefer the helper over raw AppleScript, raw `tmux send-keys`, or direct agent CLI calls.
-- Use Headless named tmux sessions as durable endpoints: node `worker-1` with agent `codex` maps to `headless-codex-worker-1`.
+- Use Headless named tmux sessions as durable endpoints: node `review` with agent `claude` maps to `headless-claude-review`.
 - `start` launches all requested Headless sessions in parallel, then rebuilds the visible tmux aggregator once.
-- For mixed-agent starts, prefix nodes as `agent:node`, for example `codex:code claude:review gemini:docs`. Unprefixed nodes use `--agent`.
+- For mixed-agent starts, prefix nodes as `agent:node`, for example `codex:code claude:review gemini:docs pi:ux`. Unprefixed nodes use `--agent`.
 - If the node equals the agent, for example `claude:claude`, the tmux name is normalized to `headless-claude-main` instead of `headless-claude-claude`.
 - Keep the focused orchestrator pane as a full-height left control pane. Subagents appear in one right-side Ghostty pane running a tmux aggregator.
 - Size the nested tmux grid explicitly: 4 agents become 2 x 2, and 8 agents become 2 x 4.
@@ -57,8 +67,8 @@ Give each node a narrow assignment and tell it whether edits are allowed. The he
 For prompts longer than a short sentence, prefer `--prompt-file`:
 
 ```bash
-"$HELPER" start --agent codex --work-dir "$PWD" --prompt-file /tmp/swarm-task.md worker-1 reviewer
-"$HELPER" send reviewer --agent codex --prompt-file /tmp/review-followup.md
+"$HELPER" start --work-dir "$PWD" --prompt-file /tmp/swarm-task.md codex:worker claude:reviewer
+"$HELPER" send claude:reviewer --prompt-file /tmp/review-followup.md
 ```
 
 ## Recovery
@@ -72,7 +82,7 @@ osascript -e 'tell application "Ghostty" to get version'
 If a visible split closes, reattach manually:
 
 ```bash
-headless attach headless-codex-worker-1
+headless attach headless-claude-review
 ```
 
 If a node is not responding, check status and capture:
@@ -80,5 +90,5 @@ If a node is not responding, check status and capture:
 ```bash
 "$HELPER" status
 "$HELPER" wait --timeout 120
-"$HELPER" capture worker-1 --agent codex
+"$HELPER" capture claude:review
 ```

--- a/skills/headless-swarm/agents/openai.yaml
+++ b/skills/headless-swarm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Headless Swarm"
+  short_description: "Parallel Ghostty swarms for Headless"
+  default_prompt: "Use $headless-swarm to launch several Headless subagents in parallel, show them in a Ghostty tmux grid, and coordinate them from this pane."

--- a/skills/headless-swarm/scripts/create-aggregator
+++ b/skills/headless-swarm/scripts/create-aggregator
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+tmux_bin=$1
+aggregator=$2
+sessions=$3
+
+floor_sqrt() {
+  value=$1
+  result=1
+  while [ $(((result + 1) * (result + 1))) -le "$value" ]; do
+    result=$((result + 1))
+  done
+  printf '%s' "$result"
+}
+
+shell_quote() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+session_count=$(printf '%s\n' "$sessions" | sed '/^$/d' | wc -l | tr -d ' ')
+[ "$session_count" -gt 0 ] || {
+  printf '%s\n' "create-aggregator: cannot create empty swarm aggregator" >&2
+  exit 1
+}
+row_count=$(floor_sqrt "$session_count")
+column_count=$(((session_count + row_count - 1) / row_count))
+first_session=$(printf '%s\n' "$sessions" | sed '/^$/d; q')
+
+if "$tmux_bin" has-session -t "$aggregator" 2>/dev/null; then
+  "$tmux_bin" kill-session -t "$aggregator"
+fi
+
+"$tmux_bin" new-session -d -x 240 -y 80 -s "$aggregator" \
+  "/usr/bin/env -u TMUX $(shell_quote "$tmux_bin") attach-session -t $(shell_quote "$first_session")"
+
+printf '%s\n' "$sessions" | sed -n "2,${column_count}p" | while IFS= read -r session; do
+  [ -n "$session" ] || continue
+  "$tmux_bin" split-window -h -t "$aggregator" \
+    "/usr/bin/env -u TMUX $(shell_quote "$tmux_bin") attach-session -t $(shell_quote "$session")"
+  "$tmux_bin" select-layout -t "$aggregator" even-horizontal >/dev/null
+done
+
+pane_ids=$("$tmux_bin" list-panes -t "$aggregator" -F '#{pane_left}	#{pane_id}' | sort -n | cut -f2)
+column_index=1
+printf '%s\n' "$pane_ids" | while IFS= read -r pane_id; do
+  row_index=2
+  while [ "$row_index" -le "$row_count" ]; do
+    session_position=$(((row_index - 1) * column_count + column_index))
+    if [ "$session_position" -le "$session_count" ]; then
+      session=$(printf '%s\n' "$sessions" | sed -n "${session_position}p")
+      "$tmux_bin" split-window -v -t "$pane_id" \
+        "/usr/bin/env -u TMUX $(shell_quote "$tmux_bin") attach-session -t $(shell_quote "$session")"
+    fi
+    row_index=$((row_index + 1))
+  done
+  column_index=$((column_index + 1))
+done

--- a/skills/headless-swarm/scripts/headless-splits
+++ b/skills/headless-swarm/scripts/headless-splits
@@ -1,0 +1,516 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+usage() {
+  cat <<'EOF'
+Usage:
+  headless-splits start [options] <node>...
+  headless-splits send [options] <node>
+  headless-splits send-all [options] <node>...
+  headless-splits status [options]
+  headless-splits capture [options] <node>
+  headless-splits capture-all [options]
+  headless-splits wait [options]
+  headless-splits cleanup [options]
+
+Options:
+  --agent <name>        Headless agent name. Default: codex
+  --work-dir <path>     Work directory for start. Default: current directory
+  --prompt <text>       Prompt text for start/send/send-all
+  --prompt-file <path>  Read prompt text from file
+  --timeout <seconds>   Timeout for wait until tracked sessions are idle. Default: 90
+  --interval <seconds>  Poll interval for wait. Default: 5
+  --kill-sessions       With cleanup, also kill tracked Headless sessions
+  --help                Show this help
+
+Examples:
+  headless-splits start --agent codex --work-dir "$PWD" --prompt "Investigate failures" worker-1 worker-2
+  headless-splits start --work-dir "$PWD" --prompt "Use your assigned role." codex:code claude:review gemini:docs
+  headless-splits send worker-1 --agent codex --prompt "Report only root cause."
+  headless-splits capture worker-1 --agent codex
+  headless-splits wait --timeout 120
+  headless-splits capture-all
+EOF
+}
+
+die() {
+  printf '%s\n' "headless-splits: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+need_headless() {
+  headless_bin=$(command -v headless 2>/dev/null || true)
+  [ -n "$headless_bin" ] || die "missing required command: headless"
+}
+
+need_tmux() {
+  tmux_bin=$(command -v tmux 2>/dev/null || true)
+  [ -n "$tmux_bin" ] || die "missing required command: tmux"
+}
+
+swarm_state_dir() {
+  if [ -n "${HEADLESS_SWARM_STATE_DIR:-}" ]; then
+    printf '%s' "$HEADLESS_SWARM_STATE_DIR"
+  elif [ -n "${XDG_STATE_HOME:-}" ]; then
+    printf '%s/headless-swarm' "$XDG_STATE_HOME"
+  elif [ -n "${HOME:-}" ]; then
+    printf '%s/.local/state/headless-swarm' "$HOME"
+  else
+    die "HOME is required for swarm layout state"
+  fi
+}
+
+current_ghostty_tab_id() {
+  osascript <<'APPLESCRIPT'
+tell application "Ghostty"
+  get id of selected tab of front window
+end tell
+APPLESCRIPT
+}
+
+aggregator_name_for_tab() {
+  printf 'headless-swarm-%s' "$1"
+}
+
+session_name_for() {
+  printf 'headless-%s-%s' "$1" "$2"
+}
+
+validate_agent() {
+  case "$1" in
+    claude|codex|cursor|gemini|opencode|pi) ;;
+    *) die "unsupported agent: $1" ;;
+  esac
+}
+
+validate_node() {
+  case "$1" in
+    ''|*[!A-Za-z0-9_.-]*)
+      die "invalid node name '$1'; use only letters, digits, dot, underscore, or hyphen"
+      ;;
+  esac
+}
+
+parse_start_spec() {
+  case "$1" in
+    *:*)
+      node_agent=${1%%:*}
+      node=${1#*:}
+      ;;
+    *)
+      node_agent=$agent
+      node=$1
+      ;;
+  esac
+  validate_agent "$node_agent"
+  validate_node "$node"
+  if [ "$node" = "$node_agent" ]; then
+    session_alias=main
+  else
+    session_alias=$node
+  fi
+}
+
+read_prompt() {
+  if [ -n "$prompt_file" ]; then
+    [ -r "$prompt_file" ] || die "cannot read prompt file: $prompt_file"
+    cat "$prompt_file"
+    return
+  fi
+  printf '%s' "$prompt"
+}
+
+require_prompt() {
+  if [ -z "$prompt" ] && [ -z "$prompt_file" ]; then
+    die "$command requires --prompt or --prompt-file"
+  fi
+}
+
+require_macos_ghostty() {
+  [ "$(uname -s)" = "Darwin" ] || die "Ghostty split automation is macOS-only"
+  need_cmd osascript
+  osascript -e 'tell application "Ghostty" to get version' >/dev/null 2>&1 ||
+    die "cannot control Ghostty with AppleScript; open Ghostty and approve macOS Automation permission"
+}
+
+layout_and_attach() {
+  dir=$1
+  aggregator_session=$2
+  tmux_path=$3
+  existing_state=$4
+
+  osascript "$script_dir/layout-ghostty.applescript" "$dir" "$aggregator_session" "$tmux_path" "$existing_state"
+}
+
+state_sessions() {
+  if [ -n "$existing_state" ]; then
+    printf '%s\n' "$existing_state" | awk -F '\t' '$1 == "session" && $2 != "" { print $2 }'
+  fi
+}
+
+append_unique_sessions() {
+  awk 'NF && !seen[$0]++'
+}
+
+write_swarm_state() {
+  layout=$1
+  sessions=$2
+  tmp_file=$state_file.tmp.$$
+  {
+    if [ -n "$layout" ]; then
+      printf '%s\n' "$layout" | awk -F '\t' '($1 == "pane" || $1 == "swarm-pane") && $2 != "" { print }'
+    fi
+    printf '%s\n' "$sessions" | while IFS= read -r session; do
+      [ -n "$session" ] && printf 'session\t%s\n' "$session"
+    done
+  } >"$tmp_file"
+  mv "$tmp_file" "$state_file"
+}
+
+load_tab_state() {
+  state_dir=$(swarm_state_dir)
+  mkdir -p "$state_dir"
+  tab_id=$(current_ghostty_tab_id | sed 's/[^A-Za-z0-9_.-]/_/g')
+  state_file=$state_dir/$tab_id.tsv
+  existing_state=
+  if [ -r "$state_file" ]; then
+    existing_state=$(cat "$state_file")
+  fi
+  aggregator=$(aggregator_name_for_tab "$tab_id")
+}
+
+filter_live_sessions() {
+  while IFS= read -r session; do
+    [ -n "$session" ] || continue
+    if "$tmux_bin" has-session -t "$session" 2>/dev/null; then
+      printf '%s\n' "$session"
+    else
+      printf '%s\n' "dropping stale session from swarm state: $session" >&2
+    fi
+  done | append_unique_sessions
+}
+
+create_aggregator() {
+  "$script_dir/create-aggregator" "$tmux_bin" "$1" "$2"
+}
+
+start_node() {
+  node_agent=$1
+  node=$2
+  session_alias=$3
+  session=$(session_name_for "$node_agent" "$session_alias")
+  base_prompt=$(read_prompt)
+  node_prompt=$(cat <<EOF
+You are node $node in a visual Headless swarm.
+
+Orchestrator routing:
+- Your durable session is $session.
+- The orchestrator will send follow-up messages through headless send.
+- Leave your final feedback visible in this pane.
+
+Task:
+$base_prompt
+EOF
+)
+
+  "$headless_bin" "$node_agent" --tmux --session "$session_alias" --work-dir "$work_dir" --prompt "$node_prompt" >/dev/null
+  printf '%s' "$session"
+}
+
+start_nodes_parallel() {
+  tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/headless-splits.XXXXXX") || die "could not create temporary directory"
+  plan_file=$tmp_dir/plan
+  for raw_node in $nodes; do
+    parse_start_spec "$raw_node"
+    session=$(session_name_for "$node_agent" "$session_alias")
+    printf '%s\t%s\t%s\t%s\n' "$node_agent" "$node" "$session_alias" "$session" >>"$plan_file"
+  done
+  duplicate=$(awk -F '\t' 'seen[$4]++ { print $4; exit }' "$plan_file")
+  if [ -n "$duplicate" ]; then
+    rm -rf "$tmp_dir"
+    die "duplicate node specs resolve to the same tmux session: $duplicate"
+  fi
+
+  jobs=
+  index=0
+  while IFS='	' read -r node_agent node session_alias session; do
+    index=$((index + 1))
+    printf '%s\n' "starting $session" >&2
+    ( start_node "$node_agent" "$node" "$session_alias" >"$tmp_dir/session.$index" ) 2>"$tmp_dir/stderr.$index" &
+    jobs="${jobs}${jobs:+ }$!:$index"
+  done <"$plan_file"
+
+  failed=false
+  new_sessions=
+  for job in $jobs; do
+    pid=${job%%:*}
+    index=${job#*:}
+    if ! wait "$pid"; then
+      failed=true
+    fi
+    [ ! -s "$tmp_dir/stderr.$index" ] || cat "$tmp_dir/stderr.$index" >&2
+    if [ -s "$tmp_dir/session.$index" ]; then
+      session=$(cat "$tmp_dir/session.$index")
+      new_sessions="${new_sessions}${new_sessions:+
+}$session"
+    fi
+  done
+  rm -rf "$tmp_dir"
+  [ "$failed" = false ] || die "one or more Headless sessions failed to start"
+}
+
+send_node() {
+  parse_start_spec "$1"
+  session=$(session_name_for "$node_agent" "$session_alias")
+  "$headless_bin" send "$session" --prompt "$(read_prompt)"
+}
+
+capture_node() {
+  parse_start_spec "$1"
+  session=$(session_name_for "$node_agent" "$session_alias")
+  need_tmux
+  capture_session "$session"
+}
+
+capture_session() {
+  session=$1
+  pane_id=$("$tmux_bin" list-panes -s -t "$session" -F '#{pane_active}	#{pane_id}' 2>/dev/null | awk '$1 == 1 { print $2; exit }')
+  if [ -z "$pane_id" ]; then
+    pane_id=$("$tmux_bin" list-panes -s -t "$session" -F '#{pane_id}' 2>/dev/null | sed -n '1p')
+  fi
+  [ -n "$pane_id" ] || die "could not find a tmux pane for $session; try: headless attach $session"
+  "$tmux_bin" capture-pane -p -t "$pane_id" -S -2000 2>/dev/null ||
+    die "could not capture $session; try: headless attach $session"
+}
+
+tracked_sessions_or_die() {
+  load_tab_state
+  tracked_sessions=$(state_sessions | append_unique_sessions)
+  [ -n "$tracked_sessions" ] || die "no tracked swarm sessions for the current Ghostty tab"
+}
+
+status_nodes() {
+  if [ -n "${tracked_sessions:-}" ]; then
+    list=$("$headless_bin" --list 2>/dev/null || true)
+    header=$(printf '%s\n' "$list" | sed -n '1p')
+    printed_header=false
+    printf '%s\n' "$tracked_sessions" | while IFS= read -r session; do
+      line=$(printf '%s\n' "$list" | awk -v s="$session" '$1 == s { print; found = 1 } END { if (!found) exit 1 }') || true
+      if [ -n "$line" ]; then
+        if [ "$printed_header" = false ]; then
+          printf '%s\n' "$header"
+          printed_header=true
+        fi
+        printf '%s\n' "$line"
+      else
+        printf '%s\tmissing\tunknown\t-\t-\t-\n' "$session"
+      fi
+    done
+  elif "$headless_bin" --list 2>/dev/null | grep "headless-$agent-" >/dev/null 2>&1; then
+    "$headless_bin" --list | grep "headless-$agent-"
+  else
+    printf '%s\n' "No active headless tmux sessions for agent: $agent"
+  fi
+}
+
+session_state() {
+  "$headless_bin" --list 2>/dev/null | awk -v s="$1" '$1 == s { print $3; found = 1 } END { if (!found) exit 1 }'
+}
+
+wait_tracked_sessions() {
+  end_time=$(($(date +%s) + timeout))
+  while :; do
+    pending=
+    missing=
+    dead=
+    for session in $tracked_sessions; do
+      state=$(session_state "$session" || true)
+      case "$state" in
+        waiting|completed|done|exited) ;;
+        dead) dead="${dead}${dead:+ }$session" ;;
+        '') missing="${missing}${missing:+ }$session" ;;
+        *) pending="${pending}${pending:+ }$session:$state" ;;
+      esac
+    done
+    if [ -n "$dead" ]; then
+      printf '%s\n' "dead sessions: $dead" >&2
+      return 1
+    fi
+    [ -z "$pending" ] && [ -z "$missing" ] && return 0
+    if [ "$(date +%s)" -ge "$end_time" ]; then
+      [ -z "$pending" ] || printf '%s\n' "still pending: $pending" >&2
+      [ -z "$missing" ] || printf '%s\n' "missing from headless list: $missing" >&2
+      return 1
+    fi
+    sleep "$interval"
+  done
+}
+
+command=${1:-}
+[ -n "$command" ] || { usage; exit 2; }
+case "$command" in
+  --help|-h|help)
+    usage
+    exit 0
+    ;;
+esac
+shift
+
+agent=codex
+headless_bin=
+work_dir=$PWD
+prompt=
+prompt_file=
+nodes=
+timeout=90
+interval=5
+kill_sessions=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --agent)
+      [ "$#" -ge 2 ] || die "--agent requires a value"
+      agent=$2
+      shift 2
+      ;;
+    --work-dir|-C)
+      [ "$#" -ge 2 ] || die "--work-dir requires a value"
+      work_dir=$2
+      shift 2
+      ;;
+    --prompt)
+      [ "$#" -ge 2 ] || die "--prompt requires a value"
+      prompt=$2
+      shift 2
+      ;;
+    --prompt-file)
+      [ "$#" -ge 2 ] || die "--prompt-file requires a value"
+      prompt_file=$2
+      shift 2
+      ;;
+    --timeout)
+      [ "$#" -ge 2 ] || die "--timeout requires a value"
+      timeout=$2
+      shift 2
+      ;;
+    --interval)
+      [ "$#" -ge 2 ] || die "--interval requires a value"
+      interval=$2
+      shift 2
+      ;;
+    --kill-sessions)
+      kill_sessions=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      die "unknown option: $1"
+      ;;
+    *)
+      nodes="${nodes}${nodes:+
+}$1"
+      shift
+      ;;
+  esac
+done
+
+validate_agent "$agent"
+
+case "$timeout" in ''|*[!0-9]*) die "invalid --timeout: $timeout" ;; esac
+case "$interval" in ''|*[!0-9]*) die "invalid --interval: $interval" ;; esac
+
+case "$command" in
+  start)
+    require_prompt
+    [ -d "$work_dir" ] || die "work directory does not exist: $work_dir"
+    [ -n "$nodes" ] || die "start requires at least one node"
+    need_headless
+    need_tmux
+    require_macos_ghostty
+    load_tab_state
+    start_nodes_parallel
+    combined_sessions=$(
+      {
+        state_sessions
+        printf '%s\n' "$new_sessions"
+      } | filter_live_sessions
+    )
+    write_swarm_state "$existing_state" "$combined_sessions"
+    create_aggregator "$aggregator" "$combined_sessions"
+    layout_state=$(layout_and_attach "$work_dir" "$aggregator" "$tmux_bin" "$existing_state")
+    write_swarm_state "$layout_state" "$combined_sessions"
+    ;;
+  send)
+    require_prompt
+    [ "$(printf '%s\n' "$nodes" | sed '/^$/d' | wc -l | tr -d ' ')" = "1" ] || die "send requires exactly one node"
+    need_headless
+    send_node "$nodes"
+    ;;
+  send-all)
+    require_prompt
+    [ -n "$nodes" ] || die "send-all requires at least one node"
+    need_headless
+    printf '%s\n' "$nodes" | while IFS= read -r node; do
+      send_node "$node"
+    done
+    ;;
+  status)
+    [ -z "$nodes" ] || die "status does not accept node arguments"
+    need_headless
+    tracked_sessions=
+    if current_ghostty_tab_id >/dev/null 2>&1; then
+      load_tab_state
+      tracked_sessions=$(state_sessions | append_unique_sessions)
+    fi
+    status_nodes
+    ;;
+  capture)
+    [ "$(printf '%s\n' "$nodes" | sed '/^$/d' | wc -l | tr -d ' ')" = "1" ] || die "capture requires exactly one node"
+    capture_node "$nodes"
+    ;;
+  capture-all)
+    [ -z "$nodes" ] || die "capture-all does not accept node arguments"
+    need_tmux
+    tracked_sessions_or_die
+    for session in $tracked_sessions; do
+      printf '\n===== %s =====\n' "$session"
+      capture_session "$session"
+    done
+    ;;
+  wait)
+    [ -z "$nodes" ] || die "wait does not accept node arguments"
+    need_headless
+    tracked_sessions_or_die
+    wait_tracked_sessions
+    ;;
+  cleanup)
+    [ -z "$nodes" ] || die "cleanup does not accept node arguments"
+    need_tmux
+    tracked_sessions=
+    load_tab_state
+    if [ -n "$existing_state" ]; then
+      tracked_sessions=$(state_sessions | append_unique_sessions)
+    fi
+    if "$tmux_bin" has-session -t "$aggregator" 2>/dev/null; then
+      "$tmux_bin" kill-session -t "$aggregator"
+    fi
+    if [ "$kill_sessions" = true ]; then
+      for session in $tracked_sessions; do
+        "$tmux_bin" kill-session -t "$session" 2>/dev/null || true
+      done
+    fi
+    rm -f "$state_file"
+    ;;
+  *)
+    die "unknown command: $command"
+    ;;
+esac

--- a/skills/headless-swarm/scripts/layout-ghostty.applescript
+++ b/skills/headless-swarm/scripts/layout-ghostty.applescript
@@ -1,0 +1,80 @@
+on parseStateLine(stateLine)
+  set oldDelimiters to AppleScript's text item delimiters
+  set AppleScript's text item delimiters to tab
+  set parts to text items of stateLine
+  set AppleScript's text item delimiters to oldDelimiters
+  if (count of parts) < 2 then return {"", ""}
+  return {item 1 of parts, item 2 of parts}
+end parseStateLine
+
+on containsValue(theList, theValue)
+  repeat with itemValue in theList
+    if (itemValue as text) is theValue then return true
+  end repeat
+  return false
+end containsValue
+
+on appendUnique(theList, theValue)
+  if theValue is not "" and theList does not contain theValue then
+    set end of theList to theValue
+  end if
+  return theList
+end appendUnique
+
+on run argv
+  set workDir to item 1 of argv
+  set aggregatorSession to item 2 of argv
+  set tmuxPath to item 3 of argv
+  set existingState to paragraphs of (item 4 of argv)
+
+  tell application "Ghostty"
+    activate
+    set cfg to new surface configuration
+    set initial working directory of cfg to workDir
+    set currentTab to selected tab of front window
+    set anchor to focused terminal of currentTab
+
+    set trackedPaneIds to {}
+    set panesToClose to {}
+    repeat with stateLine in existingState
+      set parsedState to my parseStateLine(stateLine as text)
+      set trackedKind to item 1 of parsedState
+      set trackedValue to item 2 of parsedState
+      if (trackedKind is "pane" or trackedKind is "swarm-pane") and trackedValue is not "" then
+        set trackedPaneIds to my appendUnique(trackedPaneIds, trackedValue)
+      end if
+    end repeat
+
+    if my containsValue(trackedPaneIds, id of anchor) or (name of anchor) starts with "headless-" then
+      repeat with term in terminals of currentTab
+        if not my containsValue(trackedPaneIds, id of term) and (name of term) does not start with "headless-" then
+          set anchor to term
+          exit repeat
+        end if
+      end repeat
+    end if
+
+    repeat with term in terminals of currentTab
+      if id of term is not id of anchor then
+        set end of panesToClose to term
+      end if
+    end repeat
+
+    repeat with term in panesToClose
+      close term
+    end repeat
+
+    set command of cfg to "/usr/bin/env -u TMUX " & quoted form of tmuxPath & " attach-session -t " & quoted form of aggregatorSession
+    set wait after command of cfg to true
+    set swarmRoot to split anchor direction right with configuration cfg
+    focus anchor
+
+    set outputLines to {}
+    set end of outputLines to ("pane" & tab & (id of swarmRoot))
+    set oldDelimiters to AppleScript's text item delimiters
+    set AppleScript's text item delimiters to linefeed
+    set outputText to outputLines as text
+    set AppleScript's text item delimiters to oldDelimiters
+    return outputText
+  end tell
+end run

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1409,7 +1409,7 @@ function parseEpochSeconds(value: string): number | undefined {
 
 function parseWaitingAfterMs(env: Env): number {
   const parsed = Number.parseInt(env.HEADLESS_LIST_WAITING_AFTER_MS ?? "", 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 30_000;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 15_000;
 }
 
 function inferHeadlessTmuxSessionState(

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2503,6 +2503,38 @@ test("CLI --list honors HEADLESS_LIST_WAITING_AFTER_MS", async () => {
   }
 });
 
+test("CLI --list defaults tmux sessions to waiting after 15 seconds of inactivity", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const activity = Math.floor(Date.now() / 1000) - 16;",
+          "process.stdout.write(`headless-codex-quiet\\t1700000000\\t${activity}\\t0\\n`);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["--list"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^headless-codex-quiet\s+codex\s+waiting\s+/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --list uses tmux window activity for last activity", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {


### PR DESCRIPTION
## Summary
- add the bundled headless-swarm skill and helper scripts for visible Ghostty/tmux agent swarms
- document npm-based skill installation and agent-neutral usage
- reduce tmux waiting detection default from 30s to 15s and document the override

## Testing
- npm test -- --test-name-pattern "CLI --list"
- npm run build
- pre-push hook: build + local integration suite (9 passed, 1 skipped)