### PR TITLE
Add tmux wait mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TBD
 
+- Added `--tmux --wait` to wait for native transcript completion and print the final assistant message, plus `--delete` to kill the tmux session after capture; OpenCode wait mode now uses prompt-bearing interactive runs so sessions persist unless `--delete` is set.
 - Added native transcript activity detection for Codex, Claude, Cursor, Gemini, OpenCode, and Pi, including running, waiting-for-input, and idle/completed signals.
 - Changed tmux session listing to prefer native transcript state over tmux inactivity when available, so completed sessions can show `idle` and prompt-blocked sessions can show `waiting`.
 - Changed coordinated tmux runs so `headless run view` and `headless run wait` reconcile node status from native transcript activity, and `headless run message` marks tmux nodes busy after sending input.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ headless codex --prompt "Continue the fix" --session bughunt
 
 # Launch an interactive tmux session.
 headless codex --prompt "Fix the failing tests" --tmux
+headless codex --prompt "Fix the failing tests" --tmux --wait --delete
 headless attach --all
 
 # Validate local setup.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,11 +100,12 @@ Pass `--session <name>` to start or resume a named native session. Headless stor
 headless codex --prompt "Continue the fix" --session bughunt
 ```
 
-Pass `--tmux` to create a detached interactive session named `headless-<agent>-<pid>`, start the selected agent with the prompt as its initial message, print an attach command, and exit. Pass `--name <name>` for a stable managed session name. Pass `--session <name>` for start-or-send behavior: if `headless-<agent>-<name>` is active, Headless sends the prompt there; otherwise it starts that named session.
+Pass `--tmux` to create a detached interactive session named `headless-<agent>-<pid>`, start the selected agent with the prompt as its initial message, print an attach command, and exit. Pass `--wait` with `--tmux` to wait until the agent's native transcript reports completion, then print the final assistant message. Add `--delete` to kill the tmux session after that final message is captured. Pass `--name <name>` for a stable managed session name. Pass `--session <name>` for start-or-send behavior: if `headless-<agent>-<name>` is active, Headless sends the prompt there; otherwise it starts that named session.
 
 ```bash
 headless claude --prompt-file task.md --work-dir /path/to/project --tmux
 env -u TMUX tmux attach-session -t headless-claude-12345
+headless codex --prompt "Fix the tests" --tmux --wait --delete
 headless codex --prompt "Fix the tests" --tmux --name work
 headless codex --prompt "Run focused tests" --tmux --session work
 ```
@@ -233,11 +234,13 @@ Options:
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--docker`: run the agent inside Docker for one-shot headless execution.
 - `--modal`: run the agent in a Modal CPU sandbox for one-shot headless execution.
-- `--timeout <s>`: stop one-shot local, Docker, or Modal execution after the given number of seconds.
+- `--timeout <s>`: stop one-shot local, Docker, Modal, or `--tmux --wait` execution after the given number of seconds.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.
 - `--debug`: stream the raw agent JSON trace and append the extracted final message.
 - `--usage`: append normalized token usage and cost JSON after the final message.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
+- `--wait`: with `--tmux`, wait for native transcript completion and print the final message.
+- `--delete`: with `--tmux --wait`, kill the tmux session after completion.
 - `--name`: use a stable managed session name with `--tmux`.
 - `--session`: start or resume a named Headless session. Uses `~/.headless/sessions.json`; in tmux mode starts or sends to `headless-<agent>-<name>`.
 - `headless attach`: attach to the most recently active Headless tmux session; add `--all` to tile all active sessions.

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -378,6 +378,25 @@ function buildInteractiveOpencode(options: BuildOptions): BuiltCommand {
   return commandWithOptionalEnv("opencode", args, opencodeEnv(options.allow));
 }
 
+export function buildInteractiveOpencodeRun(options: BuildOptions): BuiltCommand {
+  const args = ["run", "--interactive"];
+  const model = options.model ?? DEFAULT_OPENCODE_MODEL;
+
+  args.push("--model", model);
+  if (options.reasoningEffort) {
+    args.push("--variant", options.reasoningEffort);
+  }
+  if (options.allow === "yolo" || options.allow === undefined) {
+    args.push("--dangerously-skip-permissions");
+  }
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--session", options.sessionId);
+  }
+  args.push(options.prompt);
+
+  return commandWithOptionalEnv("opencode", args, opencodeEnv(options.allow));
+}
+
 function buildPi(options: BuildOptions, env: Env): BuiltCommand {
   const command = env.PI_CODING_AGENT_BIN || "pi";
   const args = options.sessionMode ? ["--mode", "json"] : ["--no-session", "--mode", "json"];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1984,8 +1984,8 @@ function readTmuxFinalMessage(agent: AgentName, workDir: string, env: Env, snaps
   for (const candidate of candidates) {
     const transcript = tmuxWaitCandidateWithSnapshot(candidate, snapshot);
     if (!transcript) continue;
-    const activity = deriveNativeTranscriptActivity(agent, transcript);
-    if (activity?.status !== "idle") continue;
+    const activity = deriveNativeTranscriptActivity(agent, transcript, { terminalDonePrecedence: true });
+    if (activity?.reason !== "terminal_done") continue;
     const message = activity.message ?? indexNativeAssistantCompletion(agent, transcript)?.message;
     if (message) return message;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,7 @@ import {
 import {
   deriveNativeTranscriptActivity,
   indexNativeAssistantCompletion,
+  nativeTranscriptIncludesText,
   nativeTranscriptKey,
   resolveLatestNativeTranscripts,
 } from "./native-transcripts.js";
@@ -911,6 +912,7 @@ interface TmuxPostLaunchCommand {
 }
 
 interface TmuxWaitSnapshot {
+  marker: string;
   startedAt: string;
   transcripts: Map<string, number | undefined>;
 }
@@ -1948,8 +1950,17 @@ async function executeTmuxCommands(
   return 0;
 }
 
-function createTmuxWaitSnapshot(agent: AgentName, workDir: string, env: Env): TmuxWaitSnapshot {
+function tmuxWaitMarker(sessionName: string): string {
+  return `headless-tmux-wait:${sessionName}`;
+}
+
+function promptWithTmuxWaitMarker(prompt: string, sessionName: string): string {
+  return `${prompt}\n\n<!-- ${tmuxWaitMarker(sessionName)} -->`;
+}
+
+function createTmuxWaitSnapshot(agent: AgentName, sessionName: string, workDir: string, env: Env): TmuxWaitSnapshot {
   return {
+    marker: tmuxWaitMarker(sessionName),
     startedAt: new Date().toISOString(),
     transcripts: new Map(
       resolveLatestNativeTranscripts(agent, workDir, env, {}, 20).map((transcript) => [
@@ -1984,6 +1995,7 @@ function readTmuxFinalMessage(agent: AgentName, workDir: string, env: Env, snaps
   for (const candidate of candidates) {
     const transcript = tmuxWaitCandidateWithSnapshot(candidate, snapshot);
     if (!transcript) continue;
+    if (!nativeTranscriptIncludesText(transcript, snapshot.marker)) continue;
     const activity = deriveNativeTranscriptActivity(agent, transcript, { terminalDonePrecedence: true });
     if (activity?.reason !== "terminal_done") continue;
     const message = activity.message ?? indexNativeAssistantCompletion(agent, transcript)?.message;
@@ -2769,14 +2781,15 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         ? buildHeadlessTmuxSessionName(parsed.agent, parsed.sessionAlias)
         : undefined;
       if (sessionName && (await headlessTmuxSessionExists(sessionName, env))) {
-        const tmuxCommands = buildTmuxSendCommands(sessionName, composedPrompt);
+        const tmuxPrompt = parsed.wait ? promptWithTmuxWaitMarker(composedPrompt, sessionName) : composedPrompt;
+        const tmuxCommands = buildTmuxSendCommands(sessionName, tmuxPrompt);
         if (parsed.printCommand) {
           for (const command of tmuxCommands.commands) {
             stdout(`${quoteCommand(command)}\n`);
           }
           return 0;
         }
-        const waitSnapshot = parsed.wait ? createTmuxWaitSnapshot(parsed.agent, tmuxWaitWorkDir, env) : undefined;
+        const waitSnapshot = parsed.wait ? createTmuxWaitSnapshot(parsed.agent, sessionName, tmuxWaitWorkDir, env) : undefined;
         const code = await executeTmuxSendCommands(tmuxCommands, env, stderr);
         if (parsed.runId && parsed.role && nodeId) {
           if (code === 0) {
@@ -2822,8 +2835,11 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         }
         return code;
       }
+      const tmuxNamePart = parsed.sessionAlias ?? parsed.tmuxName ?? String(process.pid);
+      const tmuxSessionName = buildHeadlessTmuxSessionName(parsed.agent, tmuxNamePart);
+      const tmuxPrompt = parsed.wait ? promptWithTmuxWaitMarker(composedPrompt, tmuxSessionName) : composedPrompt;
       const tmuxCommandOptions = {
-        prompt: composedPrompt,
+        prompt: tmuxPrompt,
         model: configuredDefaults.model,
         allow,
         reasoningEffort: configuredDefaults.reasoningEffort,
@@ -2839,10 +2855,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       const tmuxCommands = buildTmuxCommands(
         parsed.agent,
         tmuxCommand,
-        composedPrompt,
+        tmuxPrompt,
         cwd,
         env,
-        parsed.sessionAlias ?? parsed.tmuxName,
+        tmuxNamePart,
         { pastePrompt: !(parsed.agent === "opencode" && parsed.wait) },
       );
       if (parsed.printCommand) {
@@ -2860,7 +2876,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         trustCursorWorkspace(cwd, env);
       }
 
-      const waitSnapshot = parsed.wait ? createTmuxWaitSnapshot(parsed.agent, tmuxWaitWorkDir, env) : undefined;
+      const waitSnapshot = parsed.wait
+        ? createTmuxWaitSnapshot(parsed.agent, tmuxCommands.sessionName, tmuxWaitWorkDir, env)
+        : undefined;
       const code = await executeTmuxCommands(tmuxCommands, cwd, env, stderr);
       if (parsed.runId && parsed.role && nodeId) {
         if (code === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   buildAgentCommand,
+  buildInteractiveOpencodeRun,
   buildInteractiveAgentCommand,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_OPENCODE_MODEL,
@@ -62,7 +63,12 @@ import {
   fetchModelsDevPricing,
   priceUsageSummary,
 } from "./output.js";
-import { deriveNativeTranscriptActivity, nativeTranscriptKey, resolveLatestNativeTranscripts } from "./native-transcripts.js";
+import {
+  deriveNativeTranscriptActivity,
+  indexNativeAssistantCompletion,
+  nativeTranscriptKey,
+  resolveLatestNativeTranscripts,
+} from "./native-transcripts.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import { extractRunNodeMetrics } from "./run-metrics.js";
 import { createRunStatusReporter, parseRunStatusIntervalMs } from "./run-status.js";
@@ -145,6 +151,8 @@ interface ParsedArgs {
   json: boolean;
   debug: boolean;
   usage: boolean;
+  wait: boolean;
+  delete: boolean;
   printCommand: boolean;
   showConfig: boolean;
   check: boolean;
@@ -222,6 +230,8 @@ function usage(): string {
     "  --debug              Stream raw trace and print extracted final message.",
     "  --usage              Print final message plus normalized token and cost JSON.",
     "  --tmux               Launch an interactive agent in a tmux session.",
+    "  --wait               With --tmux, wait for native transcript completion and print the final message.",
+    "  --delete             With --tmux --wait, kill the tmux session after completion.",
     "  --name <name>        Use a managed tmux session name with --tmux.",
     "  --session <name>     Start or resume a named Headless session.",
     "  attach [session]     Attach to one or all active headless tmux sessions.",
@@ -266,6 +276,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     json: false,
     debug: false,
     usage: false,
+    wait: false,
+    delete: false,
     printCommand: false,
     showConfig: false,
     check: false,
@@ -426,6 +438,12 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--usage":
         parsed.usage = true;
+        break;
+      case "--wait":
+        parsed.wait = true;
+        break;
+      case "--delete":
+        parsed.delete = true;
         break;
       case "--tmux":
         parsed.tmux = true;
@@ -890,6 +908,11 @@ interface TmuxAttachAllCommands {
 interface TmuxPostLaunchCommand {
   command: BuiltCommand;
   delayMs: number;
+}
+
+interface TmuxWaitSnapshot {
+  startedAt: string;
+  transcripts: Map<string, number | undefined>;
 }
 
 interface HeadlessTmuxSession {
@@ -1381,9 +1404,11 @@ function buildTmuxCommands(
   cwd: string | undefined,
   env: Env,
   customName: string | undefined,
+  options: { pastePrompt?: boolean } = {},
 ): TmuxCommands {
   const sessionName = buildHeadlessTmuxSessionName(agent, customName ?? String(process.pid));
   const startDir = cwd ?? process.cwd();
+  const pastePrompt = options.pastePrompt ?? true;
   const opencodeWakeDelayMs = parseDelayMs(
     env.HEADLESS_TMUX_OPENCODE_WAKE_DELAY_MS ?? env.HEADLESS_TMUX_OPENCODE_ENTER_DELAY_MS,
     4000,
@@ -1398,7 +1423,7 @@ function buildTmuxCommands(
       args: ["new-session", "-d", "-s", sessionName, "-c", startDir, quoteCommand(command)],
     },
     postLaunch:
-      agent === "opencode"
+      agent === "opencode" && pastePrompt
         ? [
             {
               command: { command: "tmux", args: ["send-keys", "-t", sessionName, "Space", "BSpace"] },
@@ -1923,6 +1948,89 @@ async function executeTmuxCommands(
   return 0;
 }
 
+function createTmuxWaitSnapshot(agent: AgentName, workDir: string, env: Env): TmuxWaitSnapshot {
+  return {
+    startedAt: new Date().toISOString(),
+    transcripts: new Map(
+      resolveLatestNativeTranscripts(agent, workDir, env, {}, 20).map((transcript) => [
+        tmuxWaitTranscriptIdentity(transcript),
+        transcript.kind === "jsonl" ? statSync(transcript.path).size : undefined,
+      ]),
+    ),
+  };
+}
+
+function tmuxWaitTranscriptIdentity(transcript: ReturnType<typeof resolveLatestNativeTranscripts>[number]): string {
+  return [transcript.kind, transcript.path, transcript.sessionId ?? ""].join("\t");
+}
+
+function tmuxWaitCandidateWithSnapshot(
+  transcript: ReturnType<typeof resolveLatestNativeTranscripts>[number],
+  snapshot: TmuxWaitSnapshot,
+): ReturnType<typeof resolveLatestNativeTranscripts>[number] | undefined {
+  if (transcript.kind !== "jsonl") {
+    return transcript;
+  }
+  const startOffset = snapshot.transcripts.get(tmuxWaitTranscriptIdentity(transcript)) ?? 0;
+  const endOffset = statSync(transcript.path).size;
+  if (startOffset >= endOffset) {
+    return undefined;
+  }
+  return { ...transcript, startOffset, endOffset };
+}
+
+function readTmuxFinalMessage(agent: AgentName, workDir: string, env: Env, snapshot: TmuxWaitSnapshot): string {
+  const candidates = resolveLatestNativeTranscripts(agent, workDir, env, { startedAt: snapshot.startedAt }, 20);
+  for (const candidate of candidates) {
+    const transcript = tmuxWaitCandidateWithSnapshot(candidate, snapshot);
+    if (!transcript) continue;
+    const activity = deriveNativeTranscriptActivity(agent, transcript);
+    if (activity?.status !== "idle") continue;
+    const message = activity.message ?? indexNativeAssistantCompletion(agent, transcript)?.message;
+    if (message) return message;
+  }
+  return "";
+}
+
+async function waitForTmuxFinalMessage(
+  agent: AgentName,
+  sessionName: string,
+  workDir: string,
+  env: Env,
+  snapshot: TmuxWaitSnapshot,
+  timeoutSeconds: number | undefined,
+): Promise<string> {
+  const intervalMs = parseDelayMs(env.HEADLESS_TMUX_WAIT_INTERVAL_MS, 1000);
+  const deadline = timeoutSeconds === undefined ? undefined : Date.now() + timeoutSeconds * 1000;
+  while (true) {
+    const message = readTmuxFinalMessage(agent, workDir, env, snapshot);
+    if (message) return message;
+    if (deadline !== undefined && Date.now() >= deadline) {
+      throw new CliError(`tmux wait timed out after ${timeoutSeconds}s`);
+    }
+    if (!(await headlessTmuxSessionExists(sessionName, env))) {
+      const finalMessage = readTmuxFinalMessage(agent, workDir, env, snapshot);
+      if (finalMessage) return finalMessage;
+      throw new CliError(`tmux session ended before final message: ${sessionName}`);
+    }
+    await waitForDelay(intervalMs);
+  }
+}
+
+async function deleteTmuxSession(sessionName: string, env: Env, stderr: (text: string) => void): Promise<number> {
+  const result = await captureSimpleCommand({ command: "tmux", args: ["kill-session", "-t", sessionName] }, undefined, env);
+  if (result.code === 0) {
+    return 0;
+  }
+  if (result.stderr.includes("no server running") || result.stderr.includes("can't find session")) {
+    return 0;
+  }
+  if (result.stderr) {
+    stderr(result.stderr);
+  }
+  return result.code;
+}
+
 async function executeTmuxSendCommands(
   commands: TmuxSendCommands,
   env: Env,
@@ -2179,6 +2287,8 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       }
       if (
         parsed.tmux ||
+        parsed.wait ||
+        parsed.delete ||
         parsed.sessionAlias !== undefined ||
         parsed.json ||
         parsed.debug ||
@@ -2219,6 +2329,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       }
       if (parsed.tmux) {
         throw new CliError("--tmux cannot be used with attach");
+      }
+      if (parsed.wait) {
+        throw new CliError("--wait cannot be used with attach");
+      }
+      if (parsed.delete) {
+        throw new CliError("--delete cannot be used with attach");
       }
       if (parsed.json) {
         throw new CliError("--json cannot be used with attach");
@@ -2330,6 +2446,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (parsed.tmux) {
         throw new CliError("--tmux cannot be used with rename");
       }
+      if (parsed.wait) {
+        throw new CliError("--wait cannot be used with rename");
+      }
+      if (parsed.delete) {
+        throw new CliError("--delete cannot be used with rename");
+      }
       if (parsed.json) {
         throw new CliError("--json cannot be used with rename");
       }
@@ -2376,6 +2498,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (parsed.tmux) {
         throw new CliError("--tmux cannot be used with send");
       }
+      if (parsed.wait) {
+        throw new CliError("--wait cannot be used with send");
+      }
+      if (parsed.delete) {
+        throw new CliError("--delete cannot be used with send");
+      }
       if (parsed.json) {
         throw new CliError("--json cannot be used with send");
       }
@@ -2416,6 +2544,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (parsed.timeoutSeconds !== undefined) {
         throw new CliError("--timeout cannot be used with --check");
       }
+      if (parsed.wait) {
+        throw new CliError("--wait cannot be used with --check");
+      }
+      if (parsed.delete) {
+        throw new CliError("--delete cannot be used with --check");
+      }
       if (parsed.sessionAlias !== undefined) {
         throw new CliError("--session cannot be used with --check");
       }
@@ -2436,6 +2570,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.list) {
       if (parsed.timeoutSeconds !== undefined) {
         throw new CliError("--timeout cannot be used with --list");
+      }
+      if (parsed.wait) {
+        throw new CliError("--wait cannot be used with --list");
+      }
+      if (parsed.delete) {
+        throw new CliError("--delete cannot be used with --list");
       }
       if (parsed.sessionAlias !== undefined) {
         throw new CliError("--session cannot be used with --list");
@@ -2476,7 +2616,18 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       throw new CliError("--json cannot be used with --tmux");
     }
     if (parsed.tmux && parsed.timeoutSeconds !== undefined) {
-      throw new CliError("--timeout cannot be used with --tmux");
+      if (!parsed.wait) {
+        throw new CliError("--timeout cannot be used with --tmux");
+      }
+    }
+    if (parsed.wait && !parsed.tmux) {
+      throw new CliError("--wait requires --tmux");
+    }
+    if (parsed.delete && !parsed.wait) {
+      throw new CliError("--delete requires --wait");
+    }
+    if (parsed.wait && parsed.printCommand) {
+      throw new CliError("--wait cannot be used with --print-command");
     }
     if (parsed.usage && parsed.json) {
       throw new CliError("--usage cannot be used with --json");
@@ -2613,6 +2764,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     );
 
     if (parsed.tmux) {
+      const tmuxWaitWorkDir = cwd ?? process.cwd();
       const sessionName = parsed.sessionAlias
         ? buildHeadlessTmuxSessionName(parsed.agent, parsed.sessionAlias)
         : undefined;
@@ -2624,6 +2776,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
           }
           return 0;
         }
+        const waitSnapshot = parsed.wait ? createTmuxWaitSnapshot(parsed.agent, tmuxWaitWorkDir, env) : undefined;
         const code = await executeTmuxSendCommands(tmuxCommands, env, stderr);
         if (parsed.runId && parsed.role && nodeId) {
           if (code === 0) {
@@ -2648,20 +2801,37 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
           }
         }
         if (code === 0) {
+          if (waitSnapshot) {
+            stderr(`sent: ${tmuxCommands.sessionName}\n`);
+            const finalMessage = await waitForTmuxFinalMessage(
+              parsed.agent,
+              tmuxCommands.sessionName,
+              tmuxWaitWorkDir,
+              env,
+              waitSnapshot,
+              commandTimeoutSeconds,
+            );
+            if (parsed.runId && parsed.role && nodeId) {
+              updateNodeStatus(env, parsed.runId, nodeId, "idle", finalMessage);
+            }
+            const deleteCode = parsed.delete ? await deleteTmuxSession(tmuxCommands.sessionName, env, stderr) : 0;
+            stdout(`${finalMessage}\n`);
+            return deleteCode;
+          }
           stdout(`sent: ${tmuxCommands.sessionName}\n`);
         }
         return code;
       }
-      const tmuxCommand = buildInteractiveAgentCommand(
-        parsed.agent,
-        {
-          prompt: composedPrompt,
-          model: configuredDefaults.model,
-          allow,
-          reasoningEffort: configuredDefaults.reasoningEffort,
-        },
-        env,
-      );
+      const tmuxCommandOptions = {
+        prompt: composedPrompt,
+        model: configuredDefaults.model,
+        allow,
+        reasoningEffort: configuredDefaults.reasoningEffort,
+      };
+      const tmuxCommand =
+        parsed.agent === "opencode" && parsed.wait
+          ? buildInteractiveOpencodeRun(tmuxCommandOptions)
+          : buildInteractiveAgentCommand(parsed.agent, tmuxCommandOptions, env);
       const reasoningWarning = unsupportedReasoningEffortWarning(parsed.agent, configuredDefaults.reasoningEffort, "tmux");
       if (reasoningWarning) {
         stderr(reasoningWarning);
@@ -2673,6 +2843,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         cwd,
         env,
         parsed.sessionAlias ?? parsed.tmuxName,
+        { pastePrompt: !(parsed.agent === "opencode" && parsed.wait) },
       );
       if (parsed.printCommand) {
         stdout(`${quoteCommand(tmuxCommands.newSession)}\n`);
@@ -2689,6 +2860,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         trustCursorWorkspace(cwd, env);
       }
 
+      const waitSnapshot = parsed.wait ? createTmuxWaitSnapshot(parsed.agent, tmuxWaitWorkDir, env) : undefined;
       const code = await executeTmuxCommands(tmuxCommands, cwd, env, stderr);
       if (parsed.runId && parsed.role && nodeId) {
         if (code === 0) {
@@ -2713,8 +2885,28 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         }
       }
       if (code === 0) {
-        stdout(`tmux session: ${tmuxCommands.sessionName}\n`);
-        stdout(`attach: ${quoteCommand(buildTmuxAttachCommand(tmuxCommands.sessionName).command)}\n`);
+        const sessionLine = `tmux session: ${tmuxCommands.sessionName}\n`;
+        const attachLine = `attach: ${quoteCommand(buildTmuxAttachCommand(tmuxCommands.sessionName).command)}\n`;
+        if (waitSnapshot) {
+          stderr(sessionLine);
+          stderr(attachLine);
+          const finalMessage = await waitForTmuxFinalMessage(
+            parsed.agent,
+            tmuxCommands.sessionName,
+            tmuxWaitWorkDir,
+            env,
+            waitSnapshot,
+            commandTimeoutSeconds,
+          );
+          if (parsed.runId && parsed.role && nodeId) {
+            updateNodeStatus(env, parsed.runId, nodeId, "idle", finalMessage);
+          }
+          const deleteCode = parsed.delete ? await deleteTmuxSession(tmuxCommands.sessionName, env, stderr) : 0;
+          stdout(`${finalMessage}\n`);
+          return deleteCode;
+        }
+        stdout(sessionLine);
+        stdout(attachLine);
       }
       return code;
     }

--- a/src/native-activity.ts
+++ b/src/native-activity.ts
@@ -16,6 +16,7 @@ export interface NativeTranscriptActivity {
 export interface NativeTranscriptActivityOptions {
   nowMs?: number;
   runningTtlMs?: number;
+  terminalDonePrecedence?: boolean;
   waitingTtlMs?: number;
 }
 
@@ -58,6 +59,7 @@ export function deriveNativeTranscriptActivity(
   const nowMsValue = options.nowMs ?? Date.now();
   const decision = deriveActivityDecision(agent, events, updatedAtMs, nowMsValue, {
     runningTtlMs: options.runningTtlMs ?? defaultRunningTtlMs,
+    terminalDonePrecedence: options.terminalDonePrecedence ?? false,
     waitingTtlMs: options.waitingTtlMs ?? defaultWaitingTtlMs,
   });
   return { ...decision, updatedAtMs };
@@ -151,11 +153,16 @@ function deriveActivityDecision(
   events: NativeActivityEvent[],
   updatedAtMs: number,
   nowMsValue: number,
-  ttl: { runningTtlMs: number; waitingTtlMs: number },
+  ttl: { runningTtlMs: number; terminalDonePrecedence: boolean; waitingTtlMs: number },
 ): NativeActivityDecision {
   const unmatchedToolUses = countUnmatchedToolUses(events);
   if (unmatchedToolUses > 0) {
     return applyFreshness({ status: "running", reason: "pending_tool_use_fresh" }, updatedAtMs, nowMsValue, ttl.runningTtlMs);
+  }
+
+  const terminalEvent = findLatestTerminalDoneEvent(agent, events);
+  if (terminalEvent && ttl.terminalDonePrecedence) {
+    return { status: "idle", reason: "terminal_done", message: latestMessage(terminalEvent) || latestAssistantMessage(events) };
   }
 
   const waitEvent = findPendingWaitSignalEvent(events);
@@ -168,7 +175,6 @@ function deriveActivityDecision(
     );
   }
 
-  const terminalEvent = findLatestTerminalDoneEvent(agent, events);
   if (terminalEvent) {
     return { status: "idle", reason: "terminal_done", message: latestMessage(terminalEvent) || latestAssistantMessage(events) };
   }

--- a/src/native-transcripts.ts
+++ b/src/native-transcripts.ts
@@ -144,6 +144,11 @@ export function indexNativeAssistantCompletion(
   return { message, source: "native-transcript", path: transcript.path };
 }
 
+export function nativeTranscriptIncludesText(transcript: NativeTranscript | undefined, text: string): boolean {
+  if (!transcript || !text || !existsSync(transcript.path)) return false;
+  return transcript.kind === "sqlite" ? openCodeTranscriptIncludesText(transcript, text) : readTranscriptSlice(transcript).includes(text);
+}
+
 function readTranscriptSlice(transcript: NativeTranscript): string {
   const bytes = readFileSync(transcript.path);
   const start = transcript.startOffset ?? 0;
@@ -174,6 +179,31 @@ function indexOpenCodeCompletion(transcript: NativeTranscript): string {
   );
   if (sqlite.status !== 0) return "";
   return sqlite.stdout.trim();
+}
+
+function openCodeTranscriptIncludesText(transcript: NativeTranscript, text: string): boolean {
+  if (!transcript.sessionId || !/^[A-Za-z0-9_.:-]+$/.test(transcript.sessionId)) return false;
+  const sqlite = spawnSync(
+    "sqlite3",
+    [
+      "-json",
+      transcript.path,
+      [
+        "select part.data as part_data",
+        "from part",
+        `where part.session_id = '${transcript.sessionId.replaceAll("'", "''")}'`,
+        "order by part.time_created asc;",
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  if (sqlite.status !== 0 || !sqlite.stdout.trim()) return false;
+  try {
+    const rows = JSON.parse(sqlite.stdout) as unknown;
+    return Array.isArray(rows) && rows.some((row) => asString(asRecord(row).part_data).includes(text));
+  } catch {
+    return false;
+  }
 }
 
 function claudeTranscriptPath(nativeId: string, workDir: string | undefined, env: Env): string | undefined {
@@ -250,6 +280,10 @@ function geminiProjectSlot(root: string, workspace: string): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
 }
 
 function findFileContaining(root: string | undefined, text: string): string | undefined {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2534,9 +2534,11 @@ test("CLI --tmux --wait prints final message from native transcript activity", a
           "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
           "if (args[0] === 'new-session') {",
           "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
+          "  const sessionName = args[3];",
           "  const cwd = args[5];",
           "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'wait', cwd } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello <!-- headless-tmux-wait:' + sessionName + ' -->' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'wait final' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
           "    '',",
@@ -2605,6 +2607,7 @@ test("CLI --tmux --wait ignores stale transcript bytes from an existing session"
           "const args = process.argv.slice(2);",
           "if (args[0] === 'new-session') {",
           "  fs.appendFileSync(process.env.HEADLESS_TRANSCRIPT, [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'again <!-- headless-tmux-wait:' + args[3] + ' -->' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'fresh final' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
           "    '',",
@@ -2658,6 +2661,7 @@ test("CLI --tmux --wait accepts terminal completion even when final answer asks 
           "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
           "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'question', cwd: args[5] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello <!-- headless-tmux-wait:' + args[3] + ' -->' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Should I run the full gate?' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
           "    '',",
@@ -2689,6 +2693,70 @@ test("CLI --tmux --wait accepts terminal completion even when final answer asks 
   }
 });
 
+test("CLI --tmux --wait ignores another same-workdir transcript without its wait marker", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const workDir = join(dir, "work");
+    const sessionsDir = join(home, ".codex", "sessions", "2026", "05", "14");
+    mkdirSync(workDir, { recursive: true });
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "if (args[0] === 'new-session') {",
+          "  const sessionName = args[3];",
+          "  const cwd = args[5];",
+          "  const sessionsDir = process.env.HEADLESS_SESSIONS_DIR;",
+          "  fs.mkdirSync(sessionsDir, { recursive: true });",
+          "  fs.writeFileSync(path.join(sessionsDir, 'rollout-target.jsonl'), [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'target', cwd } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello <!-- headless-tmux-wait:' + sessionName + ' -->' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'target final' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:03.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "  fs.writeFileSync(path.join(sessionsDir, 'rollout-other.jsonl'), [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'other', cwd } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'other <!-- headless-tmux-wait:headless-codex-other -->' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'other final' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:03.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "}",
+          "if (args[0] === 'has-session') process.exit(1);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--work-dir", workDir, "--tmux", "--wait", "--timeout", "2"], {
+      env: {
+        ...process.env,
+        HEADLESS_SESSIONS_DIR: sessionsDir,
+        HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "target final\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --tmux --wait --delete kills the tmux session after final output", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
@@ -2713,6 +2781,7 @@ test("CLI --tmux --wait --delete kills the tmux session after final output", asy
           "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
           "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'delete', cwd: args[5] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello <!-- headless-tmux-wait:' + args[3] + ' -->' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'delete final' }] } }),",
           "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
           "    '',",
@@ -2775,12 +2844,15 @@ test(
             "if (args[0] === 'new-session') {",
             "  const sessionId = 'ses_wait_delete';",
             "  const now = Date.now();",
+            "  const userPart = JSON.stringify({ type: 'text', text: args[6] }).replaceAll(\"'\", \"''\");",
             "  const sql = `",
             "create table session (id text primary key, directory text not null, time_updated integer not null, data text);",
             "create table message (id text primary key, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);",
             "create table part (id text primary key, message_id text not null, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);",
             "insert into session values ('${sessionId}', '${args[5].replaceAll(\"'\", \"''\")}', ${now}, '{}');",
+            "insert into message values ('user_msg', '${sessionId}', ${now}, ${now}, '{\"role\":\"user\"}');",
             "insert into message values ('assistant_msg', '${sessionId}', ${now}, ${now + 2}, '{\"role\":\"assistant\"}');",
+            "insert into part values ('user_part', 'user_msg', '${sessionId}', ${now}, ${now}, '${userPart}');",
             "insert into part values ('text_part', 'assistant_msg', '${sessionId}', ${now + 1}, ${now + 1}, '{\"type\":\"text\",\"text\":\"opencode wait final\",\"metadata\":{\"openai\":{\"phase\":\"final_answer\"}}}');",
             "insert into part values ('finish_part', 'assistant_msg', '${sessionId}', ${now + 2}, ${now + 2}, '{\"type\":\"step-finish\",\"reason\":\"stop\"}');",
             "`;",

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2512,6 +2512,267 @@ test("CLI --tmux launches an interactive tmux session and sends the prompt", asy
   }
 });
 
+test("CLI --tmux --wait prints final message from native transcript activity", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const workDir = join(dir, "work");
+    const captureFile = join(dir, "tmux.jsonl");
+    const transcriptPath = join(home, ".codex", "sessions", "2026", "05", "14", "rollout-wait.jsonl");
+    mkdirSync(workDir, { recursive: true });
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
+          "if (args[0] === 'new-session') {",
+          "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
+          "  const cwd = args[5];",
+          "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'wait', cwd } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'wait final' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "}",
+          "if (args[0] === 'has-session') process.exit(0);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--work-dir", workDir, "--tmux", "--wait", "--timeout", "2"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_CAPTURE: captureFile,
+        HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+        HEADLESS_TRANSCRIPT: transcriptPath,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stderr: (text) => stderr.push(text),
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "wait final\n");
+    assert.match(stderr.join(""), /tmux session: headless-codex-\d+/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --tmux --wait ignores stale transcript bytes from an existing session", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const workDir = join(dir, "work");
+    const transcriptPath = join(home, ".codex", "sessions", "2026", "05", "14", "rollout-existing.jsonl");
+    mkdirSync(dirname(transcriptPath), { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-14T09:00:00.000Z", type: "session_meta", payload: { id: "existing", cwd: workDir } }),
+        JSON.stringify({
+          timestamp: "2026-05-14T09:00:01.000Z",
+          type: "response_item",
+          payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "stale final" }] },
+        }),
+        JSON.stringify({ timestamp: "2026-05-14T09:00:02.000Z", type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"),
+    );
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const args = process.argv.slice(2);",
+          "if (args[0] === 'new-session') {",
+          "  fs.appendFileSync(process.env.HEADLESS_TRANSCRIPT, [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'fresh final' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "}",
+          "if (args[0] === 'has-session') process.exit(0);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "again", "--work-dir", workDir, "--tmux", "--wait", "--timeout", "2"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+        HEADLESS_TRANSCRIPT: transcriptPath,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "fresh final\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --tmux --wait --delete kills the tmux session after final output", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const workDir = join(dir, "work");
+    const captureFile = join(dir, "tmux.jsonl");
+    const transcriptPath = join(home, ".codex", "sessions", "2026", "05", "14", "rollout-delete.jsonl");
+    mkdirSync(workDir, { recursive: true });
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
+          "if (args[0] === 'new-session') {",
+          "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
+          "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'delete', cwd: args[5] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'delete final' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "}",
+          "if (args[0] === 'has-session') process.exit(0);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--work-dir", workDir, "--tmux", "--wait", "--delete", "--timeout", "2"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_CAPTURE: captureFile,
+        HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+        HEADLESS_TRANSCRIPT: transcriptPath,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const sessionName = calls[0][3];
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "delete final\n");
+    assert.deepEqual(calls.at(-1), ["kill-session", "-t", sessionName]);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test(
+  "CLI opencode --tmux --wait runs prompt-bearing interactive command without deleting the session",
+  { skip: spawnSync("sqlite3", ["--version"]).status !== 0 },
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+    try {
+      const dataHome = join(dir, "opencode-data");
+      const binDir = join(dir, "bin");
+      const workDir = join(dir, "work");
+      const captureFile = join(dir, "tmux.jsonl");
+      const dbPath = join(dataHome, "opencode.db");
+      mkdirSync(workDir, { recursive: true });
+      mkdirSync(dataHome, { recursive: true });
+      await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+        await mkdir(binDir);
+        const tmux = join(binDir, "tmux");
+        await writeFile(
+          tmux,
+          [
+            "#!/usr/bin/env node",
+            "const fs = require('node:fs');",
+            "const { spawnSync } = require('node:child_process');",
+            "const args = process.argv.slice(2);",
+            "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
+            "if (args[0] === 'new-session') {",
+            "  const sessionId = 'ses_wait_delete';",
+            "  const now = Date.now();",
+            "  const sql = `",
+            "create table session (id text primary key, directory text not null, time_updated integer not null, data text);",
+            "create table message (id text primary key, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);",
+            "create table part (id text primary key, message_id text not null, session_id text not null, time_created integer not null, time_updated integer not null, data text not null);",
+            "insert into session values ('${sessionId}', '${args[5].replaceAll(\"'\", \"''\")}', ${now}, '{}');",
+            "insert into message values ('assistant_msg', '${sessionId}', ${now}, ${now + 2}, '{\"role\":\"assistant\"}');",
+            "insert into part values ('text_part', 'assistant_msg', '${sessionId}', ${now + 1}, ${now + 1}, '{\"type\":\"text\",\"text\":\"opencode wait final\",\"metadata\":{\"openai\":{\"phase\":\"final_answer\"}}}');",
+            "insert into part values ('finish_part', 'assistant_msg', '${sessionId}', ${now + 2}, ${now + 2}, '{\"type\":\"step-finish\",\"reason\":\"stop\"}');",
+            "`;",
+            "  const created = spawnSync('sqlite3', [process.env.HEADLESS_OPENCODE_DB, sql], { encoding: 'utf8' });",
+            "  if (created.status !== 0) { process.stderr.write(created.stderr); process.exit(created.status ?? 1); }",
+            "}",
+            "if (args[0] === 'has-session') process.exit(0);",
+            "if (args[0] === 'kill-session') process.exit(9);",
+            "",
+          ].join("\n"),
+        );
+        await chmod(tmux, 0o755);
+      });
+
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      const code = await runCli(
+        ["opencode", "--prompt", "hello", "--work-dir", workDir, "--tmux", "--wait", "--timeout", "2"],
+        {
+          env: {
+            ...process.env,
+            HEADLESS_OPENCODE_DB: dbPath,
+            HEADLESS_TMUX_CAPTURE: captureFile,
+            HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+            OPENCODE_DATA_HOME: dataHome,
+            PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          },
+          stderr: (text) => stderr.push(text),
+          stdout: (text) => stdout.push(text),
+        },
+      );
+
+      const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      assert.equal(code, 0);
+      assert.equal(stdout.join(""), "opencode wait final\n");
+      assert.doesNotMatch(stderr.join(""), /no server running/);
+      assert.match(calls[0][6], /opencode run --interactive/);
+      assert.match(calls[0][6], /hello/);
+      assert.deepEqual(calls.map((call) => call[0]), ["new-session"]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);
+
 test("CLI --tmux --session starts or sends to a named tmux session", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2636,6 +2636,59 @@ test("CLI --tmux --wait ignores stale transcript bytes from an existing session"
   }
 });
 
+test("CLI --tmux --wait accepts terminal completion even when final answer asks a question", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const workDir = join(dir, "work");
+    const transcriptPath = join(home, ".codex", "sessions", "2026", "05", "14", "rollout-question.jsonl");
+    mkdirSync(workDir, { recursive: true });
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "if (args[0] === 'new-session') {",
+          "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
+          "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'session_meta', payload: { id: 'question', cwd: args[5] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Should I run the full gate?' }] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "}",
+          "if (args[0] === 'has-session') process.exit(1);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--work-dir", workDir, "--tmux", "--wait", "--timeout", "2"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+        HEADLESS_TRANSCRIPT: transcriptPath,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "Should I run the full gate?\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --tmux --wait --delete kills the tmux session after final output", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {


### PR DESCRIPTION
## Summary
- add `--tmux --wait` to wait for native transcript completion and print the final assistant message
- add `--delete` to explicitly clean up the tmux session after capture
- preserve OpenCode tmux sessions by using prompt-bearing interactive runs for wait mode
- document the new flags and update the TBD changelog section

## Testing
- `npm run check`
  - 258 tests passed, 0 failed
- pre-push hook on `git push -u origin tmux_wait`
  - local integration suite: 9 passed, 1 skipped, 0 failed
- manual OpenCode verification
  - `headless opencode --work-dir /Users/rob/Dropbox/projects/headless-cli --prompt "Say exactly: tmux wait works" --tmux --wait --timeout 120` printed `tmux wait works` and left the tmux session alive
  - `headless opencode --work-dir /Users/rob/Dropbox/projects/headless-cli --prompt "Say exactly: tmux wait works" --tmux --wait --delete --timeout 120` printed `tmux wait works` and removed the tmux session