### PR TITLE
Improve tmux state tracking from native transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+- Added native transcript activity detection for Codex, Claude, Cursor, Gemini, OpenCode, and Pi, including running, waiting-for-input, and idle/completed signals.
+- Changed tmux session listing to prefer native transcript state over tmux inactivity when available, so completed sessions can show `idle` and prompt-blocked sessions can show `waiting`.
+- Changed coordinated tmux runs so `headless run view` and `headless run wait` reconcile node status from native transcript activity, and `headless run message` marks tmux nodes busy after sending input.
+- Added a `waiting` run-node status for tmux nodes that are waiting on user input.
+
 ## 0.3.1 - 2026-05-12
 
 - Added `[general]` settings in `~/.headless/config.toml` for default timeout, default agent, coordination mode, run status interval, and tmux waiting threshold.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,7 @@ import {
   fetchModelsDevPricing,
   priceUsageSummary,
 } from "./output.js";
+import { deriveNativeTranscriptActivity, resolveLatestNativeTranscript } from "./native-transcripts.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import { extractRunNodeMetrics } from "./run-metrics.js";
 import { createRunStatusReporter, parseRunStatusIntervalMs } from "./run-status.js";
@@ -896,7 +897,7 @@ interface HeadlessTmuxSession {
   agent: AgentName;
 }
 
-type HeadlessTmuxSessionState = "running" | "waiting" | "dead";
+type HeadlessTmuxSessionState = "running" | "waiting" | "idle" | "dead";
 
 interface HeadlessTmuxSessionDetails extends HeadlessTmuxSession {
   state: HeadlessTmuxSessionState;
@@ -1501,30 +1502,51 @@ function inferHeadlessTmuxSessionState(
   paneDead: string,
   lastActivitySeconds: number,
   waitingAfterMs: number,
+  nativeStatus?: "running" | "waiting_input" | "idle",
 ): HeadlessTmuxSessionState {
   if (paneDead === "1") {
     return "dead";
   }
+  if (nativeStatus === "idle") return "idle";
+  if (nativeStatus === "waiting_input") return "waiting";
+  if (nativeStatus === "running") return "running";
   return Date.now() - lastActivitySeconds * 1000 <= waitingAfterMs ? "running" : "waiting";
 }
 
 function parseHeadlessTmuxSessionDetails(
   line: string,
   waitingAfterMs: number,
+  env: Env,
 ): HeadlessTmuxSessionDetails | undefined {
-  const [name, createdRaw, activityRaw, paneDead = "0"] = line.split("\t");
+  const [name, createdRaw, activityRaw, paneDead = "0", workDirRaw = ""] = line.split("\t");
   const session = parseHeadlessTmuxSession(name?.trim() ?? "");
   const createdSeconds = parseEpochSeconds(createdRaw ?? "");
   const activitySeconds = parseEpochSeconds(activityRaw ?? "");
   if (!session || createdSeconds === undefined || activitySeconds === undefined) {
     return undefined;
   }
+  const createdAt = formatEpochSeconds(createdSeconds);
+  const nativeActivity = tmuxNativeActivity(session.agent, workDirRaw.trim() || undefined, createdAt, env);
+  const lastActivitySecondsWithNative = nativeActivity?.updatedAtMs
+    ? Math.max(activitySeconds, Math.floor(nativeActivity.updatedAtMs / 1000))
+    : activitySeconds;
   return {
     ...session,
-    state: inferHeadlessTmuxSessionState(paneDead.trim(), activitySeconds, waitingAfterMs),
-    createdAt: formatEpochSeconds(createdSeconds),
-    lastActivityAt: formatEpochSeconds(activitySeconds),
+    state: inferHeadlessTmuxSessionState(paneDead.trim(), lastActivitySecondsWithNative, waitingAfterMs, nativeActivity?.status),
+    createdAt,
+    lastActivityAt: formatEpochSeconds(lastActivitySecondsWithNative),
   };
+}
+
+function tmuxNativeActivity(
+  agent: AgentName,
+  workDir: string | undefined,
+  createdAt: string,
+  env: Env,
+): ReturnType<typeof deriveNativeTranscriptActivity> {
+  if (!workDir) return undefined;
+  const transcript = resolveLatestNativeTranscript(agent, workDir, env, { startedAt: createdAt });
+  return deriveNativeTranscriptActivity(agent, transcript);
 }
 
 function renderTable(headers: string[], rows: string[][]): string {
@@ -1648,7 +1670,7 @@ async function listHeadlessTmuxSessionDetails(
   const result = await captureSimpleCommand(
     {
       command: "tmux",
-      args: ["list-sessions", "-F", "#{session_name}\t#{session_created}\t#{window_activity}\t#{pane_dead}"],
+      args: ["list-sessions", "-F", "#{session_name}\t#{session_created}\t#{window_activity}\t#{pane_dead}\t#{pane_current_path}"],
     },
     undefined,
     env,
@@ -1666,7 +1688,7 @@ async function listHeadlessTmuxSessionDetails(
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((line) => parseHeadlessTmuxSessionDetails(line, waitingAfterMs))
+    .map((line) => parseHeadlessTmuxSessionDetails(line, waitingAfterMs, env))
     .filter((session): session is HeadlessTmuxSessionDetails => Boolean(session))
     .filter((session) => agent === undefined || session.agent === agent);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1571,17 +1571,56 @@ function assignTmuxNativeActivities(
         right.activitySeconds - left.activitySeconds ||
         right.name.localeCompare(left.name),
     );
+  const candidatesByScope = tmuxSessionTranscriptCandidatesByScope(eligibleSessions, env);
 
   for (const session of eligibleSessions) {
-    const transcript = resolveLatestNativeTranscripts(session.agent, session.workDir, env, {
-      startedAt: formatEpochSeconds(session.createdSeconds),
-    }).find((candidate) => !claimedTranscripts.has(nativeTranscriptKey(candidate)));
+    const transcript = (candidatesByScope.get(tmuxSessionTranscriptScope(session.agent, session.workDir)) ?? []).find(
+      (candidate) => !claimedTranscripts.has(nativeTranscriptKey(candidate)),
+    );
     if (!transcript) continue;
     claimedTranscripts.add(nativeTranscriptKey(transcript));
     const activity = deriveNativeTranscriptActivity(session.agent, transcript);
     if (activity) activities.set(session.name, activity);
   }
   return activities;
+}
+
+function tmuxSessionTranscriptCandidatesByScope(
+  sessions: ParsedHeadlessTmuxSessionDetails[],
+  env: Env,
+): Map<string, ReturnType<typeof resolveLatestNativeTranscripts>> {
+  const sessionsByScope = new Map<string, ParsedHeadlessTmuxSessionDetails[]>();
+  for (const session of sessions) {
+    const scope = tmuxSessionTranscriptScope(session.agent, session.workDir);
+    const scopedSessions = sessionsByScope.get(scope) ?? [];
+    scopedSessions.push(session);
+    sessionsByScope.set(scope, scopedSessions);
+  }
+
+  const candidatesByScope = new Map<string, ReturnType<typeof resolveLatestNativeTranscripts>>();
+  for (const [scope, scopedSessions] of sessionsByScope) {
+    const firstSession = scopedSessions[0];
+    if (!firstSession) continue;
+    const earliestCreatedSeconds = scopedSessions.reduce(
+      (earliest, session) => Math.min(earliest, session.createdSeconds),
+      scopedSessions[0]?.createdSeconds ?? 0,
+    );
+    candidatesByScope.set(
+      scope,
+      resolveLatestNativeTranscripts(
+        firstSession.agent,
+        firstSession.workDir,
+        env,
+        { startedAt: formatEpochSeconds(earliestCreatedSeconds) },
+        scopedSessions.length,
+      ),
+    );
+  }
+  return candidatesByScope;
+}
+
+function tmuxSessionTranscriptScope(agent: AgentName, workDir: string | undefined): string {
+  return `${agent}\t${workDir ?? ""}`;
 }
 
 function renderTable(headers: string[], rows: string[][]): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,7 +62,7 @@ import {
   fetchModelsDevPricing,
   priceUsageSummary,
 } from "./output.js";
-import { deriveNativeTranscriptActivity, resolveLatestNativeTranscript } from "./native-transcripts.js";
+import { deriveNativeTranscriptActivity, nativeTranscriptKey, resolveLatestNativeTranscripts } from "./native-transcripts.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import { extractRunNodeMetrics } from "./run-metrics.js";
 import { createRunStatusReporter, parseRunStatusIntervalMs } from "./run-status.js";
@@ -905,6 +905,13 @@ interface HeadlessTmuxSessionDetails extends HeadlessTmuxSession {
   lastActivityAt: string;
 }
 
+interface ParsedHeadlessTmuxSessionDetails extends HeadlessTmuxSession {
+  paneDead: string;
+  createdSeconds: number;
+  activitySeconds: number;
+  workDir?: string;
+}
+
 type StdoutHandling = "capture" | "stream" | "capture-and-stream";
 
 interface ExecuteCommandOptions {
@@ -1513,11 +1520,9 @@ function inferHeadlessTmuxSessionState(
   return Date.now() - lastActivitySeconds * 1000 <= waitingAfterMs ? "running" : "waiting";
 }
 
-function parseHeadlessTmuxSessionDetails(
+function parseHeadlessTmuxSessionLine(
   line: string,
-  waitingAfterMs: number,
-  env: Env,
-): HeadlessTmuxSessionDetails | undefined {
+): ParsedHeadlessTmuxSessionDetails | undefined {
   const [name, createdRaw, activityRaw, paneDead = "0", workDirRaw = ""] = line.split("\t");
   const session = parseHeadlessTmuxSession(name?.trim() ?? "");
   const createdSeconds = parseEpochSeconds(createdRaw ?? "");
@@ -1525,28 +1530,58 @@ function parseHeadlessTmuxSessionDetails(
   if (!session || createdSeconds === undefined || activitySeconds === undefined) {
     return undefined;
   }
-  const createdAt = formatEpochSeconds(createdSeconds);
-  const nativeActivity = tmuxNativeActivity(session.agent, workDirRaw.trim() || undefined, createdAt, env);
-  const lastActivitySecondsWithNative = nativeActivity?.updatedAtMs
-    ? Math.max(activitySeconds, Math.floor(nativeActivity.updatedAtMs / 1000))
-    : activitySeconds;
   return {
     ...session,
-    state: inferHeadlessTmuxSessionState(paneDead.trim(), lastActivitySecondsWithNative, waitingAfterMs, nativeActivity?.status),
+    paneDead: paneDead.trim(),
+    createdSeconds,
+    activitySeconds,
+    workDir: workDirRaw.trim() || undefined,
+  };
+}
+
+function headlessTmuxSessionDetails(
+  session: ParsedHeadlessTmuxSessionDetails,
+  waitingAfterMs: number,
+  nativeActivity?: NonNullable<ReturnType<typeof deriveNativeTranscriptActivity>>,
+): HeadlessTmuxSessionDetails | undefined {
+  const createdAt = formatEpochSeconds(session.createdSeconds);
+  const lastActivitySecondsWithNative = nativeActivity?.updatedAtMs
+    ? Math.max(session.activitySeconds, Math.floor(nativeActivity.updatedAtMs / 1000))
+    : session.activitySeconds;
+  return {
+    name: session.name,
+    agent: session.agent,
+    state: inferHeadlessTmuxSessionState(session.paneDead, lastActivitySecondsWithNative, waitingAfterMs, nativeActivity?.status),
     createdAt,
     lastActivityAt: formatEpochSeconds(lastActivitySecondsWithNative),
   };
 }
 
-function tmuxNativeActivity(
-  agent: AgentName,
-  workDir: string | undefined,
-  createdAt: string,
+function assignTmuxNativeActivities(
+  sessions: ParsedHeadlessTmuxSessionDetails[],
   env: Env,
-): ReturnType<typeof deriveNativeTranscriptActivity> {
-  if (!workDir) return undefined;
-  const transcript = resolveLatestNativeTranscript(agent, workDir, env, { startedAt: createdAt });
-  return deriveNativeTranscriptActivity(agent, transcript);
+): Map<string, NonNullable<ReturnType<typeof deriveNativeTranscriptActivity>>> {
+  const claimedTranscripts = new Set<string>();
+  const activities = new Map<string, NonNullable<ReturnType<typeof deriveNativeTranscriptActivity>>>();
+  const eligibleSessions = sessions
+    .filter((session) => session.paneDead !== "1" && Boolean(session.workDir))
+    .sort(
+      (left, right) =>
+        right.createdSeconds - left.createdSeconds ||
+        right.activitySeconds - left.activitySeconds ||
+        right.name.localeCompare(left.name),
+    );
+
+  for (const session of eligibleSessions) {
+    const transcript = resolveLatestNativeTranscripts(session.agent, session.workDir, env, {
+      startedAt: formatEpochSeconds(session.createdSeconds),
+    }).find((candidate) => !claimedTranscripts.has(nativeTranscriptKey(candidate)));
+    if (!transcript) continue;
+    claimedTranscripts.add(nativeTranscriptKey(transcript));
+    const activity = deriveNativeTranscriptActivity(session.agent, transcript);
+    if (activity) activities.set(session.name, activity);
+  }
+  return activities;
 }
 
 function renderTable(headers: string[], rows: string[][]): string {
@@ -1684,11 +1719,15 @@ async function listHeadlessTmuxSessionDetails(
   }
 
   const waitingAfterMs = parseWaitingAfterMs(env, configuredWaitingAfterMs);
-  return result.stdout
+  const sessions = result.stdout
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((line) => parseHeadlessTmuxSessionDetails(line, waitingAfterMs, env))
+    .map(parseHeadlessTmuxSessionLine)
+    .filter((session): session is ParsedHeadlessTmuxSessionDetails => Boolean(session));
+  const nativeActivities = assignTmuxNativeActivities(sessions, env);
+  return sessions
+    .map((session) => headlessTmuxSessionDetails(session, waitingAfterMs, nativeActivities.get(session.name)))
     .filter((session): session is HeadlessTmuxSessionDetails => Boolean(session))
     .filter((session) => agent === undefined || session.agent === agent);
 }

--- a/src/native-activity.ts
+++ b/src/native-activity.ts
@@ -1,0 +1,449 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+import type { NativeTranscript } from "./runs.js";
+import type { AgentName } from "./types.js";
+
+export type NativeActivityStatus = "running" | "waiting_input" | "idle";
+
+export interface NativeTranscriptActivity {
+  status: NativeActivityStatus;
+  reason: "pending_tool_use_fresh" | "explicit_wait_marker_fresh" | "terminal_done" | "recent_activity_fresh" | "stale_timeout" | "no_active_signal";
+  message?: string;
+  updatedAtMs: number;
+}
+
+export interface NativeTranscriptActivityOptions {
+  nowMs?: number;
+  runningTtlMs?: number;
+  waitingTtlMs?: number;
+}
+
+interface NativeActivityEvent {
+  kind: "assistant" | "user" | "tool_use" | "tool_result" | "system" | "meta";
+  rawType: string;
+  raw: Record<string, unknown>;
+  text: string[];
+  toolUseId?: string;
+  timestampMs: number | null;
+}
+
+interface NativeActivityDecision {
+  status: NativeActivityStatus;
+  reason: NativeTranscriptActivity["reason"];
+  message?: string;
+}
+
+const defaultRunningTtlMs = 20_000;
+const defaultWaitingTtlMs = 1_800_000;
+const waitingInputPattern =
+  /\b(?:await(?:ing)?\s+(?:user|input)|waiting\s+for\s+(?:user|input|approval)|user\s+input\s+required|needs?\s+user\s+input|permission\s+required|approval\s+required|confirm(?:ation)?\s+(?:required|needed)|press\s+enter\s+to\s+continue)\b/i;
+const waitingPromptPattern =
+  /\b(?:do\s+you\s+want(?:\s+me)?|would\s+you\s+like(?:\s+me)?|should\s+i\b|can\s+you\s+confirm|please\s+confirm|let\s+me\s+know\s+if\s+you(?:'d)?\s+like|which\s+(?:option|approach)|choose\s+(?:one|an?\s+option)|pick\s+(?:one|an?\s+option)|approve(?:\s+this)?|permission\s+to)\b/i;
+
+export function deriveNativeTranscriptActivity(
+  agent: AgentName,
+  transcript: NativeTranscript | undefined,
+  options: NativeTranscriptActivityOptions = {},
+): NativeTranscriptActivity | undefined {
+  if (!transcript || !existsSync(transcript.path)) return undefined;
+  const events =
+    transcript.kind === "sqlite"
+      ? readOpenCodeActivityEvents(transcript)
+      : parseActivityEvents(agent, readTranscriptSlice(transcript));
+  if (events.length === 0) return undefined;
+
+  const fallbackUpdatedAtMs = statSync(transcript.path).mtimeMs;
+  const updatedAtMs = Math.max(fallbackUpdatedAtMs, ...events.map((event) => event.timestampMs ?? 0));
+  const nowMsValue = options.nowMs ?? Date.now();
+  const decision = deriveActivityDecision(agent, events, updatedAtMs, nowMsValue, {
+    runningTtlMs: options.runningTtlMs ?? defaultRunningTtlMs,
+    waitingTtlMs: options.waitingTtlMs ?? defaultWaitingTtlMs,
+  });
+  return { ...decision, updatedAtMs };
+}
+
+function readTranscriptSlice(transcript: NativeTranscript): string {
+  const bytes = readFileSync(transcript.path);
+  const start = transcript.startOffset ?? 0;
+  const end = transcript.endOffset ?? bytes.length;
+  return bytes.subarray(start, end).toString("utf8");
+}
+
+function readOpenCodeActivityEvents(transcript: NativeTranscript): NativeActivityEvent[] {
+  if (!transcript.sessionId || !/^[A-Za-z0-9_.:-]+$/.test(transcript.sessionId)) return [];
+  const sqlite = spawnSync(
+    "sqlite3",
+    [
+      "-json",
+      transcript.path,
+      [
+        "select json_extract(message.data, '$.role') as role, part.data as part_data, part.time_updated as time_updated, part.time_created as time_created",
+        "from part",
+        "join message on message.id = part.message_id",
+        `where part.session_id = '${transcript.sessionId.replaceAll("'", "''")}'`,
+        "order by part.time_created asc;",
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  if (sqlite.status !== 0 || !sqlite.stdout.trim()) return [];
+  try {
+    const rows = JSON.parse(sqlite.stdout) as unknown;
+    if (!Array.isArray(rows)) return [];
+    return rows.flatMap((row) => {
+      const record = asJsonRecord(row);
+      const part = asJsonRecord(parseJson(asString(record.part_data)));
+      const role = normalizeRole(record.role);
+      return [
+        toActivityEvent("opencode", {
+          type: part.type,
+          role,
+          part,
+          message: { role },
+          timestamp: epochMsFromUnknown(record.time_updated) ?? epochMsFromUnknown(record.time_created),
+        }),
+      ];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function parseActivityEvents(agent: AgentName, text: string): NativeActivityEvent[] {
+  const events: NativeActivityEvent[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(toActivityEvent(agent, asJsonRecord(JSON.parse(trimmed) as unknown)));
+    } catch {
+      // Native logs may include non-JSON warnings. They do not carry activity state.
+    }
+  }
+  return events;
+}
+
+function toActivityEvent(agent: AgentName, raw: Record<string, unknown>): NativeActivityEvent {
+  const payload = asJsonRecord(raw.payload);
+  const message = asJsonRecord(raw.message);
+  const part = asJsonRecord(raw.part);
+  const record = Object.keys(payload).length > 0 && asString(raw.type).toLowerCase() === "response_item" ? payload : raw;
+  const rawType = normalizeMarkerText(record.type || raw.type);
+  const role = normalizeRole(record.role) || normalizeRole(message.role) || roleFromRawType(agent, rawType);
+  const kind = eventKindFromRecord(rawType, role, record);
+  const toolUseId =
+    kind === "tool_use" || kind === "tool_result"
+      ? asString(record.call_id) || asString(record.id) || asString(record.tool_use_id) || asString(part.id)
+      : undefined;
+  return {
+    kind,
+    rawType,
+    raw,
+    text: collectText(record).concat(collectText(message), collectText(part)),
+    toolUseId,
+    timestampMs: timestampMsFromRecord(raw),
+  };
+}
+
+function deriveActivityDecision(
+  agent: AgentName,
+  events: NativeActivityEvent[],
+  updatedAtMs: number,
+  nowMsValue: number,
+  ttl: { runningTtlMs: number; waitingTtlMs: number },
+): NativeActivityDecision {
+  const unmatchedToolUses = countUnmatchedToolUses(events);
+  if (unmatchedToolUses > 0) {
+    return applyFreshness({ status: "running", reason: "pending_tool_use_fresh" }, updatedAtMs, nowMsValue, ttl.runningTtlMs);
+  }
+
+  const waitEvent = findPendingWaitSignalEvent(events);
+  if (waitEvent) {
+    return applyFreshness(
+      { status: "waiting_input", reason: "explicit_wait_marker_fresh", message: latestMessage(waitEvent) },
+      updatedAtMs,
+      nowMsValue,
+      ttl.waitingTtlMs,
+    );
+  }
+
+  const terminalEvent = findLatestTerminalDoneEvent(agent, events);
+  if (terminalEvent) {
+    return { status: "idle", reason: "terminal_done", message: latestMessage(terminalEvent) || latestAssistantMessage(events) };
+  }
+
+  if (updatedAtMs > 0 && nowMsValue - updatedAtMs <= Math.max(0, ttl.runningTtlMs)) {
+    return { status: "running", reason: "recent_activity_fresh" };
+  }
+
+  return { status: "idle", reason: "no_active_signal", message: latestAssistantMessage(events) };
+}
+
+function applyFreshness(
+  decision: NativeActivityDecision,
+  updatedAtMs: number,
+  nowMsValue: number,
+  ttlMs: number,
+): NativeActivityDecision {
+  if (updatedAtMs <= 0 || nowMsValue - updatedAtMs > Math.max(0, ttlMs)) {
+    return { status: "idle", reason: "stale_timeout", message: decision.message };
+  }
+  return decision;
+}
+
+function countUnmatchedToolUses(events: NativeActivityEvent[]): number {
+  const uses = new Set<string>();
+  const results = new Set<string>();
+  for (const event of events) {
+    if (!event.toolUseId) continue;
+    if (event.kind === "tool_use") uses.add(event.toolUseId);
+    if (event.kind === "tool_result") results.add(event.toolUseId);
+  }
+  let unmatched = 0;
+  for (const id of uses) {
+    if (!results.has(id)) unmatched += 1;
+  }
+  return unmatched;
+}
+
+function findPendingWaitSignalEvent(events: NativeActivityEvent[]): NativeActivityEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event) continue;
+    if (event.kind === "user" || event.kind === "tool_use" || event.kind === "tool_result") return undefined;
+    if (hasWaitingSignal(event)) return event;
+    if (isPassiveActivityEvent(event)) continue;
+    if (event.kind === "assistant" && event.text.length > 0) return undefined;
+  }
+  return undefined;
+}
+
+function findLatestTerminalDoneEvent(agent: AgentName, events: NativeActivityEvent[]): NativeActivityEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event) continue;
+    if (isPassiveActivityEvent(event)) continue;
+    if (isTerminalDoneEvent(agent, event)) return event;
+    return undefined;
+  }
+  return undefined;
+}
+
+function isTerminalDoneEvent(agent: AgentName, event: NativeActivityEvent): boolean {
+  const raw = event.raw;
+  const payload = asJsonRecord(raw.payload);
+  const message = asJsonRecord(raw.message);
+  const part = asJsonRecord(raw.part);
+  const rawType = normalizeMarkerText(raw.type || event.rawType);
+  const payloadType = normalizeMarkerText(payload.type);
+  const partType = normalizeMarkerText(part.type);
+  const stopReason = normalizeMarkerText(message.stop_reason || message.stopReason || raw.stop_reason || raw.stopReason);
+  const partReason = normalizeMarkerText(part.reason);
+
+  if (payloadType === "task complete") return true;
+  if (rawType === "assistant" && stopReason === "end turn") return true;
+  if (event.kind === "assistant" && stopReason === "stop") return true;
+  if (partType === "step finish" && partReason === "stop") return true;
+  if (hasFinalAnswerMarker(raw) || hasFinalAnswerMarker(part)) return true;
+  if ((agent === "gemini" || agent === "cursor") && event.kind === "assistant" && event.text.length > 0) return true;
+  return false;
+}
+
+function hasWaitingSignal(event: NativeActivityEvent): boolean {
+  const raw = event.raw;
+  const payload = asJsonRecord(raw.payload);
+  const part = asJsonRecord(raw.part);
+  const partState = asJsonRecord(part.state);
+  const message = asJsonRecord(raw.message);
+  const candidates = [
+    event.rawType,
+    raw.type,
+    raw.subtype,
+    raw.status,
+    raw.state,
+    raw.phase,
+    raw.reason,
+    payload.type,
+    payload.subtype,
+    payload.status,
+    payload.state,
+    payload.phase,
+    payload.reason,
+    part.type,
+    part.status,
+    part.state,
+    part.phase,
+    part.reason,
+    partState.status,
+    partState.state,
+    partState.phase,
+    partState.reason,
+    message.status,
+    message.state,
+    message.phase,
+  ];
+  if (candidates.some(isStructuredWaitingValue)) return true;
+  const text = [event.rawType, ...event.text].join(" ");
+  return waitingInputPattern.test(text) || waitingPromptPattern.test(text);
+}
+
+function isPassiveActivityEvent(event: NativeActivityEvent): boolean {
+  const raw = event.raw;
+  const payload = asJsonRecord(raw.payload);
+  const part = asJsonRecord(raw.part);
+  const rawType = normalizeMarkerText(raw.type || event.rawType);
+  const payloadType = normalizeMarkerText(payload.type);
+  const partType = normalizeMarkerText(part.type);
+
+  if (rawType === "token count" || payloadType === "token count") return true;
+  if (rawType === "last prompt" || rawType === "last-prompt" || rawType === "ai title" || rawType === "permission mode") return true;
+  if (rawType === "attachment" || rawType === "file history snapshot" || rawType === "queue operation") return true;
+  if (rawType === "model change" || rawType === "thinking level change") return true;
+  if (rawType === "info" || rawType === "session" || rawType === "session meta" || rawType === "session diff meta") return true;
+  if (partType === "snapshot" || partType === "patch" || partType === "file") return true;
+  if (Object.prototype.hasOwnProperty.call(raw, "$set")) return true;
+  if (event.kind === "system" && event.text.length === 0) return true;
+  if (event.kind === "meta" && !payloadType && !partType && event.text.length === 0) return true;
+  return false;
+}
+
+function hasFinalAnswerMarker(record: Record<string, unknown>): boolean {
+  const metadata = asJsonRecord(record.metadata);
+  const openai = asJsonRecord(metadata.openai);
+  if (normalizeMarkerText(metadata.phase) === "final answer") return true;
+  if (normalizeMarkerText(openai.phase) === "final answer") return true;
+  for (const item of asArray(record.content)) {
+    const itemRecord = asJsonRecord(item);
+    if (normalizeMarkerText(itemRecord.phase) === "final answer") return true;
+    const signature = asString(itemRecord.textSignature);
+    if (signature && normalizeMarkerText(asJsonRecord(parseJson(signature)).phase) === "final answer") return true;
+  }
+  return false;
+}
+
+function eventKindFromRecord(rawType: string, role: string, record: Record<string, unknown>): NativeActivityEvent["kind"] {
+  if (rawType === "function call" || rawType === "tool call" || rawType === "tool use") return "tool_use";
+  if (rawType === "function call output" || rawType === "tool result") return "tool_result";
+  if (rawType === "tool") {
+    const state = normalizeMarkerText(asJsonRecord(record.state).status || record.status);
+    return state === "completed" || state === "error" ? "tool_result" : "tool_use";
+  }
+  if (role === "user") return "user";
+  if (role === "assistant") return "assistant";
+  if (role === "system") return "system";
+  return "meta";
+}
+
+function roleFromRawType(agent: AgentName, rawType: string): string {
+  if (rawType === "assistant" || rawType === "model" || rawType === "gemini") return "assistant";
+  if (rawType === "user") return "user";
+  if (agent === "gemini" && rawType === "system") return "system";
+  return "";
+}
+
+function collectText(value: unknown): string[] {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(value)) return value.flatMap(collectText);
+  const record = asJsonRecord(value);
+  if (Object.keys(record).length === 0) return [];
+  const type = normalizeMarkerText(record.type);
+  if (type === "tool use" || type === "tool result" || type === "function call" || type === "function call output") return [];
+  return [
+    asString(record.text),
+    asString(record.content),
+    asString(record.result),
+    asString(record.response),
+    ...collectText(record.content),
+    ...collectText(record.parts),
+  ]
+    .map((text) => text.trim())
+    .filter(Boolean);
+}
+
+function latestMessage(event: NativeActivityEvent): string | undefined {
+  return event.text.at(-1)?.trim() || undefined;
+}
+
+function latestAssistantMessage(events: NativeActivityEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.kind !== "assistant") continue;
+    const message = latestMessage(event);
+    if (message) return message;
+  }
+  return undefined;
+}
+
+function timestampMsFromRecord(record: Record<string, unknown>): number | null {
+  const candidates = [
+    record.timestamp,
+    record.time,
+    record.updatedAt,
+    asJsonRecord(record.time).updated,
+    asJsonRecord(record.time).completed,
+    asJsonRecord(record.time).end,
+    asJsonRecord(record.time).created,
+  ];
+  for (const candidate of candidates) {
+    const parsed = epochMsFromUnknown(candidate);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function epochMsFromUnknown(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const text = asString(value).trim();
+  if (!text) return null;
+  const parsed = Date.parse(text);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isStructuredWaitingValue(value: unknown): boolean {
+  const normalized = normalizeMarkerText(value);
+  if (!normalized) return false;
+  if (normalized === "waiting") return true;
+  if (normalized.includes("awaiting") && (normalized.includes("user") || normalized.includes("input"))) return true;
+  if (normalized.includes("waiting for") && (normalized.includes("user") || normalized.includes("input"))) return true;
+  if ((normalized.includes("needs") || normalized.includes("requires")) && normalized.includes("input")) return true;
+  if (normalized.includes("approval required") || normalized.includes("permission required")) return true;
+  if (normalized.includes("confirmation required") || normalized.includes("confirmation needed")) return true;
+  if (normalized.includes("press enter to continue")) return true;
+  return false;
+}
+
+function normalizeRole(value: unknown): string {
+  const role = normalizeMarkerText(value);
+  return role === "model" || role === "gemini" ? "assistant" : role;
+}
+
+function normalizeMarkerText(value: unknown): string {
+  return asString(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ");
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return {};
+  }
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asJsonRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/src/native-transcripts.ts
+++ b/src/native-transcripts.ts
@@ -1,0 +1,401 @@
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { extractFinalMessage } from "./output.js";
+import type { NativeTranscript } from "./runs.js";
+import type { AgentName, Env } from "./types.js";
+export { deriveNativeTranscriptActivity } from "./native-activity.js";
+export type { NativeActivityStatus, NativeTranscriptActivity, NativeTranscriptActivityOptions } from "./native-activity.js";
+
+export interface NativeAssistantCompletion {
+  message: string;
+  source: "native-transcript";
+  path: string;
+}
+
+export function resolveNativeTranscript(
+  agent: AgentName,
+  nativeId: string | undefined,
+  workDir: string | undefined,
+  env: Env,
+  partial: Partial<NativeTranscript> = {},
+): NativeTranscript | undefined {
+  if (!nativeId) return undefined;
+
+  const path =
+    agent === "claude"
+      ? claudeTranscriptPath(nativeId, workDir, env)
+      : agent === "codex"
+        ? findFileContaining(codexSessionsRoot(env), nativeId)
+        : agent === "cursor"
+          ? cursorTranscriptPath(nativeId, workDir, env)
+          : agent === "gemini"
+            ? geminiTranscriptPath(nativeId, workDir, env)
+            : agent === "opencode"
+              ? opencodeDatabasePath(env)
+              : agent === "pi"
+                ? piTranscriptPath(nativeId, workDir, env)
+                : undefined;
+
+  if (!path || !existsSync(path)) return undefined;
+  const kind = agent === "opencode" ? "sqlite" : "jsonl";
+  return {
+    kind,
+    path,
+    sessionId: nativeId,
+    ...partial,
+    endOffset: kind === "jsonl" ? statSync(path).size : partial.endOffset,
+  };
+}
+
+export function beginNativeTranscript(
+  agent: AgentName,
+  nativeId: string | undefined,
+  workDir: string | undefined,
+  env: Env,
+): NativeTranscript | undefined {
+  const startedAt = new Date().toISOString();
+  const transcript = resolveNativeTranscript(agent, nativeId, workDir, env, { startedAt });
+  if (!transcript || transcript.kind !== "jsonl") {
+    return transcript ?? (agent === "opencode" ? resolveNativeTranscript(agent, nativeId, workDir, env, { startedAt }) : undefined);
+  }
+  return { ...transcript, startOffset: transcript.endOffset, endOffset: undefined };
+}
+
+export function finalizeNativeTranscript(
+  agent: AgentName,
+  nativeId: string | undefined,
+  workDir: string | undefined,
+  env: Env,
+  started?: NativeTranscript,
+): NativeTranscript | undefined {
+  const completedAt = new Date().toISOString();
+  const transcript = resolveNativeTranscript(agent, nativeId, workDir, env, {
+    ...started,
+    completedAt,
+    startOffset: started?.startOffset,
+  });
+  if (transcript || !started?.path || !existsSync(started.path)) return transcript;
+  return {
+    ...started,
+    completedAt,
+    endOffset: started.kind === "jsonl" ? statSync(started.path).size : started.endOffset,
+  };
+}
+
+export function resolveLatestNativeTranscript(
+  agent: AgentName,
+  workDir: string | undefined,
+  env: Env,
+  partial: Partial<NativeTranscript> = {},
+): NativeTranscript | undefined {
+  const workspace = realWorkspace(workDir);
+  if (!workspace) return undefined;
+  if (agent === "opencode") {
+    return latestOpenCodeTranscript(workspace, workDir, env, partial);
+  }
+
+  const path =
+    agent === "claude"
+      ? latestFileInDirectory(claudeProjectRoot(workspace, env), partial)
+      : agent === "codex"
+        ? latestWorkspaceFile(codexSessionsRoot(env), workspace, workDir, partial)
+        : agent === "cursor"
+          ? latestFileInDirectory(cursorTranscriptsRoot(workspace, env), partial)
+          : agent === "gemini"
+            ? latestGeminiTranscript(workspace, env, partial)
+            : agent === "pi"
+              ? latestFileInDirectory(piProjectRoot(workspace, env), partial)
+              : undefined;
+  if (!path) return undefined;
+  const nativeId = nativeIdFromPath(agent, path);
+  return {
+    kind: "jsonl",
+    path,
+    sessionId: nativeId,
+    ...partial,
+    endOffset: statSync(path).size,
+  };
+}
+
+export function indexNativeAssistantCompletion(
+  agent: AgentName,
+  transcript: NativeTranscript | undefined,
+): NativeAssistantCompletion | undefined {
+  if (!transcript || !existsSync(transcript.path)) return undefined;
+  const message =
+    transcript.kind === "sqlite"
+      ? indexOpenCodeCompletion(transcript)
+      : extractFinalMessage(agent, readTranscriptSlice(transcript));
+  if (!message) return undefined;
+  return { message, source: "native-transcript", path: transcript.path };
+}
+
+function readTranscriptSlice(transcript: NativeTranscript): string {
+  const bytes = readFileSync(transcript.path);
+  const start = transcript.startOffset ?? 0;
+  const end = transcript.endOffset ?? bytes.length;
+  return bytes.subarray(start, end).toString("utf8");
+}
+
+function indexOpenCodeCompletion(transcript: NativeTranscript): string {
+  if (!transcript.sessionId || !/^[A-Za-z0-9_.:-]+$/.test(transcript.sessionId)) return "";
+  const startedAtMs = transcript.startedAt ? Date.parse(transcript.startedAt) : Number.NaN;
+  const sqlite = spawnSync(
+    "sqlite3",
+    [
+      transcript.path,
+      [
+        "select json_extract(part.data, '$.text')",
+        "from part",
+        "join message on message.id = part.message_id",
+        `where part.session_id = '${transcript.sessionId.replaceAll("'", "''")}'`,
+        "and json_extract(part.data, '$.type') = 'text'",
+        "and json_extract(message.data, '$.role') = 'assistant'",
+        ...(Number.isFinite(startedAtMs) ? [`and part.time_created >= ${Math.floor(startedAtMs)}`] : []),
+        "order by json_extract(part.data, '$.metadata.openai.phase') = 'final_answer' desc, part.time_created desc",
+        "limit 1;",
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  if (sqlite.status !== 0) return "";
+  return sqlite.stdout.trim();
+}
+
+function claudeTranscriptPath(nativeId: string, workDir: string | undefined, env: Env): string | undefined {
+  const root = env.CLAUDE_CONFIG_DIR ?? (env.HOME ? join(env.HOME, ".claude") : undefined);
+  const workspace = realWorkspace(workDir);
+  return root && workspace ? join(claudeProjectRoot(workspace, env) ?? root, `${nativeId}.jsonl`) : undefined;
+}
+
+function claudeProjectRoot(workspace: string, env: Env): string | undefined {
+  const root = env.CLAUDE_CONFIG_DIR ?? (env.HOME ? join(env.HOME, ".claude") : undefined);
+  return root ? join(root, "projects", claudeProjectKey(workspace)) : undefined;
+}
+
+function codexSessionsRoot(env: Env): string | undefined {
+  return env.CODEX_HOME ? join(env.CODEX_HOME, "sessions") : env.HOME ? join(env.HOME, ".codex", "sessions") : undefined;
+}
+
+function cursorTranscriptPath(nativeId: string, workDir: string | undefined, env: Env): string | undefined {
+  const workspace = realWorkspace(workDir);
+  return workspace
+    ? join(cursorTranscriptsRoot(workspace, env) ?? "", nativeId, `${nativeId}.jsonl`)
+    : undefined;
+}
+
+function cursorTranscriptsRoot(workspace: string, env: Env): string | undefined {
+  const root = env.CURSOR_HOME ?? (env.HOME ? join(env.HOME, ".cursor") : undefined);
+  return root ? join(root, "projects", cursorProjectKey(workspace), "agent-transcripts") : undefined;
+}
+
+function geminiTranscriptPath(nativeId: string, workDir: string | undefined, env: Env): string | undefined {
+  const root = env.GEMINI_HOME ?? (env.HOME ? join(env.HOME, ".gemini") : undefined);
+  const workspace = realWorkspace(workDir);
+  if (!root || !workspace) return undefined;
+  const projectSlot = geminiProjectSlot(root, workspace);
+  if (!projectSlot) return undefined;
+  return findFileContaining(join(root, "tmp", projectSlot, "chats"), nativeId.slice(0, 8));
+}
+
+function opencodeDatabasePath(env: Env): string | undefined {
+  return env.OPENCODE_DATA_HOME
+    ? join(env.OPENCODE_DATA_HOME, "opencode.db")
+    : env.HOME
+      ? join(env.HOME, ".local", "share", "opencode", "opencode.db")
+      : undefined;
+}
+
+function piTranscriptPath(nativeId: string, workDir: string | undefined, env: Env): string | undefined {
+  if (nativeId.endsWith(".jsonl")) return nativeId;
+  const workspace = realWorkspace(workDir);
+  return workspace ? findFileContaining(piProjectRoot(workspace, env), nativeId) : undefined;
+}
+
+function piProjectRoot(workspace: string, env: Env): string | undefined {
+  const root = env.PI_CODING_AGENT_HOME ?? (env.HOME ? join(env.HOME, ".pi", "agent") : undefined);
+  return root ? join(root, "sessions", piProjectKey(workspace)) : undefined;
+}
+
+function geminiProjectSlot(root: string, workspace: string): string {
+  const projectsPath = join(root, "projects.json");
+  if (!existsSync(projectsPath)) return "";
+  try {
+    const config = JSON.parse(readFileSync(projectsPath, "utf8")) as Record<string, unknown>;
+    const projects = isRecord(config.projects) ? config.projects : config;
+    const direct = projects[workspace];
+    if (typeof direct === "string") return direct;
+    for (const [key, value] of Object.entries(projects)) {
+      if (realWorkspace(key) === workspace && typeof value === "string") return value;
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function findFileContaining(root: string | undefined, text: string): string | undefined {
+  if (!root || !text || !existsSync(root)) return undefined;
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(path);
+      } else if (entry.isFile() && entry.name.includes(text)) {
+        return path;
+      }
+    }
+  }
+  return undefined;
+}
+
+function latestGeminiTranscript(
+  workspace: string,
+  env: Env,
+  partial: Partial<NativeTranscript>,
+): string | undefined {
+  const root = env.GEMINI_HOME ?? (env.HOME ? join(env.HOME, ".gemini") : undefined);
+  if (!root) return undefined;
+  const projectSlot = geminiProjectSlot(root, workspace);
+  return projectSlot ? latestFileInDirectory(join(root, "tmp", projectSlot, "chats"), partial) : undefined;
+}
+
+function latestOpenCodeTranscript(
+  workspace: string,
+  workDir: string | undefined,
+  env: Env,
+  partial: Partial<NativeTranscript>,
+): NativeTranscript | undefined {
+  const path = opencodeDatabasePath(env);
+  if (!path || !existsSync(path)) return undefined;
+  const directories = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
+  const startedAtMs = partial.startedAt ? Date.parse(partial.startedAt) : Number.NaN;
+  const whereDirectory = directories.map((directory) => `'${directory.replaceAll("'", "''")}'`).join(", ");
+  const sqlite = spawnSync(
+    "sqlite3",
+    [
+      path,
+      [
+        "select id",
+        "from session",
+        `where directory in (${whereDirectory})`,
+        ...(Number.isFinite(startedAtMs) ? [`and time_updated >= ${Math.floor(startedAtMs)}`] : []),
+        "order by time_updated desc",
+        "limit 1;",
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  const sessionId = sqlite.status === 0 ? sqlite.stdout.trim() : "";
+  return sessionId ? { kind: "sqlite", path, sessionId, ...partial } : undefined;
+}
+
+function latestWorkspaceFile(
+  root: string | undefined,
+  workspace: string,
+  workDir: string | undefined,
+  partial: Partial<NativeTranscript>,
+): string | undefined {
+  const candidates = latestFiles(root, partial);
+  const needles = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
+  return candidates.find((path) => fileHasWorkspaceCwd(path, needles));
+}
+
+function latestFileInDirectory(root: string | undefined, partial: Partial<NativeTranscript>): string | undefined {
+  return latestFiles(root, partial)[0];
+}
+
+function latestFiles(root: string | undefined, partial: Partial<NativeTranscript>): string[] {
+  if (!root || !existsSync(root)) return [];
+  const startedAtMs = partial.startedAt ? Date.parse(partial.startedAt) : Number.NaN;
+  const files: Array<{ path: string; mtimeMs: number }> = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(path);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      const stat = statSync(path);
+      if (Number.isFinite(startedAtMs) && stat.mtimeMs < startedAtMs) continue;
+      files.push({ path, mtimeMs: stat.mtimeMs });
+    }
+  }
+  return files.sort((left, right) => right.mtimeMs - left.mtimeMs || right.path.localeCompare(left.path)).map((file) => file.path);
+}
+
+function fileHasWorkspaceCwd(path: string, needles: string[]): boolean {
+  try {
+    for (const line of readFileSync(path, "utf8").split(/\r?\n/).slice(0, 40)) {
+      if (!line.trim()) continue;
+      const record = JSON.parse(line) as Record<string, unknown>;
+      const cwd = cwdFromRecord(record);
+      if (cwd && needles.includes(cwd)) return true;
+      const realCwd = realWorkspace(cwd);
+      if (realCwd && needles.includes(realCwd)) return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function cwdFromRecord(record: Record<string, unknown>): string {
+  const payload = isRecord(record.payload) ? record.payload : undefined;
+  const path = isRecord(record.path) ? record.path : undefined;
+  return asString(record.cwd) || asString(payload?.cwd) || asString(path?.cwd);
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function nativeIdFromPath(agent: AgentName, path: string): string | undefined {
+  const name = path.split("/").at(-1)?.replace(/\.jsonl$/, "");
+  if (!name) return undefined;
+  if (agent === "codex") {
+    const match = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i.exec(name);
+    return match?.[1] ?? name;
+  }
+  if (agent === "gemini") {
+    const match = /session-[^-]+-[^-]+-(.+)$/.exec(name);
+    return match?.[1] ?? name;
+  }
+  return name;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function realWorkspace(workDir: string | undefined): string | undefined {
+  if (!workDir) return undefined;
+  try {
+    return realpathSync(workDir);
+  } catch {
+    return workDir;
+  }
+}
+
+function claudeProjectKey(workspace: string): string {
+  return workspace.replace(/\//g, "-");
+}
+
+function cursorProjectKey(workspace: string): string {
+  return workspace.replace(/^\/+/, "").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function piProjectKey(workspace: string): string {
+  return `--${workspace.replace(/^\/+/, "").replace(/[\\/]+/g, "-")}--`;
+}

--- a/src/native-transcripts.ts
+++ b/src/native-transcripts.ts
@@ -90,33 +90,45 @@ export function resolveLatestNativeTranscript(
   env: Env,
   partial: Partial<NativeTranscript> = {},
 ): NativeTranscript | undefined {
+  return resolveLatestNativeTranscripts(agent, workDir, env, partial, 1)[0];
+}
+
+export function resolveLatestNativeTranscripts(
+  agent: AgentName,
+  workDir: string | undefined,
+  env: Env,
+  partial: Partial<NativeTranscript> = {},
+  limit = 20,
+): NativeTranscript[] {
   const workspace = realWorkspace(workDir);
-  if (!workspace) return undefined;
+  if (!workspace) return [];
   if (agent === "opencode") {
-    return latestOpenCodeTranscript(workspace, workDir, env, partial);
+    return latestOpenCodeTranscripts(workspace, workDir, env, partial, limit);
   }
 
-  const path =
+  const paths =
     agent === "claude"
-      ? latestFileInDirectory(claudeProjectRoot(workspace, env), partial)
+      ? latestFiles(claudeProjectRoot(workspace, env), partial)
       : agent === "codex"
-        ? latestWorkspaceFile(codexSessionsRoot(env), workspace, workDir, partial)
+        ? latestWorkspaceFiles(codexSessionsRoot(env), workspace, workDir, partial)
         : agent === "cursor"
-          ? latestFileInDirectory(cursorTranscriptsRoot(workspace, env), partial)
+          ? latestFiles(cursorTranscriptsRoot(workspace, env), partial)
           : agent === "gemini"
-            ? latestGeminiTranscript(workspace, env, partial)
+            ? latestGeminiTranscripts(workspace, env, partial)
             : agent === "pi"
-              ? latestFileInDirectory(piProjectRoot(workspace, env), partial)
-              : undefined;
-  if (!path) return undefined;
-  const nativeId = nativeIdFromPath(agent, path);
-  return {
+              ? latestFiles(piProjectRoot(workspace, env), partial)
+              : [];
+  return paths.slice(0, Math.max(0, limit)).map((path) => ({
     kind: "jsonl",
     path,
-    sessionId: nativeId,
+    sessionId: nativeIdFromPath(agent, path),
     ...partial,
     endOffset: statSync(path).size,
-  };
+  }));
+}
+
+export function nativeTranscriptKey(transcript: NativeTranscript): string {
+  return [transcript.kind, transcript.path, transcript.sessionId ?? "", transcript.startOffset ?? "", transcript.endOffset ?? ""].join("\t");
 }
 
 export function indexNativeAssistantCompletion(
@@ -257,25 +269,26 @@ function findFileContaining(root: string | undefined, text: string): string | un
   return undefined;
 }
 
-function latestGeminiTranscript(
+function latestGeminiTranscripts(
   workspace: string,
   env: Env,
   partial: Partial<NativeTranscript>,
-): string | undefined {
+): string[] {
   const root = env.GEMINI_HOME ?? (env.HOME ? join(env.HOME, ".gemini") : undefined);
-  if (!root) return undefined;
+  if (!root) return [];
   const projectSlot = geminiProjectSlot(root, workspace);
-  return projectSlot ? latestFileInDirectory(join(root, "tmp", projectSlot, "chats"), partial) : undefined;
+  return projectSlot ? latestFiles(join(root, "tmp", projectSlot, "chats"), partial) : [];
 }
 
-function latestOpenCodeTranscript(
+function latestOpenCodeTranscripts(
   workspace: string,
   workDir: string | undefined,
   env: Env,
   partial: Partial<NativeTranscript>,
-): NativeTranscript | undefined {
+  limit: number,
+): NativeTranscript[] {
   const path = opencodeDatabasePath(env);
-  if (!path || !existsSync(path)) return undefined;
+  if (!path || !existsSync(path)) return [];
   const directories = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
   const startedAtMs = partial.startedAt ? Date.parse(partial.startedAt) : Number.NaN;
   const whereDirectory = directories.map((directory) => `'${directory.replaceAll("'", "''")}'`).join(", ");
@@ -289,28 +302,24 @@ function latestOpenCodeTranscript(
         `where directory in (${whereDirectory})`,
         ...(Number.isFinite(startedAtMs) ? [`and time_updated >= ${Math.floor(startedAtMs)}`] : []),
         "order by time_updated desc",
-        "limit 1;",
+        `limit ${Math.max(0, limit)};`,
       ].join("\n"),
     ],
     { encoding: "utf8" },
   );
-  const sessionId = sqlite.status === 0 ? sqlite.stdout.trim() : "";
-  return sessionId ? { kind: "sqlite", path, sessionId, ...partial } : undefined;
+  const sessionIds = sqlite.status === 0 ? sqlite.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean) : [];
+  return sessionIds.map((sessionId) => ({ kind: "sqlite", path, sessionId, ...partial }));
 }
 
-function latestWorkspaceFile(
+function latestWorkspaceFiles(
   root: string | undefined,
   workspace: string,
   workDir: string | undefined,
   partial: Partial<NativeTranscript>,
-): string | undefined {
+): string[] {
   const candidates = latestFiles(root, partial);
   const needles = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
-  return candidates.find((path) => fileHasWorkspaceCwd(path, needles));
-}
-
-function latestFileInDirectory(root: string | undefined, partial: Partial<NativeTranscript>): string | undefined {
-  return latestFiles(root, partial)[0];
+  return candidates.filter((path) => fileHasWorkspaceCwd(path, needles));
 }
 
 function latestFiles(root: string | undefined, partial: Partial<NativeTranscript>): string[] {

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -4,7 +4,7 @@ import type { TeamNodeSpec } from "./teams.js";
 
 export const roles = ["orchestrator", "explorer", "worker", "reviewer"] as const;
 export const coordinationModes = ["session", "tmux", "oneshot"] as const;
-export const runStatuses = ["planned", "starting", "busy", "idle", "done", "failed", "unknown"] as const;
+export const runStatuses = ["planned", "starting", "busy", "waiting", "idle", "done", "failed", "unknown"] as const;
 
 export type Role = (typeof roles)[number];
 export type CoordinationMode = (typeof coordinationModes)[number];

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -167,9 +167,10 @@ function reconcileTmuxRunNodes(env: Env, runId: string): void {
   const nodes = Object.values(run.nodes)
     .filter(shouldReconcileTmuxNode)
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.updatedAt.localeCompare(left.updatedAt) || right.nodeId.localeCompare(left.nodeId));
+  const candidatesByScope = tmuxTranscriptCandidatesByScope(nodes, env);
 
   for (const node of nodes) {
-    const transcript = resolveLatestNativeTranscripts(node.agent, node.workDir, env, { startedAt: node.createdAt }).find(
+    const transcript = (candidatesByScope.get(tmuxTranscriptScope(node.agent, node.workDir)) ?? []).find(
       (candidate) => !claimedTranscripts.has(nativeTranscriptKey(candidate)),
     );
     if (!transcript) continue;
@@ -185,6 +186,32 @@ function reconcileTmuxRunNodes(env: Env, runId: string): void {
 function shouldReconcileTmuxNode(node: RunNode): boolean {
   if (node.coordination !== "tmux") return false;
   return node.status === "busy" || node.status === "starting" || node.status === "waiting";
+}
+
+function tmuxTranscriptCandidatesByScope(nodes: RunNode[], env: Env): Map<string, ReturnType<typeof resolveLatestNativeTranscripts>> {
+  const nodesByScope = new Map<string, RunNode[]>();
+  for (const node of nodes) {
+    const scope = tmuxTranscriptScope(node.agent, node.workDir);
+    const scopedNodes = nodesByScope.get(scope) ?? [];
+    scopedNodes.push(node);
+    nodesByScope.set(scope, scopedNodes);
+  }
+
+  const candidatesByScope = new Map<string, ReturnType<typeof resolveLatestNativeTranscripts>>();
+  for (const [scope, scopedNodes] of nodesByScope) {
+    const firstNode = scopedNodes[0];
+    if (!firstNode) continue;
+    const earliestCreatedAt = scopedNodes.reduce((earliest, node) => (node.createdAt < earliest ? node.createdAt : earliest), scopedNodes[0]?.createdAt ?? "");
+    candidatesByScope.set(
+      scope,
+      resolveLatestNativeTranscripts(firstNode.agent, firstNode.workDir, env, { startedAt: earliestCreatedAt }, scopedNodes.length),
+    );
+  }
+  return candidatesByScope;
+}
+
+function tmuxTranscriptScope(agent: AgentName, workDir: string | undefined): string {
+  return `${agent}\t${workDir ?? ""}`;
 }
 
 function startAsyncRunMessage(

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { join } from "node:path";
 
 import { extractFinalMessage } from "./output.js";
+import { deriveNativeTranscriptActivity, resolveLatestNativeTranscript } from "./native-transcripts.js";
 import { extractRunNodeMetrics } from "./run-metrics.js";
 import { renderRunList, renderRunView } from "./run-view.js";
 import {
@@ -50,6 +51,7 @@ export async function handleRunCommand(input: RunCommandInput, handlers: RunComm
   }
   const runId = requireValue(input.runId, "run");
   if (input.command === "view") {
+    reconcileTmuxRunNodes(handlers.env, runId);
     const run = readRun(handlers.env, runId);
     if (!run) {
       throw new Error(`unknown run: ${runId}`);
@@ -98,6 +100,7 @@ async function handleRunMessage(
     const code = await handlers.sendTmux(sessionName, prompt.prompt, input.printCommand);
     if (code === 0 && !input.printCommand) {
       recordMessage(handlers.env, runId, handlers.env.HEADLESS_RUN_NODE || "cli", nodeId, prompt.prompt);
+      updateNodeStatus(handlers.env, runId, nodeId, "busy");
       handlers.stdout(`sent: ${runId}/${nodeId}\n`);
     }
     return code;
@@ -142,6 +145,7 @@ async function waitForRunIdle(env: Env, runId: string): Promise<void> {
   const intervalMs = parseDelayMs(env.HEADLESS_RUN_WAIT_INTERVAL_MS, 1000);
   const currentNode = env.HEADLESS_RUN_NODE;
   while (true) {
+    reconcileTmuxRunNodes(env, runId);
     const run = readRun(env, runId);
     if (!run) {
       throw new Error(`unknown run: ${runId}`);
@@ -153,6 +157,21 @@ async function waitForRunIdle(env: Env, runId: string): Promise<void> {
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+function reconcileTmuxRunNodes(env: Env, runId: string): void {
+  const run = readRun(env, runId);
+  if (!run) return;
+  for (const node of Object.values(run.nodes)) {
+    if (node.coordination !== "tmux") continue;
+    if (node.status !== "busy" && node.status !== "starting" && node.status !== "waiting") continue;
+    const transcript = resolveLatestNativeTranscript(node.agent, node.workDir, env, { startedAt: node.createdAt });
+    const activity = deriveNativeTranscriptActivity(node.agent, transcript);
+    if (!activity) continue;
+    const status = activity.status === "running" ? "busy" : activity.status === "waiting_input" ? "waiting" : "idle";
+    if (status === node.status && (!activity.message || activity.message === node.lastMessage)) continue;
+    updateNodeStatus(env, runId, node.nodeId, status, activity.message);
   }
 }
 

--- a/src/run-commands.ts
+++ b/src/run-commands.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { join } from "node:path";
 
 import { extractFinalMessage } from "./output.js";
-import { deriveNativeTranscriptActivity, resolveLatestNativeTranscript } from "./native-transcripts.js";
+import { deriveNativeTranscriptActivity, nativeTranscriptKey, resolveLatestNativeTranscripts } from "./native-transcripts.js";
 import { extractRunNodeMetrics } from "./run-metrics.js";
 import { renderRunList, renderRunView } from "./run-view.js";
 import {
@@ -163,16 +163,28 @@ async function waitForRunIdle(env: Env, runId: string): Promise<void> {
 function reconcileTmuxRunNodes(env: Env, runId: string): void {
   const run = readRun(env, runId);
   if (!run) return;
-  for (const node of Object.values(run.nodes)) {
-    if (node.coordination !== "tmux") continue;
-    if (node.status !== "busy" && node.status !== "starting" && node.status !== "waiting") continue;
-    const transcript = resolveLatestNativeTranscript(node.agent, node.workDir, env, { startedAt: node.createdAt });
+  const claimedTranscripts = new Set<string>();
+  const nodes = Object.values(run.nodes)
+    .filter(shouldReconcileTmuxNode)
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.updatedAt.localeCompare(left.updatedAt) || right.nodeId.localeCompare(left.nodeId));
+
+  for (const node of nodes) {
+    const transcript = resolveLatestNativeTranscripts(node.agent, node.workDir, env, { startedAt: node.createdAt }).find(
+      (candidate) => !claimedTranscripts.has(nativeTranscriptKey(candidate)),
+    );
+    if (!transcript) continue;
+    claimedTranscripts.add(nativeTranscriptKey(transcript));
     const activity = deriveNativeTranscriptActivity(node.agent, transcript);
     if (!activity) continue;
     const status = activity.status === "running" ? "busy" : activity.status === "waiting_input" ? "waiting" : "idle";
     if (status === node.status && (!activity.message || activity.message === node.lastMessage)) continue;
     updateNodeStatus(env, runId, node.nodeId, status, activity.message);
   }
+}
+
+function shouldReconcileTmuxNode(node: RunNode): boolean {
+  if (node.coordination !== "tmux") return false;
+  return node.status === "busy" || node.status === "starting" || node.status === "waiting";
 }
 
 function startAsyncRunMessage(

--- a/src/run-status.ts
+++ b/src/run-status.ts
@@ -238,6 +238,7 @@ function visibleLength(text: string): number {
 function transitionLevel(status: string): LogLevel {
   if (status === "failed" || status === "unknown") return "error";
   if (status === "done" || status === "idle") return "ok";
+  if (status === "waiting") return "warn";
   if (status === "busy" || status === "starting") return "info";
   return "info";
 }
@@ -252,6 +253,7 @@ function statusColor(status: string): AnsiColor | undefined {
       return "green";
     case "busy":
     case "starting":
+    case "waiting":
       return "yellow";
     case "failed":
     case "unknown":

--- a/src/run-view.ts
+++ b/src/run-view.ts
@@ -153,7 +153,7 @@ function tmuxAttachCommand(sessionName: string): string {
 }
 
 function graphLineColor(line: string): TableColor | undefined {
-  for (const status of ["failed", "busy", "starting", "done", "idle", "planned", "unknown"] as const) {
+  for (const status of ["failed", "busy", "starting", "waiting", "done", "idle", "planned", "unknown"] as const) {
     if (line.includes(`[${status} `)) {
       return statusColor(status);
     }
@@ -167,6 +167,7 @@ function statusColor(status: RunStatus): TableColor | undefined {
       return "green";
     case "busy":
     case "starting":
+    case "waiting":
       return "yellow";
     case "failed":
     case "unknown":

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -58,6 +58,16 @@ export interface RunNodeMetrics {
   totalTokens?: number;
 }
 
+export interface NativeTranscript {
+  kind: "jsonl" | "sqlite";
+  path: string;
+  sessionId?: string;
+  startedAt?: string;
+  completedAt?: string;
+  startOffset?: number;
+  endOffset?: number;
+}
+
 export interface RunEvent {
   type:
     | "run_started"

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2823,7 +2823,7 @@ test("CLI --list lists active headless tmux sessions", async () => {
         tmux,
         [
           "#!/usr/bin/env node",
-          "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}') process.exit(2);",
+          "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}\\t#{pane_current_path}') process.exit(2);",
           "process.stdout.write('headless-codex-123\\t1700000000\\t4102444800\\t0\\nother\\t1700000000\\t1700000000\\t0\\nheadless-opencode-456\\t1700000000\\t1700000000\\t0\\nheadless-unknown-789\\t1700000000\\t1700000000\\t0\\n');",
           "",
         ].join("\n"),
@@ -2916,6 +2916,55 @@ test("CLI --list marks dead tmux panes", async () => {
 
     assert.equal(code, 0);
     assert.match(stdout.join(""), /^headless-claude-dead\s+claude\s+dead\s+/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --list uses native transcript completion before tmux inactivity fallback", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const binDir = join(dir, "bin");
+    const transcriptPath = join(home, ".codex", "sessions", "2026", "05", "13", "rollout-complete.jsonl");
+    mkdirSync(dirname(transcriptPath), { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-13T10:00:00.000Z", type: "session_meta", payload: { id: "complete", cwd: workDir } }),
+        JSON.stringify({
+          timestamp: "2026-05-13T10:00:01.000Z",
+          type: "response_item",
+          payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
+        }),
+        JSON.stringify({ timestamp: "2026-05-13T10:00:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"),
+    );
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          `process.stdout.write('headless-codex-complete\\t1770000000\\t1700000000\\t0\\t${workDir}\\n');`,
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["--list"], {
+      env: { ...process.env, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.match(stdout.join(""), /^headless-codex-complete\s+codex\s+idle\s+/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -2965,6 +2965,67 @@ test("CLI --list uses native transcript completion before tmux inactivity fallba
 
     assert.equal(code, 0);
     assert.match(stdout.join(""), /^headless-codex-complete\s+codex\s+idle\s+/m);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --list assigns same-workdir native transcripts to one tmux session each", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const binDir = join(dir, "bin");
+    const nativeDir = join(home, ".codex", "sessions", "2026", "05", "13");
+    const olderPath = join(nativeDir, "rollout-alpha.jsonl");
+    const newerPath = join(nativeDir, "rollout-beta.jsonl");
+    mkdirSync(nativeDir, { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(
+      olderPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-13T10:00:00.000Z", type: "session_meta", payload: { id: "alpha", cwd: workDir } }),
+        JSON.stringify({ timestamp: "2026-05-13T10:00:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      newerPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-13T10:01:00.000Z", type: "session_meta", payload: { id: "beta", cwd: workDir } }),
+        JSON.stringify({ timestamp: "2026-05-13T10:01:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"),
+    );
+    const nowMs = Date.now();
+    const olderMtimeMs = nowMs + 1000;
+    const newerMtimeMs = nowMs + 2000;
+    utimesSync(olderPath, new Date(olderMtimeMs), new Date(olderMtimeMs));
+    utimesSync(newerPath, new Date(newerMtimeMs), new Date(newerMtimeMs));
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          `process.stdout.write('headless-codex-alpha\\t1770000000\\t1700000000\\t0\\t${workDir}\\nheadless-codex-beta\\t1770000001\\t1700000000\\t0\\t${workDir}\\n');`,
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["--list"], {
+      env: { ...process.env, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+    const output = stdout.join("");
+
+    assert.equal(code, 0);
+    assert.match(output, new RegExp(`^headless-codex-alpha\\s+codex\\s+idle\\s+.*${new Date(Math.floor(olderMtimeMs / 1000) * 1000).toISOString()}`, "m"));
+    assert.match(output, new RegExp(`^headless-codex-beta\\s+codex\\s+idle\\s+.*${new Date(Math.floor(newerMtimeMs / 1000) * 1000).toISOString()}`, "m"));
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/native-transcripts.test.ts
+++ b/tests/native-transcripts.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -97,6 +97,9 @@ test("resolves the latest native transcript for a workspace", () => {
       otherPath,
       `${JSON.stringify({ type: "session_meta", payload: { id: "other-thread", cwd: realpathSync(otherWorkDir) } })}\n`,
     );
+    utimesSync(olderPath, new Date("2026-05-13T10:00:00.000Z"), new Date("2026-05-13T10:00:00.000Z"));
+    utimesSync(latestPath, new Date("2026-05-13T10:01:00.000Z"), new Date("2026-05-13T10:01:00.000Z"));
+    utimesSync(otherPath, new Date("2026-05-13T10:02:00.000Z"), new Date("2026-05-13T10:02:00.000Z"));
 
     assert.equal(resolveLatestNativeTranscript("codex", workDir, { HOME: home })?.path, latestPath);
   } finally {

--- a/tests/native-transcripts.test.ts
+++ b/tests/native-transcripts.test.ts
@@ -1,0 +1,325 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  deriveNativeTranscriptActivity,
+  indexNativeAssistantCompletion,
+  resolveLatestNativeTranscript,
+  resolveNativeTranscript,
+} from "../src/native-transcripts.ts";
+
+test("resolves native transcript files for jsonl-backed agents", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    mkdirSync(workDir, { recursive: true });
+    const realWorkDir = realpathSync(workDir);
+    const claudePath = join(home, ".claude", "projects", realWorkDir.replace(/\//g, "-"), "claude-session.jsonl");
+    const codexPath = join(home, ".codex", "sessions", "2026", "05", "13", "rollout-2026-05-13T11-12-33-codex-thread.jsonl");
+    const cursorPath = join(
+      home,
+      ".cursor",
+      "projects",
+      realWorkDir.replace(/^\/+/, "").replace(/[^A-Za-z0-9]+/g, "-"),
+      "agent-transcripts",
+      "cursor-session",
+      "cursor-session.jsonl",
+    );
+    const geminiPath = join(home, ".gemini", "tmp", "gemini-7", "chats", "session-2026-05-13T09-12-gemini-s.jsonl");
+    const piPath = join(home, ".pi", "agent", "sessions", "--work--", "pi-session.jsonl");
+    for (const path of [claudePath, codexPath, cursorPath, geminiPath, piPath]) {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, `${JSON.stringify({ type: "assistant", content: "done" })}\n`);
+    }
+    mkdirSync(join(home, ".gemini"), { recursive: true });
+    writeFileSync(join(home, ".gemini", "projects.json"), `${JSON.stringify({ [workDir]: "gemini-7" })}\n`);
+
+    assert.deepEqual(resolveNativeTranscript("claude", "claude-session", workDir, { HOME: home })?.path, claudePath);
+    assert.deepEqual(resolveNativeTranscript("codex", "codex-thread", workDir, { HOME: home })?.path, codexPath);
+    assert.deepEqual(resolveNativeTranscript("cursor", "cursor-session", workDir, { HOME: home })?.path, cursorPath);
+    assert.deepEqual(resolveNativeTranscript("gemini", "gemini-session", workDir, { HOME: home })?.path, geminiPath);
+    assert.deepEqual(resolveNativeTranscript("pi", piPath, workDir, { HOME: home })?.path, piPath);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("resolves gemini transcripts from nested projects config", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    mkdirSync(workDir, { recursive: true });
+    const realWorkDir = realpathSync(workDir);
+    const geminiPath = join(home, ".gemini", "tmp", "gemini-3", "chats", "session-2026-05-13T09-38-8b04386a.jsonl");
+    mkdirSync(dirname(geminiPath), { recursive: true });
+    writeFileSync(geminiPath, `${JSON.stringify({ type: "gemini", content: "done" })}\n`);
+    mkdirSync(join(home, ".gemini"), { recursive: true });
+    writeFileSync(join(home, ".gemini", "projects.json"), `${JSON.stringify({ projects: { [realWorkDir]: "gemini-3" } })}\n`);
+
+    assert.deepEqual(
+      resolveNativeTranscript("gemini", "8b04386a-4c08-41ab-ba34-e7c7db908091", workDir, { HOME: home })?.path,
+      geminiPath,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("resolves the latest native transcript for a workspace", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const otherWorkDir = join(dir, "other");
+    mkdirSync(workDir, { recursive: true });
+    mkdirSync(otherWorkDir, { recursive: true });
+    const realWorkDir = realpathSync(workDir);
+    const nativeDir = join(home, ".codex", "sessions", "2026", "05", "13");
+    const olderPath = join(nativeDir, "rollout-older-thread.jsonl");
+    const latestPath = join(nativeDir, "rollout-latest-thread.jsonl");
+    const otherPath = join(nativeDir, "rollout-other-thread.jsonl");
+    mkdirSync(nativeDir, { recursive: true });
+    writeFileSync(
+      olderPath,
+      `${JSON.stringify({ type: "session_meta", payload: { id: "older-thread", cwd: realWorkDir } })}\n`,
+    );
+    writeFileSync(
+      latestPath,
+      `${JSON.stringify({ type: "session_meta", payload: { id: "latest-thread", cwd: realWorkDir } })}\n`,
+    );
+    writeFileSync(
+      otherPath,
+      `${JSON.stringify({ type: "session_meta", payload: { id: "other-thread", cwd: realpathSync(otherWorkDir) } })}\n`,
+    );
+
+    assert.equal(resolveLatestNativeTranscript("codex", workDir, { HOME: home })?.path, latestPath);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("resolves latest native transcripts after a start time", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    mkdirSync(workDir, { recursive: true });
+    const realWorkDir = realpathSync(workDir);
+    const nativeDir = join(home, ".codex", "sessions", "2026", "05", "13");
+    const oldPath = join(nativeDir, "rollout-old-thread.jsonl");
+    mkdirSync(nativeDir, { recursive: true });
+    writeFileSync(oldPath, `${JSON.stringify({ type: "session_meta", payload: { id: "old-thread", cwd: realWorkDir } })}\n`);
+    const afterOldFile = new Date(Date.now() + 10_000).toISOString();
+
+    assert.equal(resolveLatestNativeTranscript("codex", workDir, { HOME: home }, { startedAt: afterOldFile }), undefined);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("indexes the latest assistant completion from a native transcript", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const path = join(dir, "transcript.jsonl");
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "older" }] } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "latest" }] } }),
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepEqual(indexNativeAssistantCompletion("claude", { kind: "jsonl", path }), {
+      message: "latest",
+      source: "native-transcript",
+      path,
+    });
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test(
+  "indexes an opencode assistant completion from sqlite",
+  { skip: spawnSync("sqlite3", ["--version"]).status !== 0 },
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+    try {
+      const path = join(dir, "opencode.db");
+      const sessionId = "ses_test";
+      const sql = `
+create table message (id text primary key, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);
+create table part (id text primary key, message_id text not null, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);
+insert into message values ('user_msg', '${sessionId}', 1, 1, '{"role":"user"}');
+insert into part values ('user_part', 'user_msg', '${sessionId}', 1, 1, '{"type":"text","text":"prompt"}');
+insert into message values ('assistant_msg', '${sessionId}', 2, 2, '{"role":"assistant"}');
+insert into part values ('assistant_part', 'assistant_msg', '${sessionId}', 3, 3, '{"type":"text","text":"native final","metadata":{"openai":{"phase":"final_answer"}}}');
+`;
+      const created = spawnSync("sqlite3", [path, sql], { encoding: "utf8" });
+      assert.equal(created.status, 0, created.stderr);
+
+      assert.deepEqual(indexNativeAssistantCompletion("opencode", { kind: "sqlite", path, sessionId }), {
+        message: "native final",
+        source: "native-transcript",
+        path,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);
+
+test("derives idle from native terminal markers for jsonl-backed agents", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const cases = [
+      {
+        agent: "codex" as const,
+        records: [
+          { timestamp: "2026-02-12T10:00:00.000Z", type: "session_meta", payload: { id: "codex-complete" } },
+          {
+            timestamp: "2026-02-12T10:00:01.000Z",
+            type: "response_item",
+            payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "Done." }] },
+          },
+          { timestamp: "2026-02-12T10:00:02.000Z", type: "event_msg", payload: { type: "task_complete" } },
+        ],
+      },
+      {
+        agent: "claude" as const,
+        records: [
+          {
+            timestamp: "2026-02-12T10:00:00.000Z",
+            type: "assistant",
+            message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "Done." }] },
+          },
+          { type: "last-prompt" },
+        ],
+      },
+      {
+        agent: "pi" as const,
+        records: [
+          {
+            timestamp: "2026-02-12T10:00:00.000Z",
+            type: "message",
+            message: {
+              role: "assistant",
+              stopReason: "stop",
+              content: [{ type: "text", text: "Done.", textSignature: "{\"phase\":\"final_answer\"}" }],
+            },
+          },
+        ],
+      },
+      {
+        agent: "gemini" as const,
+        records: [
+          { timestamp: "2026-02-12T10:00:00.000Z", type: "gemini", content: "Done." },
+          { $set: { lastUpdated: "2026-02-12T10:00:00.000Z" } },
+        ],
+      },
+      {
+        agent: "cursor" as const,
+        records: [{ role: "assistant", message: { content: [{ type: "text", text: "Done." }] } }],
+      },
+    ];
+
+    for (const item of cases) {
+      const path = join(dir, `${item.agent}.jsonl`);
+      writeFileSync(path, `${item.records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+
+      assert.deepEqual(deriveNativeTranscriptActivity(item.agent, { kind: "jsonl", path }, { nowMs: Date.now() })?.status, "idle");
+      assert.equal(deriveNativeTranscriptActivity(item.agent, { kind: "jsonl", path }, { nowMs: Date.now() })?.reason, "terminal_done");
+    }
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("derives waiting input before terminal idle when assistant asks for confirmation", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const path = join(dir, "codex-waiting.jsonl");
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ timestamp: "2026-02-12T10:00:00.000Z", type: "session_meta", payload: { id: "waiting" } }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Would you like me to run the full gate now?" }],
+          },
+        }),
+        JSON.stringify({ timestamp: "2026-02-12T10:00:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+      ].join("\n"),
+    );
+
+    const activity = deriveNativeTranscriptActivity("codex", { kind: "jsonl", path }, { nowMs: Date.now() });
+
+    assert.equal(activity?.status, "waiting_input");
+    assert.equal(activity?.reason, "explicit_wait_marker_fresh");
+    assert.equal(activity?.message, "Would you like me to run the full gate now?");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("derives running from unmatched native tool calls", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const path = join(dir, "codex-running.jsonl");
+    writeFileSync(
+      path,
+      `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        type: "response_item",
+        payload: { type: "function_call", call_id: "call_1", name: "run_command", arguments: "{}" },
+      })}\n`,
+    );
+
+    const activity = deriveNativeTranscriptActivity("codex", { kind: "jsonl", path }, { nowMs: Date.now() });
+
+    assert.equal(activity?.status, "running");
+    assert.equal(activity?.reason, "pending_tool_use_fresh");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test(
+  "derives opencode idle from sqlite step-finish stop",
+  { skip: spawnSync("sqlite3", ["--version"]).status !== 0 },
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+    try {
+      const path = join(dir, "opencode.db");
+      const sessionId = "ses_activity";
+      const sql = `
+create table message (id text primary key, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);
+create table part (id text primary key, message_id text not null, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);
+insert into message values ('assistant_msg', '${sessionId}', 1, 3, '{"role":"assistant"}');
+insert into part values ('text_part', 'assistant_msg', '${sessionId}', 2, 2, '{"type":"text","text":"done","metadata":{"openai":{"phase":"final_answer"}}}');
+insert into part values ('finish_part', 'assistant_msg', '${sessionId}', 3, 3, '{"type":"step-finish","reason":"stop"}');
+`;
+      const created = spawnSync("sqlite3", [path, sql], { encoding: "utf8" });
+      assert.equal(created.status, 0, created.stderr);
+
+      const activity = deriveNativeTranscriptActivity("opencode", { kind: "sqlite", path, sessionId }, { nowMs: Date.now() });
+
+      assert.equal(activity?.status, "idle");
+      assert.equal(activity?.reason, "terminal_done");
+      assert.equal(activity?.message, "done");
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -654,6 +654,78 @@ test("run wait reconciles completed tmux nodes from native transcripts", async (
     assert.equal(stdout.join(""), "run idle: auth\n");
     assert.equal(run?.nodes["worker-1"].status, "idle");
     assert.equal(run?.nodes["worker-1"].lastMessage, "tmux final");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run view assigns same-workdir native transcripts to one tmux node each", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    mkdirSync(workDir, { recursive: true });
+    const env = { ...process.env, HOME: home };
+    for (const nodeId of ["worker-1", "worker-2"]) {
+      registerNode(env, {
+        runId: "auth",
+        nodeId,
+        role: "worker",
+        agent: "codex",
+        coordination: "tmux",
+        status: "busy",
+        planned: true,
+        workDir,
+        tmuxSessionName: `headless-codex-${nodeId}`,
+      });
+    }
+    const nativeDir = join(home, ".codex", "sessions", "2026", "05", "13");
+    const olderPath = join(nativeDir, "rollout-worker-1.jsonl");
+    const newerPath = join(nativeDir, "rollout-worker-2.jsonl");
+    mkdirSync(nativeDir, { recursive: true });
+    writeFileSync(
+      olderPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-13T10:00:00.000Z", type: "session_meta", payload: { id: "worker-1", cwd: workDir } }),
+        JSON.stringify({
+          timestamp: "2026-05-13T10:00:01.000Z",
+          type: "response_item",
+          payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "worker 1 final" }] },
+        }),
+        JSON.stringify({ timestamp: "2026-05-13T10:00:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      newerPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-13T10:01:00.000Z", type: "session_meta", payload: { id: "worker-2", cwd: workDir } }),
+        JSON.stringify({
+          timestamp: "2026-05-13T10:01:01.000Z",
+          type: "response_item",
+          payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "worker 2 final" }] },
+        }),
+        JSON.stringify({ timestamp: "2026-05-13T10:01:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"),
+    );
+    const nowMs = Date.now();
+    utimesSync(olderPath, new Date(nowMs + 1000), new Date(nowMs + 1000));
+    utimesSync(newerPath, new Date(nowMs + 2000), new Date(nowMs + 2000));
+
+    assert.equal(
+      await runCli(["run", "view", "auth"], {
+        env,
+        stdout: () => undefined,
+      }),
+      0,
+    );
+
+    const run = readRun(env, "auth");
+    assert.equal(run?.nodes["worker-1"].status, "idle");
+    assert.equal(run?.nodes["worker-1"].lastMessage, "worker 1 final");
+    assert.equal(run?.nodes["worker-2"].status, "idle");
+    assert.equal(run?.nodes["worker-2"].lastMessage, "worker 2 final");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -607,6 +607,100 @@ test("run message routes tmux nodes through tmux buffers", async () => {
   }
 });
 
+test("run wait reconciles completed tmux nodes from native transcripts", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    mkdirSync(workDir, { recursive: true });
+    const env = { ...process.env, HOME: home };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "tmux",
+      status: "busy",
+      planned: true,
+      workDir,
+      tmuxSessionName: "headless-codex-worker-1",
+    });
+    const transcriptPath = join(home, ".codex", "sessions", "2026", "05", "13", "rollout-complete.jsonl");
+    mkdirSync(dirname(transcriptPath), { recursive: true });
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-13T10:00:00.000Z", type: "session_meta", payload: { id: "complete", cwd: workDir } }),
+        JSON.stringify({
+          timestamp: "2026-05-13T10:00:01.000Z",
+          type: "response_item",
+          payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "tmux final" }] },
+        }),
+        JSON.stringify({ timestamp: "2026-05-13T10:00:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"),
+    );
+
+    const stdout: string[] = [];
+    assert.equal(
+      await runCli(["run", "wait", "auth"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+
+    const run = readRun(env, "auth");
+    assert.equal(stdout.join(""), "run idle: auth\n");
+    assert.equal(run?.nodes["worker-1"].status, "idle");
+    assert.equal(run?.nodes["worker-1"].lastMessage, "tmux final");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("run message marks tmux nodes busy after sending input", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "tmux.jsonl");
+    await writeExecutable(
+      join(binDir, "tmux"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+        "",
+      ].join("\n"),
+    );
+    const env = { ...process.env, HEADLESS_TMUX_CAPTURE: captureFile, HOME: join(dir, "home"), PATH: `${binDir}:${process.env.PATH ?? ""}` };
+    registerNode(env, {
+      runId: "auth",
+      nodeId: "worker-1",
+      role: "worker",
+      agent: "codex",
+      coordination: "tmux",
+      status: "idle",
+      planned: true,
+      tmuxSessionName: "headless-codex-worker-1",
+    });
+
+    assert.equal(
+      await runCli(["run", "message", "auth", "worker-1", "--prompt", "continue"], {
+        env,
+        stdout: () => undefined,
+      }),
+      0,
+    );
+
+    const run = readRun(env, "auth");
+    assert.equal(run?.nodes["worker-1"].status, "busy");
+    assert.equal(run?.nodes["worker-1"].lastMessage, "continue");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("tmux run launch failure marks the node failed", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
   try {

--- a/tests/tmux-name.test.ts
+++ b/tests/tmux-name.test.ts
@@ -118,7 +118,7 @@ test("CLI list includes named headless tmux sessions", async () => {
       binDir,
       [
         "#!/usr/bin/env node",
-        "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}') process.exit(2);",
+        "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}\\t#{pane_current_path}') process.exit(2);",
         "process.stdout.write('headless-codex-work\\t1700000000\\t4102444800\\t0\\nheadless-opencode-review.1\\t1700000000\\t1700000000\\t0\\nother\\t1700000000\\t1700000000\\t0\\n');",
         "",
       ].join("\n"),
@@ -186,7 +186,7 @@ test("CLI attach attaches the only active headless tmux session", async () => {
         "const fs = require('node:fs');",
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
-        "if (args.join(' ') === 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}') {",
+        "if (args.join(' ') === 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}\\t#{pane_current_path}') {",
         "  process.stdout.write('headless-codex-work\\t1700000000\\t4102444800\\t0\\nother\\t1700000000\\t1700000000\\t0\\n');",
         "}",
         "",
@@ -200,7 +200,7 @@ test("CLI attach attaches the only active headless tmux session", async () => {
 
     assert.equal(code, 0);
     assert.deepEqual(readTmuxCalls(captureFile), [
-      ["list-sessions", "-F", "#{session_name}\t#{session_created}\t#{window_activity}\t#{pane_dead}"],
+      ["list-sessions", "-F", "#{session_name}\t#{session_created}\t#{window_activity}\t#{pane_dead}\t#{pane_current_path}"],
       ["attach-session", "-t", "headless-codex-work"],
     ]);
   } finally {
@@ -220,7 +220,7 @@ test("CLI attach uses the most recently active headless tmux session by default"
         "const fs = require('node:fs');",
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
-        "if (args.join(' ') === 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}') {",
+        "if (args.join(' ') === 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}\\t#{pane_current_path}') {",
         "  process.stdout.write('headless-codex-work\\t1700000000\\t1700000000\\t0\\nheadless-opencode-review\\t1700000000\\t4102444800\\t0\\n');",
         "}",
         "",
@@ -234,7 +234,7 @@ test("CLI attach uses the most recently active headless tmux session by default"
 
     assert.equal(code, 0);
     assert.deepEqual(readTmuxCalls(captureFile), [
-      ["list-sessions", "-F", "#{session_name}\t#{session_created}\t#{window_activity}\t#{pane_dead}"],
+      ["list-sessions", "-F", "#{session_name}\t#{session_created}\t#{window_activity}\t#{pane_dead}\t#{pane_current_path}"],
       ["attach-session", "-t", "headless-opencode-review"],
     ]);
   } finally {
@@ -250,7 +250,7 @@ test("CLI attach --all prints tiled aggregator commands", async () => {
       binDir,
       [
         "#!/usr/bin/env node",
-        "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}') process.exit(2);",
+        "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}\\t#{pane_current_path}') process.exit(2);",
         "process.stdout.write('headless-codex-work\\t1700000000\\t4102444800\\t0\\nheadless-opencode-review\\t1700000000\\t1700000000\\t0\\n');",
         "",
       ].join("\n"),
@@ -283,7 +283,7 @@ test("CLI attach --all attaches directly when only one session exists", async ()
       binDir,
       [
         "#!/usr/bin/env node",
-        "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}') process.exit(2);",
+        "if (process.argv.slice(2).join(' ') !== 'list-sessions -F #{session_name}\\t#{session_created}\\t#{window_activity}\\t#{pane_dead}\\t#{pane_current_path}') process.exit(2);",
         "process.stdout.write('headless-codex-work\\t1700000000\\t4102444800\\t0\\n');",
         "",
       ].join("\n"),


### PR DESCRIPTION
## What changed
- Add native transcript activity detection for Codex, Claude, Cursor, Gemini, OpenCode, and Pi.
- Use transcript-derived running/waiting/idle state in tmux session listing when available.
- Reconcile tmux run nodes from native transcript activity in `headless run view` and `headless run wait`.
- Mark tmux run nodes busy after `headless run message` sends new input.
- Document the changes under a TBD changelog section.

## Why
Tmux pane activity alone cannot distinguish an agent that completed from one that is just quiet. Native transcripts expose backend-specific terminal, pending tool, and waiting-for-user-input signals, so Headless can show more accurate state.

## Test plan
- `npm run check`
- pre-push hook: `npm run build`
- pre-push hook: `npm run test:integration:local` (9 passed, 1 skipped)