### PR TITLE
feat: add Antigravity CLI harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TBD
 
+- Added Antigravity CLI (`agy`) harness support for one-shot prompts, model selection, read-only sandbox mode, native session aliases, tmux launches, `--tmux --wait`, transcript final-message extraction, setup checks, Docker packaging, and README/config documentation.
 - Changed Claude model overrides to normalize versioned `opus`, `sonnet`, and `haiku` shorthand such as `opus-4.8` or `sonnet-4.5` to Claude Code model IDs before execution.
 - Changed Claude model normalization to also cover `fable` shorthand, mapping `fable-5` to `claude-fable-5`, including major-only versions without a minor component.
 - Changed `--tmux --wait` to identify each run's native transcript without injecting a marker into the executed prompt, using a per-harness strategy: Claude and Gemini pin `--session-id`, Cursor mints and resumes a session id, OpenCode tags the session with a unique title, Pi isolates the run in its own `--session-dir`, and Codex claims the brand-new transcript under a per-(agent, working-directory) launch lock. This keeps transcript identification correct even when multiple headless runs execute concurrently, including in the same working directory. Set `HEADLESS_TMUX_WAIT_FORCE_MARKER=1` to restore the legacy prompt-marker behavior.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ ARG TARGETARCH
 ARG CURSOR_AGENT_VERSION=2026.04.17-787b533
 ARG CURSOR_AGENT_SHA256_AMD64=942b2b583239497715f2390336eb8e2df3673703bd167bd59f7be33a27e15c5a
 ARG CURSOR_AGENT_SHA256_ARM64=985191ffc606da1317e1399f99306481f58643f345ed2252033b011504c780ce
+ARG AGY_RELEASE=1.0.9-6003845613092864
+ARG AGY_SHA512_AMD64=9c09eef905ea34079988908067cb716aaeadf3807ea572403d792c5113533213f98f43159d63679408819869bfe143d8e2789e3fab0f28593ffd04f2a7dcf47b
+ARG AGY_SHA512_ARM64=e0b13d0cc3f1337962d1dff7f03f44b2c44b5e07dd483c9633a00235d7b5c8257c6dc5e084b12281aaa18e1c94aa81602c994ee19b5d2e376bc24d85f569372d
 
 RUN set -eu; \
   case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
@@ -33,6 +36,20 @@ RUN set -eu; \
   && ln -sf /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent \
   && ln -sf /usr/local/bin/cursor-agent /usr/local/bin/agent
 
+RUN set -eu; \
+  case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+    amd64) agy_arch="linux-x64"; agy_file="cli_linux_x64.tar.gz"; agy_sha512="${AGY_SHA512_AMD64}" ;; \
+    arm64) agy_arch="linux-arm"; agy_file="cli_linux_arm64.tar.gz"; agy_sha512="${AGY_SHA512_ARM64}" ;; \
+    *) echo "unsupported Antigravity CLI architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
+  esac; \
+  agy_tarball="/tmp/agy.tar.gz"; \
+  curl "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_RELEASE}/${agy_arch}/${agy_file}" -fsSL -o "${agy_tarball}"; \
+  echo "${agy_sha512}  ${agy_tarball}" | sha512sum -c -; \
+  tar -xzf "${agy_tarball}" -C /tmp antigravity; \
+  install -m 0755 /tmp/antigravity /usr/local/bin/agy; \
+  rm -f "${agy_tarball}" /tmp/antigravity
+
+ENV AGY_CLI_DISABLE_AUTO_UPDATE=true
 ENV PATH="/home/node/.local/bin:/home/node/.cursor/bin:/home/node/.cursor/cli/bin:/headless-home/.local/bin:/headless-home/.cursor/bin:/headless-home/.cursor/cli/bin:/root/.local/bin:/root/.cursor/bin:/root/.cursor/cli/bin:${PATH}"
 
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Headless CLI</h1>
 
 <p align="center">
-  One CLI entrypoint for running Claude, Codex, Cursor, Gemini, Pi, OpenCode, and ACP-compatible agents in headless mode.
+  One CLI entrypoint for running Antigravity, Claude, Codex, Cursor, Gemini, Pi, OpenCode, and ACP-compatible agents in headless mode.
 </p>
 
 <p align="center">
@@ -59,6 +59,7 @@ printf "Review this diff" | headless pi --model claude-opus
 
 # Preview the native backend command.
 headless gemini --prompt "Summarize the codebase" --print-command
+headless antigravity --prompt "Inspect the current worktree" --print-command
 headless --prompt "identity" --print-command --json
 
 # Run an ACP-compatible agent from the registry or a custom ACP server command.
@@ -85,7 +86,7 @@ headless attach --all
 headless --check
 ```
 
-When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`. ACP-compatible agents are explicit-only: use `headless acp --acp-agent ...` or `headless acp --acp-command ...`.
+When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `antigravity`, `cursor`. ACP-compatible agents are explicit-only: use `headless acp --acp-agent ...` or `headless acp --acp-command ...`.
 
 ## Scheduled Jobs
 
@@ -121,6 +122,7 @@ Roles include `orchestrator`, `explorer`, `worker`, and `reviewer`. Team specs a
 
 | Agent | Install | Binary used by Headless |
 | --- | --- | --- |
+| [Antigravity CLI](https://antigravity.google/docs/cli-overview) | Follow Google's [CLI install docs](https://antigravity.google/docs/cli-getting-started); the upstream installer runs a shell script from `antigravity.google` | `agy`, or set `ANTIGRAVITY_CLI_BIN` / `AGY_CLI_BIN` |
 | [Codex](https://developers.openai.com/codex/cli/reference) | `npm install -g @openai/codex` | `codex` |
 | [Claude Code](https://code.claude.com/docs/en/cli-reference) | `npm install -g @anthropic-ai/claude-code` | `claude` |
 | [Cursor](https://cursor.com/docs/cli/headless) | `curl https://cursor.com/install -fsS \| bash` | `agent`, or set `CURSOR_CLI_BIN=cursor-agent` |

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,10 @@ coordination = "session"
 run_status_interval_ms = 5000
 list_waiting_after_ms = 15000
 
+[agents.antigravity]
+# model = "Gemini 3.5 Flash (High)" # Use a name reported by `agy models`.
+# reasoning_effort = "high" # Accepted for config compatibility; execution prints an unsupported warning.
+
 [agents.claude]
 model = "claude-opus-4-6"
 # reasoning_effort = "xhigh"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ printf "Review this diff" | headless pi --model claude-opus
 | Agent | Command shape |
 | --- | --- |
 | `acp` | `headless acp-client -- <acp-server-command>`, selected with `--acp-agent` or `--acp-command` |
-| `antigravity` | `agy -p ... --cwd <workdir> --dangerously-skip-permissions` |
+| `antigravity` | `agy -p ... --dangerously-skip-permissions` |
 | `claude` | `claude -p ... --output-format stream-json --verbose --dangerously-skip-permissions` |
 | `codex` | `codex exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check ...` |
 | `cursor` | `agent -p --trust --force --output-format stream-json --model gpt-5.5-medium ...` |
@@ -137,9 +137,9 @@ Pass `--session <name>` to start or resume a named native session. Headless stor
 headless codex --prompt "Continue the fix" --session bughunt
 ```
 
-Antigravity native `--session` is currently rejected because the documented CLI surface can resume a known conversation id but does not expose a reliable way for Headless to discover and store that id after a first run.
+For Antigravity, Headless stores the native conversation id from `~/.gemini/antigravity-cli/brain/<conversation-id>/transcript.jsonl` after the first successful run and resumes with `agy --conversation <conversation-id>`.
 
-Pass `--tmux` to create a detached interactive session named `headless-<agent>-<pid>`, start the selected agent with the prompt as its initial message, print an attach command, and exit. Pass `--wait` with `--tmux` to wait until the agent's native transcript reports completion, then print the final assistant message. `--wait` identifies this run's transcript without altering the executed prompt, using each harness's native mechanism: Claude and Gemini pin a caller-assigned `--session-id`, Cursor mints and resumes a session id, OpenCode tags the session with a unique title, Pi isolates the run in its own `--session-dir`, and Codex claims the brand-new transcript under a short per-(agent, working-directory) launch lock so concurrent runs in the same directory never pick up each other's transcript. Antigravity tmux launches are supported, but Antigravity `--tmux --wait` is rejected until a stable native transcript path is available. Set `HEADLESS_TMUX_WAIT_FORCE_MARKER=1` to fall back to the legacy behavior of appending a single-line marker comment to the prompt for supported transcript-backed agents. Add `--delete` to kill the tmux session after that final message is captured. Pass `--name <name>` for a stable managed session name. Pass `--session <name>` for start-or-send behavior: if `headless-<agent>-<name>` is active, Headless sends the prompt there; otherwise it starts that named session.
+Pass `--tmux` to create a detached interactive session named `headless-<agent>-<pid>`, start the selected agent with the prompt as its initial message, print an attach command, and exit. Pass `--wait` with `--tmux` to wait until the agent's native transcript reports completion, then print the final assistant message. `--wait` identifies this run's transcript without altering the executed prompt, using each harness's native mechanism: Claude and Gemini pin a caller-assigned `--session-id`, Cursor mints and resumes a session id, OpenCode tags the session with a unique title, Pi isolates the run in its own `--session-dir`, and Antigravity/Codex claim the brand-new native transcript under a short per-(agent, working-directory) launch lock so concurrent runs in the same directory never pick up each other's transcript. Set `HEADLESS_TMUX_WAIT_FORCE_MARKER=1` to fall back to the legacy behavior of appending a single-line marker comment to the prompt for supported transcript-backed agents. Add `--delete` to kill the tmux session after that final message is captured. Pass `--name <name>` for a stable managed session name. Pass `--session <name>` for start-or-send behavior: if `headless-<agent>-<name>` is active, Headless sends the prompt there; otherwise it starts that named session.
 
 ```bash
 headless claude --prompt-file task.md --work-dir /path/to/project --tmux

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,7 @@ printf "Review this diff" | headless pi --model claude-opus
 | Agent | Command shape |
 | --- | --- |
 | `acp` | `headless acp-client -- <acp-server-command>`, selected with `--acp-agent` or `--acp-command` |
+| `antigravity` | `agy -p ... --cwd <workdir> --dangerously-skip-permissions` |
 | `claude` | `claude -p ... --output-format stream-json --verbose --dangerously-skip-permissions` |
 | `codex` | `codex exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check ...` |
 | `cursor` | `agent -p --trust --force --output-format stream-json --model gpt-5.5-medium ...` |
@@ -24,9 +25,9 @@ printf "Review this diff" | headless pi --model claude-opus
 | `opencode` | `opencode run --format json --model openai/gpt-5.4 --dangerously-skip-permissions ...` |
 | `pi` | `pi --no-session --mode json --provider openai-codex --model gpt-5.5 --tools read,bash,edit,write ...` |
 
-When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `cursor`. ACP-compatible agents are explicit-only: use `headless acp --acp-agent ...` or `headless acp --acp-command ...`.
+When no agent is specified, Headless selects the first installed agent in this order: `codex`, `claude`, `pi`, `opencode`, `gemini`, `antigravity`, `cursor`. ACP-compatible agents are explicit-only: use `headless acp --acp-agent ...` or `headless acp --acp-command ...`.
 
-When `--model` is omitted, Headless defaults Codex to `gpt-5.5`, Claude to `claude-opus-4-6`, Cursor to the `gpt-5.5` family with medium effort, Gemini to `gemini-3.1-pro-preview`, OpenCode to `openai/gpt-5.4`, and Pi to `openai-codex/gpt-5.5`.
+When `--model` is omitted, Headless defaults Codex to `gpt-5.5`, Claude to `claude-opus-4-6`, Cursor to the `gpt-5.5` family with medium effort, Gemini to `gemini-3.1-pro-preview`, OpenCode to `openai/gpt-5.4`, and Pi to `openai-codex/gpt-5.5`. Antigravity has no built-in Headless model default; pass one of the names reported by `agy models` with `--model` when you want a per-run override.
 
 ## ACP Agents
 
@@ -58,7 +59,7 @@ Environment equivalents are also supported: `HEADLESS_ACP_AGENT`, `HEADLESS_ACP_
 
 By default, Headless uses each agent's native auto-approve/bypass mode. Pass `--allow read-only` to use each agent's read-only or planning mode where available. Pass `--allow yolo` to request full tool access explicitly.
 
-Pass `--reasoning-effort low|medium|high|xhigh` or `--effort low|medium|high|xhigh` to request a normalized reasoning effort for agents with native support. Claude receives `--effort`, Codex receives `model_reasoning_effort`, Cursor combines the model family and effort into Cursor's model variant string, OpenCode receives `--variant` in one-shot mode, and Pi receives `--thinking`. Docker and Modal inherit the same one-shot command. In tmux mode, Claude, Codex, Cursor, and Pi receive their interactive effort flags. Gemini and OpenCode tmux currently accept the option, leave the command unchanged, and print a warning.
+Pass `--reasoning-effort low|medium|high|xhigh` or `--effort low|medium|high|xhigh` to request a normalized reasoning effort for agents with native support. Claude receives `--effort`, Codex receives `model_reasoning_effort`, Cursor combines the model family and effort into Cursor's model variant string, OpenCode receives `--variant` in one-shot mode, and Pi receives `--thinking`. Docker and Modal inherit the same one-shot command. In tmux mode, Claude, Codex, Cursor, and Pi receive their interactive effort flags. Antigravity, Gemini, and OpenCode tmux currently accept the option, leave the command unchanged, and print a warning.
 
 ## Output Modes
 
@@ -136,7 +137,9 @@ Pass `--session <name>` to start or resume a named native session. Headless stor
 headless codex --prompt "Continue the fix" --session bughunt
 ```
 
-Pass `--tmux` to create a detached interactive session named `headless-<agent>-<pid>`, start the selected agent with the prompt as its initial message, print an attach command, and exit. Pass `--wait` with `--tmux` to wait until the agent's native transcript reports completion, then print the final assistant message. `--wait` identifies this run's transcript without altering the executed prompt, using each harness's native mechanism: Claude and Gemini pin a caller-assigned `--session-id`, Cursor mints and resumes a session id, OpenCode tags the session with a unique title, Pi isolates the run in its own `--session-dir`, and Codex claims the brand-new transcript under a short per-(agent, working-directory) launch lock so concurrent runs in the same directory never pick up each other's transcript. Set `HEADLESS_TMUX_WAIT_FORCE_MARKER=1` to fall back to the legacy behavior of appending a single-line marker comment to the prompt. Add `--delete` to kill the tmux session after that final message is captured. Pass `--name <name>` for a stable managed session name. Pass `--session <name>` for start-or-send behavior: if `headless-<agent>-<name>` is active, Headless sends the prompt there; otherwise it starts that named session.
+Antigravity native `--session` is currently rejected because the documented CLI surface can resume a known conversation id but does not expose a reliable way for Headless to discover and store that id after a first run.
+
+Pass `--tmux` to create a detached interactive session named `headless-<agent>-<pid>`, start the selected agent with the prompt as its initial message, print an attach command, and exit. Pass `--wait` with `--tmux` to wait until the agent's native transcript reports completion, then print the final assistant message. `--wait` identifies this run's transcript without altering the executed prompt, using each harness's native mechanism: Claude and Gemini pin a caller-assigned `--session-id`, Cursor mints and resumes a session id, OpenCode tags the session with a unique title, Pi isolates the run in its own `--session-dir`, and Codex claims the brand-new transcript under a short per-(agent, working-directory) launch lock so concurrent runs in the same directory never pick up each other's transcript. Antigravity tmux launches are supported, but Antigravity `--tmux --wait` is rejected until a stable native transcript path is available. Set `HEADLESS_TMUX_WAIT_FORCE_MARKER=1` to fall back to the legacy behavior of appending a single-line marker comment to the prompt for supported transcript-backed agents. Add `--delete` to kill the tmux session after that final message is captured. Pass `--name <name>` for a stable managed session name. Pass `--session <name>` for start-or-send behavior: if `headless-<agent>-<name>` is active, Headless sends the prompt there; otherwise it starts that named session.
 
 ```bash
 headless claude --prompt-file task.md --work-dir /path/to/project --tmux
@@ -210,7 +213,7 @@ mkdir -p ~/.headless
 cp config.toml.example ~/.headless/config.toml
 ```
 
-Supported general keys under `[general]` are `timeout_seconds`, `default_agent`, `coordination`, `run_status_interval_ms`, and `list_waiting_after_ms`. Supported agent sections are `[agents.claude]`, `[agents.codex]`, `[agents.cursor]`, `[agents.gemini]`, `[agents.opencode]`, and `[agents.pi]`; supported agent keys are `model` and `reasoning_effort`. ACP backend selection is controlled by `--acp-agent`, `--acp-command`, and the ACP environment variables rather than model defaults.
+Supported general keys under `[general]` are `timeout_seconds`, `default_agent`, `coordination`, `run_status_interval_ms`, and `list_waiting_after_ms`. Supported agent sections are `[agents.antigravity]`, `[agents.claude]`, `[agents.codex]`, `[agents.cursor]`, `[agents.gemini]`, `[agents.opencode]`, and `[agents.pi]`; supported agent keys are `model` and `reasoning_effort`. Antigravity passes `model` through to `agy --model`, and accepts `reasoning_effort` for config compatibility but prints an unsupported warning during execution. ACP backend selection is controlled by `--acp-agent`, `--acp-command`, and the ACP environment variables rather than model defaults.
 
 Precedence:
 
@@ -294,6 +297,7 @@ See [orchestration.md](orchestration.md) for `--role`, `--run`, `--node`, `--tea
 
 ## Environment
 
+- `ANTIGRAVITY_CLI_BIN`, `AGY_CLI_BIN`: Antigravity CLI binary override. Defaults to `agy`.
 - `CODEX_MODEL`: Codex model override when `--model` is omitted.
 - `CURSOR_CLI_BIN`: Cursor CLI binary override. Defaults to `agent`.
 - `CURSOR_API_KEY`: passed to Cursor as `--api-key`.

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -174,7 +174,7 @@ function withAntigravityAllow(args: string[], allow: AllowMode | undefined): str
 
 function buildAntigravity(options: BuildOptions, env: Env): BuiltCommand {
   const args = withModel([], options.model);
-  args.push("-p", options.prompt, "--cwd", options.workDir ?? env.PWD ?? process.cwd());
+  args.push("-p", options.prompt);
   args.push(...withAntigravityAllow([], options.allow));
   if (options.sessionMode === "resume" && options.sessionId) {
     args.push("--conversation", options.sessionId);
@@ -638,7 +638,7 @@ export function buildInteractiveAgentCommand(
 // without injecting a marker into the executed prompt. See WaitTier in types.ts
 // for what each tier means and how the interactive builders consume it.
 const waitTiers: Record<AgentName, WaitTier> = {
-  antigravity: "unsupported", // no documented transcript path or caller-assignable transcript id yet
+  antigravity: "claim", // claim the new brain/<conversation>/transcript.jsonl under a launch lock
   claude: "pin", // --session-id <uuid>
   gemini: "pin", // --session-id <uuid>
   cursor: "mint", // create-chat mints an id, then --resume <id>

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -173,7 +173,8 @@ function withAntigravityAllow(args: string[], allow: AllowMode | undefined): str
 }
 
 function buildAntigravity(options: BuildOptions, env: Env): BuiltCommand {
-  const args = ["-p", options.prompt, "--cwd", options.workDir ?? env.PWD ?? process.cwd()];
+  const args = withModel([], options.model);
+  args.push("-p", options.prompt, "--cwd", options.workDir ?? env.PWD ?? process.cwd());
   args.push(...withAntigravityAllow([], options.allow));
   if (options.sessionMode === "resume" && options.sessionId) {
     args.push("--conversation", options.sessionId);
@@ -184,7 +185,7 @@ function buildAntigravity(options: BuildOptions, env: Env): BuiltCommand {
 }
 
 function buildInteractiveAntigravity(options: BuildOptions, env: Env): BuiltCommand {
-  const args = withAntigravityAllow([], options.allow);
+  const args = withAntigravityAllow(withModel([], options.model), options.allow);
   if (options.sessionMode === "resume" && options.sessionId) {
     args.push("--conversation", options.sessionId);
   } else if (options.sessionMode === "resume") {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -14,7 +14,7 @@ import { delimiter, join } from "node:path";
 import { commandFromCustom, resolveAcpCommand } from "./acp.js";
 import { BUILTIN_AGENT_DEFAULTS } from "./config.js";
 
-const agentOrder: AgentName[] = ["acp", "claude", "codex", "cursor", "gemini", "opencode", "pi"];
+const agentOrder: AgentName[] = ["acp", "antigravity", "claude", "codex", "cursor", "gemini", "opencode", "pi"];
 const defaultClaudeModel = BUILTIN_AGENT_DEFAULTS.claude.model;
 const defaultCodexModel = BUILTIN_AGENT_DEFAULTS.codex.model;
 export const DEFAULT_CURSOR_MODEL = BUILTIN_AGENT_DEFAULTS.cursor.model ?? "gpt-5.5";
@@ -159,6 +159,38 @@ function buildAcp(options: BuildOptions, env: Env): BuiltCommand {
     return { command, args, env: commandEnv, stdinText: options.prompt };
   }
   return { command, args, stdinText: options.prompt };
+}
+
+function antigravityCommand(env: Env): string {
+  return env.ANTIGRAVITY_CLI_BIN || env.AGY_CLI_BIN || "agy";
+}
+
+function withAntigravityAllow(args: string[], allow: AllowMode | undefined): string[] {
+  if (allow === "read-only") {
+    return [...args, "--sandbox"];
+  }
+  return allow === "yolo" || allow === undefined ? [...args, "--dangerously-skip-permissions"] : args;
+}
+
+function buildAntigravity(options: BuildOptions, env: Env): BuiltCommand {
+  const args = ["-p", options.prompt, "--cwd", options.workDir ?? env.PWD ?? process.cwd()];
+  args.push(...withAntigravityAllow([], options.allow));
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--conversation", options.sessionId);
+  } else if (options.sessionMode === "resume") {
+    args.push("--continue");
+  }
+  return { command: antigravityCommand(env), args };
+}
+
+function buildInteractiveAntigravity(options: BuildOptions, env: Env): BuiltCommand {
+  const args = withAntigravityAllow([], options.allow);
+  if (options.sessionMode === "resume" && options.sessionId) {
+    args.push("--conversation", options.sessionId);
+  } else if (options.sessionMode === "resume") {
+    args.push("--continue");
+  }
+  return { command: antigravityCommand(env), args };
 }
 
 function buildInteractiveAcp(_options: BuildOptions, env: Env): BuiltCommand {
@@ -488,6 +520,15 @@ const harnesses: Record<AgentName, AgentHarness> = {
     buildCommand: buildAcp,
     buildInteractiveCommand: buildInteractiveAcp,
   },
+  antigravity: {
+    name: "antigravity",
+    promptFileMode: "argument",
+    configRelDir: ".gemini/antigravity-cli",
+    workspaceConfigRelDir: ".agents",
+    seedPaths: [".gemini/antigravity-cli", ".gemini/config"],
+    buildCommand: buildAntigravity,
+    buildInteractiveCommand: buildInteractiveAntigravity,
+  },
   claude: {
     name: "claude",
     promptFileMode: "stdin",
@@ -596,6 +637,7 @@ export function buildInteractiveAgentCommand(
 // without injecting a marker into the executed prompt. See WaitTier in types.ts
 // for what each tier means and how the interactive builders consume it.
 const waitTiers: Record<AgentName, WaitTier> = {
+  antigravity: "unsupported", // no documented transcript path or caller-assignable transcript id yet
   claude: "pin", // --session-id <uuid>
   gemini: "pin", // --session-id <uuid>
   cursor: "mint", // create-chat mints an id, then --resume <id>

--- a/src/check.ts
+++ b/src/check.ts
@@ -51,6 +51,9 @@ export function commandForAgent(agent: AgentName, env: Env): string {
   if (agent === "cursor") {
     return env.CURSOR_CLI_BIN || "agent";
   }
+  if (agent === "antigravity") {
+    return env.ANTIGRAVITY_CLI_BIN || env.AGY_CLI_BIN || "agy";
+  }
   if (agent === "claude") {
     return claudeCommand(env);
   }
@@ -104,6 +107,7 @@ const awsCredentialEnvNames = ["AWS_ACCESS_KEY_ID", "AWS_PROFILE"];
 
 const apiEnvNamesByAgent: Record<AgentName, string[]> = {
   acp: commonProviderApiEnvNames,
+  antigravity: [],
   claude: ["ANTHROPIC_API_KEY"],
   codex: ["CODEX_API_KEY", "OPENAI_API_KEY"],
   cursor: ["CURSOR_API_KEY"],
@@ -114,6 +118,7 @@ const apiEnvNamesByAgent: Record<AgentName, string[]> = {
 
 const oauthEnvNamesByAgent: Record<AgentName, string[]> = {
   acp: [],
+  antigravity: [],
   claude: ["CLAUDE_CODE_OAUTH_TOKEN"],
   codex: [],
   cursor: [],
@@ -124,6 +129,7 @@ const oauthEnvNamesByAgent: Record<AgentName, string[]> = {
 
 const oauthPathsByAgent: Record<AgentName, string[]> = {
   acp: [".config/acp"],
+  antigravity: [],
   claude: [".claude/.credentials.json", ".claude/auth.json"],
   codex: [".codex/auth.json"],
   cursor: [".cursor/cli-config.json"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3142,9 +3142,6 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     const cwd = validateWorkDir(parsed.workDir);
     const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux || parsed.role !== undefined || parsed.runId !== undefined });
     const allow = configuredDefaults.allow ?? roleDefaultAllow(parsed.role);
-    if (parsed.agent === "antigravity" && configuredDefaults.model) {
-      throw new CliError("--model is not supported by antigravity: no documented agy model flag is available");
-    }
     if (parsed.runId && parsed.role === "orchestrator" && allow === "read-only") {
       throw new CliError("--role orchestrator with --run cannot use --allow read-only; it must be able to launch child nodes and update run state");
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2064,7 +2064,7 @@ function createTmuxWaitSnapshot(
     startedAt: new Date().toISOString(),
     strategy,
     transcripts: new Map(
-      resolveLatestNativeTranscripts(agent, workDir, env, {}, 20).map((transcript) => [
+      resolveLatestNativeTranscripts(agent, workDir, env, {}, 20, claimTranscriptOptions(agent)).map((transcript) => [
         tmuxWaitTranscriptIdentity(transcript),
         transcript.kind === "jsonl" ? statSync(transcript.path).size : undefined,
       ]),
@@ -2124,9 +2124,34 @@ function claimedTranscript(
   snapshot: TmuxWaitSnapshot,
 ): ReturnType<typeof resolveLatestNativeTranscripts>[number] | undefined {
   const claimedPath = snapshot.strategy.kind === "claim" ? snapshot.strategy.claimed : undefined;
-  return resolveLatestNativeTranscripts(agent, workDir, env, { startedAt: snapshot.startedAt }, 20).find((candidate) =>
-    claimedPath ? candidate.path === claimedPath : !snapshot.transcripts.has(tmuxWaitTranscriptIdentity(candidate)),
+  if (claimedPath && existsSync(claimedPath)) {
+    return {
+      kind: "jsonl",
+      path: claimedPath,
+      sessionId: claimedNativeIdFromPath(agent, claimedPath),
+      startedAt: snapshot.startedAt,
+      endOffset: statSync(claimedPath).size,
+    };
+  }
+  return resolveLatestNativeTranscripts(agent, workDir, env, { startedAt: snapshot.startedAt }, 20, claimTranscriptOptions(agent)).find((candidate) =>
+    !snapshot.transcripts.has(tmuxWaitTranscriptIdentity(candidate)),
   );
+}
+
+function claimedNativeIdFromPath(agent: AgentName, path: string): string | undefined {
+  if (agent === "antigravity") {
+    const parts = path.split("/");
+    const brainIndex = parts.lastIndexOf("brain");
+    const nativeId = brainIndex >= 0 ? parts[brainIndex + 1] : undefined;
+    return nativeId && /^[A-Za-z0-9_.:-]+$/.test(nativeId) ? nativeId : undefined;
+  }
+  if (agent === "codex") {
+    const name = path.split("/").at(-1)?.replace(/\.jsonl$/, "");
+    if (!name) return undefined;
+    const match = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i.exec(name);
+    return match?.[1] ?? name;
+  }
+  return undefined;
 }
 
 function readTmuxFinalMessage(agent: AgentName, workDir: string, env: Env, snapshot: TmuxWaitSnapshot): string {
@@ -2311,6 +2336,14 @@ function realWorkspaceForLock(workDir: string): string {
   }
 }
 
+function claimLockScope(agent: AgentName, workDir: string): string {
+  return agent === "antigravity" ? "__global_antigravity_brain__" : realWorkspaceForLock(workDir);
+}
+
+function claimTranscriptOptions(agent: AgentName): Parameters<typeof resolveLatestNativeTranscripts>[5] {
+  return agent === "antigravity" ? { antigravityScope: "all" } : {};
+}
+
 // Poll until a transcript that did not exist before launch appears, so the claim
 // tier can lock onto exactly this run's transcript before the launch lock is released.
 async function claimNewTranscriptPath(
@@ -2324,7 +2357,7 @@ async function claimNewTranscriptPath(
   const intervalMs = parseDelayMs(env.HEADLESS_TMUX_WAIT_INTERVAL_MS, 1000);
   const deadline = timeoutSeconds === undefined ? undefined : Date.now() + timeoutSeconds * 1000;
   while (true) {
-    const fresh = resolveLatestNativeTranscripts(agent, workDir, env, { startedAt: snapshot.startedAt }, 20).find(
+    const fresh = resolveLatestNativeTranscripts(agent, workDir, env, { startedAt: snapshot.startedAt }, 20, claimTranscriptOptions(agent)).find(
       (candidate) => !snapshot.transcripts.has(tmuxWaitTranscriptIdentity(candidate)),
     );
     if (fresh) return fresh.path;
@@ -3327,12 +3360,11 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         trustCursorWorkspace(cwd, env);
       }
 
-      // The claim tier holds a per-(agent, workspace) lock only across launch and
-      // the moment a brand-new transcript appears, so concurrent same-workspace
-      // runs can't claim each other's transcript. Released before the long wait.
+      // The claim tier holds a short launch lock until a brand-new transcript
+      // appears, then releases before the long wait.
       const claimLock =
         waitPlan?.strategy.kind === "claim"
-          ? acquireLaunchLock(env, parsed.agent, realWorkspaceForLock(tmuxWaitWorkDir))
+          ? acquireLaunchLock(env, parsed.agent, claimLockScope(parsed.agent, tmuxWaitWorkDir))
           : undefined;
       const waitSnapshot = waitPlan
         ? createTmuxWaitSnapshot(parsed.agent, tmuxWaitWorkDir, env, waitPlan.strategy)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,7 @@ import {
   indexNativeAssistantCompletion,
   nativeTranscriptIncludesText,
   nativeTranscriptKey,
+  resolveLatestNativeTranscript,
   resolveLatestNativeTranscripts,
   resolveNativeTranscript,
   resolveOpencodeTranscriptByTitle,
@@ -1169,6 +1170,7 @@ interface SessionPlan {
   alias: string;
   mode: "new" | "resume";
   nativeId?: string;
+  startedAt?: string;
 }
 
 function validateSessionAlias(alias: string | undefined): string | undefined {
@@ -1185,9 +1187,6 @@ function buildSessionPlan(agent: AgentName, alias: string | undefined, env: Env)
   const validAlias = validateSessionAlias(alias);
   if (!validAlias) {
     return undefined;
-  }
-  if (agent === "antigravity") {
-    throw new CliError("--session is not supported by antigravity: conversation id discovery is not available");
   }
   if (!sessionStorePath(env)) {
     throw new CliError("HOME is required for --session");
@@ -1209,10 +1208,16 @@ async function prepareSessionPlan(
   cwd: string | undefined,
   env: Env,
 ): Promise<SessionPlan | undefined> {
-  if (!plan || plan.mode !== "new" || agent !== "cursor" || plan.nativeId) {
+  if (!plan || plan.mode !== "new") {
     return plan;
   }
-  return { ...plan, nativeId: await mintCursorSessionId(cwd, env) };
+  if (agent === "cursor" && !plan.nativeId) {
+    return { ...plan, nativeId: await mintCursorSessionId(cwd, env) };
+  }
+  if (agent === "antigravity" && !plan.nativeId) {
+    return { ...plan, startedAt: new Date().toISOString() };
+  }
+  return plan;
 }
 
 function applySessionPlan(commandOptions: {
@@ -1248,7 +1253,7 @@ async function persistSessionPlan(
   if (!plan) {
     return;
   }
-  const nativeId = plan.nativeId || (await discoverNativeSessionId(agent, stdout, cwd, env));
+  const nativeId = plan.nativeId || (await discoverNativeSessionId(agent, stdout, cwd, env, plan.startedAt));
   if (!nativeId) {
     throw new CliError(`could not determine ${agent} session id for --session ${plan.alias}`);
   }
@@ -1265,6 +1270,7 @@ async function discoverNativeSessionId(
   stdout: string,
   cwd: string | undefined,
   env: Env,
+  startedAt?: string,
 ): Promise<string> {
   const fromTrace = extractNativeSessionId(agent, stdout);
   if (fromTrace) {
@@ -1272,6 +1278,9 @@ async function discoverNativeSessionId(
   }
   if (agent === "gemini") {
     return await newestGeminiSessionId(cwd, env);
+  }
+  if (agent === "antigravity") {
+    return newestAntigravitySessionId(cwd, env, startedAt);
   }
   if (agent === "opencode") {
     return await newestOpenCodeSessionId(cwd, env);
@@ -1293,6 +1302,10 @@ async function newestGeminiSessionId(cwd: string | undefined, env: Env): Promise
   }
   const matches = [...result.stdout.matchAll(/\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/gi)];
   return matches.at(-1)?.[1] ?? "";
+}
+
+function newestAntigravitySessionId(cwd: string | undefined, env: Env, startedAt: string | undefined): string {
+  return resolveLatestNativeTranscript("antigravity", cwd ?? process.cwd(), env, startedAt ? { startedAt } : {})?.sessionId ?? "";
 }
 
 async function newestOpenCodeSessionId(cwd: string | undefined, env: Env): Promise<string> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -695,7 +695,7 @@ function unsupportedReasoningEffortWarning(
   if (mode === "tmux" && agent === "opencode") {
     return "headless: reasoning effort is not supported by opencode in tmux mode and was ignored\n";
   }
-  if (agent === "gemini") {
+  if (agent === "gemini" || agent === "antigravity") {
     return `headless: reasoning effort is not supported by ${agent} and was ignored\n`;
   }
   return undefined;
@@ -870,7 +870,7 @@ function validateWorkDir(workDir: string | undefined): string | undefined {
   return workDir;
 }
 
-const autoAgentPreference: AgentName[] = ["codex", "claude", "pi", "opencode", "gemini", "cursor"];
+const autoAgentPreference: AgentName[] = ["codex", "claude", "pi", "opencode", "gemini", "antigravity", "cursor"];
 
 function selectDefaultAgent(env: Env, preferredAgent: AgentName | undefined): AgentName {
   if (preferredAgent && commandExists(commandForAgent(preferredAgent, env), env)) {
@@ -1186,6 +1186,9 @@ function buildSessionPlan(agent: AgentName, alias: string | undefined, env: Env)
   if (!validAlias) {
     return undefined;
   }
+  if (agent === "antigravity") {
+    throw new CliError("--session is not supported by antigravity: conversation id discovery is not available");
+  }
   if (!sessionStorePath(env)) {
     throw new CliError("HOME is required for --session");
   }
@@ -1215,6 +1218,7 @@ async function prepareSessionPlan(
 function applySessionPlan(commandOptions: {
   prompt: string;
   promptFile?: string;
+  workDir?: string;
   model?: string;
   allow?: AllowMode;
   reasoningEffort?: ReasoningEffort;
@@ -1478,41 +1482,53 @@ function buildTmuxCommands(
   const sessionName = buildHeadlessTmuxSessionName(agent, customName ?? String(process.pid));
   const startDir = cwd ?? process.cwd();
   const pastePrompt = options.pastePrompt ?? true;
-  const opencodeWakeDelayMs = parseDelayMs(
-    env.HEADLESS_TMUX_OPENCODE_WAKE_DELAY_MS ?? env.HEADLESS_TMUX_OPENCODE_ENTER_DELAY_MS,
-    4000,
-  );
-  const opencodePasteDelayMs = parseDelayMs(env.HEADLESS_TMUX_OPENCODE_PASTE_DELAY_MS, 1000);
-  const opencodeSubmitDelayMs = parseDelayMs(env.HEADLESS_TMUX_OPENCODE_SUBMIT_DELAY_MS, 1000);
-  const opencodePromptBuffer = `${sessionName}-prompt`;
+  const promptInput = tmuxPromptInput(agent, sessionName, prompt, env, pastePrompt);
   return {
     sessionName,
     newSession: {
       command: "tmux",
       args: ["new-session", "-d", "-s", sessionName, "-c", startDir, quoteCommand(command)],
     },
-    postLaunch:
-      agent === "opencode" && pastePrompt
-        ? [
-            {
-              command: { command: "tmux", args: ["send-keys", "-t", sessionName, "Space", "BSpace"] },
-              delayMs: opencodeWakeDelayMs,
-            },
-            {
-              command: { command: "tmux", args: ["set-buffer", "-b", opencodePromptBuffer, prompt] },
-              delayMs: opencodePasteDelayMs,
-            },
-            {
-              command: { command: "tmux", args: ["paste-buffer", "-d", "-b", opencodePromptBuffer, "-t", sessionName] },
-              delayMs: 0,
-            },
-            {
-              command: { command: "tmux", args: ["send-keys", "-t", sessionName, "Enter"] },
-              delayMs: opencodeSubmitDelayMs,
-            },
-          ]
-        : [],
+    postLaunch: promptInput,
   };
+}
+
+function tmuxPromptInput(
+  agent: AgentName,
+  sessionName: string,
+  prompt: string,
+  env: Env,
+  pastePrompt: boolean,
+): TmuxPostLaunchCommand[] {
+  if (!pastePrompt || (agent !== "opencode" && agent !== "antigravity")) return [];
+
+  const envPrefix = agent === "opencode" ? "OPENCODE" : "ANTIGRAVITY";
+  const wakeDelayMs = parseDelayMs(
+    env[`HEADLESS_TMUX_${envPrefix}_WAKE_DELAY_MS`] ?? env[`HEADLESS_TMUX_${envPrefix}_ENTER_DELAY_MS`],
+    4000,
+  );
+  const pasteDelayMs = parseDelayMs(env[`HEADLESS_TMUX_${envPrefix}_PASTE_DELAY_MS`], 1000);
+  const submitDelayMs = parseDelayMs(env[`HEADLESS_TMUX_${envPrefix}_SUBMIT_DELAY_MS`], 1000);
+  const promptBuffer = `${sessionName}-prompt`;
+
+  return [
+    {
+      command: { command: "tmux", args: ["send-keys", "-t", sessionName, "Space", "BSpace"] },
+      delayMs: wakeDelayMs,
+    },
+    {
+      command: { command: "tmux", args: ["set-buffer", "-b", promptBuffer, prompt] },
+      delayMs: pasteDelayMs,
+    },
+    {
+      command: { command: "tmux", args: ["paste-buffer", "-d", "-b", promptBuffer, "-t", sessionName] },
+      delayMs: 0,
+    },
+    {
+      command: { command: "tmux", args: ["send-keys", "-t", sessionName, "Enter"] },
+      delayMs: submitDelayMs,
+    },
+  ];
 }
 
 function parseDelayMs(value: string | undefined, fallback: number): number {
@@ -2190,6 +2206,9 @@ async function resolveTmuxWaitPlan(
   cwd: string | undefined,
   env: Env,
 ): Promise<{ strategy: WaitResolveStrategy; identity: Partial<BuildOptions>; prompt: string }> {
+  if (waitTierForAgent(agent) === "unsupported") {
+    throw new CliError(`--tmux --wait is not supported by ${agent}: native transcript resolution is not available`);
+  }
   if (isTruthyFlag(env.HEADLESS_TMUX_WAIT_FORCE_MARKER)) {
     return {
       strategy: { kind: "marker", marker: tmuxWaitMarker(sessionName) },
@@ -2216,6 +2235,8 @@ async function resolveTmuxWaitPlan(
     }
     case "claim":
       return { strategy: { kind: "claim" }, identity: {}, prompt: composedPrompt };
+    case "unsupported":
+      throw new CliError(`--tmux --wait is not supported by ${agent}: native transcript resolution is not available`);
   }
 }
 
@@ -2532,6 +2553,7 @@ async function executeStoredNode(
       applySessionPlan(
         {
           prompt,
+          workDir: node.workDir,
           model: defaults.model,
           allow,
           reasoningEffort: defaults.reasoningEffort,
@@ -3120,6 +3142,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     const cwd = validateWorkDir(parsed.workDir);
     const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux || parsed.role !== undefined || parsed.runId !== undefined });
     const allow = configuredDefaults.allow ?? roleDefaultAllow(parsed.role);
+    if (parsed.agent === "antigravity" && configuredDefaults.model) {
+      throw new CliError("--model is not supported by antigravity: no documented agy model flag is available");
+    }
     if (parsed.runId && parsed.role === "orchestrator" && allow === "read-only") {
       throw new CliError("--role orchestrator with --run cannot use --allow read-only; it must be able to launch child nodes and update run state");
     }
@@ -3394,6 +3419,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       applySessionPlan({
         prompt: composedPrompt,
         promptFile: parsed.role || parsed.runId ? undefined : prompt.promptFile,
+        workDir: cwd ?? process.cwd(),
         model: configuredDefaults.model,
         allow,
         reasoningEffort: configuredDefaults.reasoningEffort,

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ export interface HeadlessConfig {
 
 export const BUILTIN_AGENT_DEFAULTS: Record<AgentName, AgentDefaults> = {
   acp: {},
+  antigravity: {},
   claude: { model: "claude-opus-4-6" },
   codex: { model: "gpt-5.5" },
   cursor: { model: "gpt-5.5", reasoningEffort: "medium" },
@@ -205,6 +206,7 @@ function parseGeneralConfigValue(defaults: GeneralDefaults, key: string, rawValu
 function parseAgentName(value: string, lineNumber: number): AgentName {
   if (
     value === "acp" ||
+    value === "antigravity" ||
     value === "claude" ||
     value === "codex" ||
     value === "cursor" ||
@@ -241,6 +243,7 @@ function parseConfigAllow(value: string, lineNumber: number): AllowMode {
 function parseConfigDefaultAgent(value: string, lineNumber: number): AgentName {
   if (
     value === "claude" ||
+    value === "antigravity" ||
     value === "codex" ||
     value === "cursor" ||
     value === "gemini" ||

--- a/src/native-activity.ts
+++ b/src/native-activity.ts
@@ -248,6 +248,13 @@ function isTerminalDoneEvent(agent: AgentName, event: NativeActivityEvent): bool
   const partReason = normalizeMarkerText(part.reason);
 
   if (payloadType === "task complete") return true;
+  if (
+    agent === "antigravity" &&
+    (rawType === "planner response" || rawType === "assistant response") &&
+    ["done", "completed"].includes(normalizeMarkerText(raw.status))
+  ) {
+    return true;
+  }
   if (rawType === "assistant" && stopReason === "end turn") return true;
   if (event.kind === "assistant" && stopReason === "stop") return true;
   if (partType === "step finish" && partReason === "stop") return true;
@@ -343,6 +350,7 @@ function eventKindFromRecord(rawType: string, role: string, record: Record<strin
 
 function roleFromRawType(agent: AgentName, rawType: string): string {
   if (rawType === "assistant" || rawType === "model" || rawType === "gemini") return "assistant";
+  if (agent === "antigravity" && (rawType === "planner response" || rawType === "assistant response")) return "assistant";
   if (rawType === "user") return "user";
   if (agent === "gemini" && rawType === "system") return "system";
   return "";

--- a/src/native-transcripts.ts
+++ b/src/native-transcripts.ts
@@ -26,6 +26,8 @@ export function resolveNativeTranscript(
   const path =
     agent === "claude"
       ? claudeTranscriptPath(nativeId, workDir, env)
+      : agent === "antigravity"
+        ? antigravityTranscriptPath(nativeId, env)
       : agent === "codex"
         ? findFileContaining(codexSessionsRoot(env), nativeId)
         : agent === "cursor"
@@ -109,6 +111,8 @@ export function resolveLatestNativeTranscripts(
   const paths =
     agent === "claude"
       ? latestFiles(claudeProjectRoot(workspace, env), partial)
+      : agent === "antigravity"
+        ? latestAntigravityTranscripts(workspace, workDir, env, partial)
       : agent === "codex"
         ? latestWorkspaceFiles(codexSessionsRoot(env), workspace, workDir, partial)
         : agent === "cursor"
@@ -217,6 +221,16 @@ function claudeProjectRoot(workspace: string, env: Env): string | undefined {
   return root ? join(root, "projects", claudeProjectKey(workspace)) : undefined;
 }
 
+function antigravityRoot(env: Env): string | undefined {
+  return env.ANTIGRAVITY_HOME ?? env.AGY_HOME ?? (env.HOME ? join(env.HOME, ".gemini", "antigravity-cli") : undefined);
+}
+
+function antigravityTranscriptPath(nativeId: string, env: Env): string | undefined {
+  if (!/^[A-Za-z0-9_.:-]+$/.test(nativeId)) return undefined;
+  const root = antigravityRoot(env);
+  return root ? join(root, "brain", nativeId, "transcript.jsonl") : undefined;
+}
+
 function codexSessionsRoot(env: Env): string | undefined {
   return env.CODEX_HOME ? join(env.CODEX_HOME, "sessions") : env.HOME ? join(env.HOME, ".codex", "sessions") : undefined;
 }
@@ -312,6 +326,29 @@ function latestGeminiTranscripts(
   if (!root) return [];
   const projectSlot = geminiProjectSlot(root, workspace);
   return projectSlot ? latestFiles(join(root, "tmp", projectSlot, "chats"), partial) : [];
+}
+
+function latestAntigravityTranscripts(
+  workspace: string,
+  workDir: string | undefined,
+  env: Env,
+  partial: Partial<NativeTranscript>,
+): string[] {
+  const root = antigravityRoot(env);
+  const brainRoot = root ? join(root, "brain") : undefined;
+  if (!brainRoot || !existsSync(brainRoot)) return [];
+  const startedAtMs = partial.startedAt ? Date.parse(partial.startedAt) : Number.NaN;
+  const candidates = readdirSync(brainRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(brainRoot, entry.name, "transcript.jsonl"))
+    .filter((path) => {
+      if (!existsSync(path)) return false;
+      const stat = statSync(path);
+      return !Number.isFinite(startedAtMs) || stat.mtimeMs >= startedAtMs;
+    })
+    .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs || right.localeCompare(left));
+  const needles = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
+  return candidates.filter((path) => fileHasWorkspaceCwd(path, needles));
 }
 
 function latestOpenCodeTranscripts(
@@ -452,6 +489,10 @@ function asString(value: unknown): string {
 }
 
 function nativeIdFromPath(agent: AgentName, path: string): string | undefined {
+  if (agent === "antigravity") {
+    const nativeId = path.split("/").at(-2);
+    return nativeId && /^[A-Za-z0-9_.:-]+$/.test(nativeId) ? nativeId : undefined;
+  }
   const name = path.split("/").at(-1)?.replace(/\.jsonl$/, "");
   if (!name) return undefined;
   if (agent === "codex") {

--- a/src/native-transcripts.ts
+++ b/src/native-transcripts.ts
@@ -14,6 +14,10 @@ export interface NativeAssistantCompletion {
   path: string;
 }
 
+interface ResolveLatestOptions {
+  antigravityScope?: "workspace" | "all";
+}
+
 export function resolveNativeTranscript(
   agent: AgentName,
   nativeId: string | undefined,
@@ -101,6 +105,7 @@ export function resolveLatestNativeTranscripts(
   env: Env,
   partial: Partial<NativeTranscript> = {},
   limit = 20,
+  options: ResolveLatestOptions = {},
 ): NativeTranscript[] {
   const workspace = realWorkspace(workDir);
   if (!workspace) return [];
@@ -112,7 +117,7 @@ export function resolveLatestNativeTranscripts(
     agent === "claude"
       ? latestFiles(claudeProjectRoot(workspace, env), partial)
       : agent === "antigravity"
-        ? latestAntigravityTranscripts(workspace, workDir, env, partial)
+        ? latestAntigravityTranscripts(workspace, workDir, env, partial, options.antigravityScope ?? "workspace")
       : agent === "codex"
         ? latestWorkspaceFiles(codexSessionsRoot(env), workspace, workDir, partial)
         : agent === "cursor"
@@ -228,7 +233,7 @@ function antigravityRoot(env: Env): string | undefined {
 function antigravityTranscriptPath(nativeId: string, env: Env): string | undefined {
   if (!/^[A-Za-z0-9_.:-]+$/.test(nativeId)) return undefined;
   const root = antigravityRoot(env);
-  return root ? join(root, "brain", nativeId, "transcript.jsonl") : undefined;
+  return root ? join(root, "brain", nativeId, ".system_generated", "logs", "transcript.jsonl") : undefined;
 }
 
 function codexSessionsRoot(env: Env): string | undefined {
@@ -333,6 +338,7 @@ function latestAntigravityTranscripts(
   workDir: string | undefined,
   env: Env,
   partial: Partial<NativeTranscript>,
+  scope: "workspace" | "all",
 ): string[] {
   const root = antigravityRoot(env);
   const brainRoot = root ? join(root, "brain") : undefined;
@@ -340,15 +346,46 @@ function latestAntigravityTranscripts(
   const startedAtMs = partial.startedAt ? Date.parse(partial.startedAt) : Number.NaN;
   const candidates = readdirSync(brainRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .map((entry) => join(brainRoot, entry.name, "transcript.jsonl"))
+    .flatMap((entry) => [
+      join(brainRoot, entry.name, ".system_generated", "logs", "transcript.jsonl"),
+      join(brainRoot, entry.name, "transcript.jsonl"),
+    ])
+    .filter((path, index, paths) => paths.indexOf(path) === index)
     .filter((path) => {
       if (!existsSync(path)) return false;
       const stat = statSync(path);
       return !Number.isFinite(startedAtMs) || stat.mtimeMs >= startedAtMs;
     })
     .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs || right.localeCompare(left));
+  if (scope === "all") return candidates;
   const needles = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
-  return candidates.filter((path) => fileHasWorkspaceCwd(path, needles));
+  const mappedIds = antigravityConversationIdsForWorkspace(root, needles);
+  const mapped = candidates.filter((path) => {
+    const nativeId = nativeIdFromPath("antigravity", path);
+    return Boolean(nativeId && mappedIds.includes(nativeId) && fileWorkspaceCwdStatus(path, needles) !== "mismatch");
+  });
+  const fromTranscript = candidates.filter((path) => fileWorkspaceCwdStatus(path, needles) === "match");
+  return uniqueStrings([...mapped, ...fromTranscript]);
+}
+
+function antigravityConversationIdsForWorkspace(root: string | undefined, needles: string[]): string[] {
+  if (!root) return [];
+  const cachePath = join(root, "cache", "last_conversations.json");
+  try {
+    const values = JSON.parse(readFileSync(cachePath, "utf8")) as Record<string, unknown>;
+    return uniqueStrings(
+      Object.entries(values)
+        .filter(([key]) => {
+          if (needles.includes(key)) return true;
+          const realKey = realWorkspace(key);
+          return Boolean(realKey && needles.includes(realKey));
+        })
+        .map(([, value]) => (typeof value === "string" && /^[A-Za-z0-9_.:-]+$/.test(value) ? value : ""))
+        .filter(Boolean),
+    );
+  } catch {
+    return [];
+  }
 }
 
 function latestOpenCodeTranscripts(
@@ -463,19 +500,25 @@ function latestFiles(root: string | undefined, partial: Partial<NativeTranscript
 }
 
 function fileHasWorkspaceCwd(path: string, needles: string[]): boolean {
+  return fileWorkspaceCwdStatus(path, needles) === "match";
+}
+
+function fileWorkspaceCwdStatus(path: string, needles: string[]): "match" | "mismatch" | "unknown" {
+  let sawCwd = false;
   try {
     for (const line of readFileSync(path, "utf8").split(/\r?\n/).slice(0, 40)) {
       if (!line.trim()) continue;
       const record = JSON.parse(line) as Record<string, unknown>;
       const cwd = cwdFromRecord(record);
-      if (cwd && needles.includes(cwd)) return true;
+      if (cwd) sawCwd = true;
+      if (cwd && needles.includes(cwd)) return "match";
       const realCwd = realWorkspace(cwd);
-      if (realCwd && needles.includes(realCwd)) return true;
+      if (realCwd && needles.includes(realCwd)) return "match";
     }
   } catch {
-    return false;
+    return "unknown";
   }
-  return false;
+  return sawCwd ? "mismatch" : "unknown";
 }
 
 function cwdFromRecord(record: Record<string, unknown>): string {
@@ -490,7 +533,9 @@ function asString(value: unknown): string {
 
 function nativeIdFromPath(agent: AgentName, path: string): string | undefined {
   if (agent === "antigravity") {
-    const nativeId = path.split("/").at(-2);
+    const parts = path.split("/");
+    const brainIndex = parts.lastIndexOf("brain");
+    const nativeId = brainIndex >= 0 ? parts[brainIndex + 1] : undefined;
     return nativeId && /^[A-Za-z0-9_.:-]+$/.test(nativeId) ? nativeId : undefined;
   }
   const name = path.split("/").at(-1)?.replace(/\.jsonl$/, "");

--- a/src/output.ts
+++ b/src/output.ts
@@ -249,6 +249,10 @@ function extractGeminiDeltaMessage(values: unknown[]): string {
 }
 
 export function extractFinalMessage(agent: AgentName, stdout: string): string {
+  if (agent === "antigravity") {
+    return stdout.trim();
+  }
+
   const values = parseJsonValues(stdout);
   if (agent === "gemini") {
     const deltaMessage = extractGeminiDeltaMessage(values);

--- a/src/output.ts
+++ b/src/output.ts
@@ -13,6 +13,14 @@ const skippedItemTypes = new Set([
   "function_call",
   "function_call_output",
 ]);
+const antigravityTraceTypes = new Set([
+  "assistant response",
+  "conversation history",
+  "planner response",
+  "session meta",
+  "system message",
+  "user input",
+]);
 
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
@@ -24,6 +32,10 @@ function asArray(value: unknown): unknown[] {
 
 function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function normalizeType(value: unknown): string {
+  return asString(value).trim().toLowerCase().replace(/_/g, " ");
 }
 
 function normalizeRole(value: unknown): string {
@@ -201,6 +213,21 @@ function collectCandidates(value: unknown, agent: AgentName): string[] {
   return candidates;
 }
 
+function isAntigravityTraceValue(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(isAntigravityTraceValue);
+  }
+
+  const record = asRecord(value);
+  if (Object.keys(record).length === 0) return false;
+
+  return (
+    antigravityTraceTypes.has(normalizeType(record.type)) ||
+    Object.hasOwn(record, "step_index") ||
+    Object.hasOwn(record, "created_at")
+  );
+}
+
 function flattenRecords(value: unknown): JsonRecord[] {
   if (Array.isArray(value)) {
     return value.flatMap((item) => flattenRecords(item));
@@ -260,7 +287,8 @@ export function extractFinalMessage(agent: AgentName, stdout: string): string {
   const values = parseJsonValues(stdout);
   if (agent === "antigravity") {
     const candidates = values.flatMap((value) => collectCandidates(value, agent));
-    return candidates.at(-1)?.trim() ?? (values.length === 0 ? stdout.trim() : "");
+    if (candidates.length > 0) return candidates.at(-1)?.trim() ?? "";
+    return values.some(isAntigravityTraceValue) ? "" : stdout.trim();
   }
 
   if (agent === "gemini") {

--- a/src/output.ts
+++ b/src/output.ts
@@ -124,6 +124,14 @@ function candidateFromRecord(record: JsonRecord, agent: AgentName): string {
     if (text) return text;
   }
 
+  if (agent === "antigravity" && (rowType === "planner_response" || rowType === "assistant_response")) {
+    const status = asString(record.status).trim().toLowerCase();
+    if (!status || status === "done" || status === "completed") {
+      const text = joinText(record.content || record.text || record.message);
+      if (text) return text;
+    }
+  }
+
   const message = asRecord(record.message);
   if (Object.keys(message).length > 0) {
     const messageRole = roleFromRecord(message) || roleFromRecord(record);
@@ -249,11 +257,12 @@ function extractGeminiDeltaMessage(values: unknown[]): string {
 }
 
 export function extractFinalMessage(agent: AgentName, stdout: string): string {
+  const values = parseJsonValues(stdout);
   if (agent === "antigravity") {
-    return stdout.trim();
+    const candidates = values.flatMap((value) => collectCandidates(value, agent));
+    return candidates.at(-1)?.trim() ?? (values.length === 0 ? stdout.trim() : "");
   }
 
-  const values = parseJsonValues(stdout);
   if (agent === "gemini") {
     const deltaMessage = extractGeminiDeltaMessage(values);
     if (deltaMessage) return deltaMessage;
@@ -264,6 +273,9 @@ export function extractFinalMessage(agent: AgentName, stdout: string): string {
 }
 
 export function extractNativeSessionId(agent: AgentName, stdout: string): string {
+  if (agent === "antigravity") {
+    return "";
+  }
   const records = parseJsonValues(stdout).flatMap(flattenRecords);
   for (const record of records) {
     if (agent === "codex") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface BuildOptions {
 //  mint  — round-trip to mint a resumable id, then pin it (cursor create-chat)
 //  tag   — unique metadata resolvable later (opencode --title)
 //  dir   — unique per-run session directory (pi --session-dir)
-//  claim — no caller-assignable id; claim the new transcript under a launch lock (codex)
+//  claim — no caller-assignable id; claim the new transcript under a launch lock (antigravity/codex)
 //  unsupported — no reliable native transcript resolution yet
 export type WaitTier = "pin" | "mint" | "tag" | "dir" | "claim" | "unsupported";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type AgentName = "acp" | "claude" | "codex" | "cursor" | "gemini" | "opencode" | "pi";
+export type AgentName = "acp" | "antigravity" | "claude" | "codex" | "cursor" | "gemini" | "opencode" | "pi";
 
 export type PromptFileMode = "argument" | "stdin";
 
@@ -11,6 +11,7 @@ export type Env = Record<string, string | undefined>;
 export interface BuildOptions {
   prompt: string;
   promptFile?: string;
+  workDir?: string;
   model?: string;
   allow?: AllowMode;
   reasoningEffort?: ReasoningEffort;
@@ -31,7 +32,8 @@ export interface BuildOptions {
 //  tag   — unique metadata resolvable later (opencode --title)
 //  dir   — unique per-run session directory (pi --session-dir)
 //  claim — no caller-assignable id; claim the new transcript under a launch lock (codex)
-export type WaitTier = "pin" | "mint" | "tag" | "dir" | "claim";
+//  unsupported — no reliable native transcript resolution yet
+export type WaitTier = "pin" | "mint" | "tag" | "dir" | "claim" | "unsupported";
 
 export interface BuiltCommand {
   command: string;

--- a/tests/allow.test.ts
+++ b/tests/allow.test.ts
@@ -69,6 +69,11 @@ test("builds read-only commands for supported agents", () => {
     ],
   });
 
+  assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", allow: "read-only", workDir: "/work" }, {}), {
+    command: "agy",
+    args: ["-p", "hello", "--cwd", "/work", "--sandbox"],
+  });
+
   assert.deepEqual(buildAgentCommand("opencode", { prompt: "hello", allow: "read-only" }, {}), {
     command: "opencode",
     args: ["run", "--format", "json", "--model", "openai/gpt-5.4", "hello"],
@@ -136,6 +141,13 @@ test("builds explicit yolo commands for supported agents", () => {
     "--approval-mode",
     "yolo",
   ]);
+  assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", allow: "yolo", workDir: "/work" }, {}).args, [
+    "-p",
+    "hello",
+    "--cwd",
+    "/work",
+    "--dangerously-skip-permissions",
+  ]);
   assert.deepEqual(buildAgentCommand("opencode", { prompt: "hello", allow: "yolo" }, {}).args, [
     "run",
     "--format",
@@ -160,12 +172,12 @@ test("builds explicit yolo commands for supported agents", () => {
 });
 
 test("defaults to yolo commands for supported agents", () => {
-  const agents = ["claude", "codex", "cursor", "gemini", "opencode", "pi"] as const;
+  const agents = ["antigravity", "claude", "codex", "cursor", "gemini", "opencode", "pi"] as const;
 
   for (const agent of agents) {
     assert.deepEqual(
-      buildAgentCommand(agent, { prompt: "hello" }, {}),
-      buildAgentCommand(agent, { prompt: "hello", allow: "yolo" }, {}),
+      buildAgentCommand(agent, { prompt: "hello", workDir: "/work" }, {}),
+      buildAgentCommand(agent, { prompt: "hello", allow: "yolo", workDir: "/work" }, {}),
     );
     assert.deepEqual(
       buildInteractiveAgentCommand(agent, { prompt: "hello" }, {}),
@@ -192,6 +204,10 @@ test("builds read-only interactive commands for tmux mode", () => {
   assert.deepEqual(buildInteractiveAgentCommand("gemini", { prompt: "hello", allow: "read-only" }, {}), {
     command: "gemini",
     args: ["--model", "gemini-3.1-pro-preview", "--skip-trust", "--approval-mode", "plan", "hello"],
+  });
+  assert.deepEqual(buildInteractiveAgentCommand("antigravity", { prompt: "hello", allow: "read-only" }, {}), {
+    command: "agy",
+    args: ["--sandbox"],
   });
   assert.deepEqual(buildInteractiveAgentCommand("opencode", { prompt: "hello", allow: "read-only" }, {}), {
     command: "opencode",
@@ -327,6 +343,16 @@ test("CLI tmux print-command includes allow mode flags", async () => {
 
   assert.equal(code, 0);
   assert.match(stdout.join(""), /codex --sandbox read-only --ask-for-approval never --search --model gpt-5\.5 hello/);
+});
+
+test("CLI Antigravity tmux print-command includes allow mode flags", async () => {
+  const stdout: string[] = [];
+  const code = await runCli(["antigravity", "--tmux", "--allow", "read-only", "--prompt", "hello", "--print-command"], {
+    stdout: (text) => stdout.push(text),
+  });
+
+  assert.equal(code, 0);
+  assert.match(stdout.join(""), /agy --sandbox/);
 });
 
 test("CLI execution passes command environment overrides", async () => {

--- a/tests/allow.test.ts
+++ b/tests/allow.test.ts
@@ -71,7 +71,7 @@ test("builds read-only commands for supported agents", () => {
 
   assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", allow: "read-only", workDir: "/work" }, {}), {
     command: "agy",
-    args: ["-p", "hello", "--cwd", "/work", "--sandbox"],
+    args: ["-p", "hello", "--sandbox"],
   });
 
   assert.deepEqual(buildAgentCommand("opencode", { prompt: "hello", allow: "read-only" }, {}), {
@@ -144,8 +144,6 @@ test("builds explicit yolo commands for supported agents", () => {
   assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", allow: "yolo", workDir: "/work" }, {}).args, [
     "-p",
     "hello",
-    "--cwd",
-    "/work",
     "--dangerously-skip-permissions",
   ]);
   assert.deepEqual(buildAgentCommand("opencode", { prompt: "hello", allow: "yolo" }, {}).args, [

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -19,6 +19,15 @@ test("CLI --check prints installed status and numeric versions for all agents", 
     const binDir = join(dir, "bin");
     mkdirSync(binDir);
     await writeExecutable(
+      join(binDir, "agy"),
+      [
+        "#!/bin/sh",
+        "if [ \"$1\" = \"--version\" ]; then echo 'agy 2.0.1'; exit 0; fi",
+        "exit 1",
+        "",
+      ].join("\n"),
+    );
+    await writeExecutable(
       join(binDir, "codex"),
       [
         "#!/bin/sh",
@@ -65,6 +74,7 @@ test("CLI --check prints installed status and numeric versions for all agents", 
     assert.equal(code, 0);
     assert.match(output, /^\+[-+]+\+$/m);
     assert.match(output, /^\| Agent\s+\| S\s+\| Auth\s+\| Version\s+\| Model\s+\| Effort\s+\|$/m);
+    assert.match(output, /^\| antigravity\s+\| ✓\s+\| -\s+\| 2\.0\.1\s+\| -\s+\| -\s+\|$/m);
     assert.match(output, /^\| codex\s+\| ✓\s+\| -\s+\| 1\.2\.3\s+\| gpt-5\.5\s+\| -\s+\|$/m);
     assert.match(output, /^\| gemini\s+\| ✓\s+\| -\s+\| 0\.39\.1\s+\| gemini-3\.1-pro-preview\s+\| -\s+\|$/m);
     assert.match(output, /^\| opencode\s+\| ✓\s+\| -\s+\| 1\.4\.10\s+\| openai\/gpt-5\.4\s+\| -\s+\|$/m);
@@ -271,6 +281,7 @@ test("CLI --check reports OAuth auth from local seed files", async () => {
   try {
     const home = join(dir, "home");
     mkdirSync(join(home, ".codex"), { recursive: true });
+    mkdirSync(join(home, ".gemini", "antigravity-cli"), { recursive: true });
     writeFileSync(join(home, ".codex", "auth.json"), "{}\n");
     writeFileSync(join(home, ".claude.json"), "{}\n");
 
@@ -282,6 +293,7 @@ test("CLI --check reports OAuth auth from local seed files", async () => {
 
     assert.equal(code, 0);
     assert.match(stdout.join(""), /^\| claude\s+\| ✗\s+\| oauth\s+\| -\s+\| claude-opus-4-6\s+\| -\s+\|$/m);
+    assert.match(stdout.join(""), /^\| antigravity\s+\| ✗\s+\| -\s+\| -\s+\| -\s+\| -\s+\|$/m);
     assert.match(stdout.join(""), /^\| codex\s+\| ✗\s+\| oauth\s+\| -\s+\| gpt-5\.5\s+\| -\s+\|$/m);
   } finally {
     rmSync(dir, { force: true, recursive: true });

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -19,9 +19,16 @@ test("Dockerfile exposes Cursor agent from a non-root path", () => {
   assert.match(dockerfile, /ARG CURSOR_AGENT_VERSION=\d{4}\.\d{2}\.\d{2}-[a-f0-9]+/);
   assert.match(dockerfile, /ARG CURSOR_AGENT_SHA256_AMD64=[a-f0-9]{64}/);
   assert.match(dockerfile, /ARG CURSOR_AGENT_SHA256_ARM64=[a-f0-9]{64}/);
+  assert.match(dockerfile, /ARG AGY_RELEASE=\d+\.\d+\.\d+-\d+/);
+  assert.match(dockerfile, /ARG AGY_SHA512_AMD64=[a-f0-9]{128}/);
+  assert.match(dockerfile, /ARG AGY_SHA512_ARM64=[a-f0-9]{128}/);
   assert.match(dockerfile, /sha256sum -c -/);
   assert.match(dockerfile, /ln -sf \/opt\/cursor-agent\/cursor-agent \/usr\/local\/bin\/cursor-agent/);
   assert.match(dockerfile, /ln -sf \/usr\/local\/bin\/cursor-agent \/usr\/local\/bin\/agent/);
+  assert.match(dockerfile, /storage\.googleapis\.com\/antigravity-public\/antigravity-cli/);
+  assert.match(dockerfile, /sha512sum -c -/);
+  assert.match(dockerfile, /install -m 0755 \/tmp\/antigravity \/usr\/local\/bin\/agy/);
+  assert.match(dockerfile, /ENV AGY_CLI_DISABLE_AUTO_UPDATE=true/);
 });
 
 test("wraps stdin-based agent command in docker with workdir, user, env, and config mounts", () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -35,7 +35,7 @@ async function waitFor(assertion: () => boolean): Promise<void> {
 }
 
 test("lists all supported agents", () => {
-  assert.deepEqual(listAgents(), ["acp", "claude", "codex", "cursor", "gemini", "opencode", "pi"]);
+  assert.deepEqual(listAgents(), ["acp", "antigravity", "claude", "codex", "cursor", "gemini", "opencode", "pi"]);
 });
 
 test("default Docker image reference is accepted by Docker", () => {
@@ -93,6 +93,35 @@ test("builds ACP adapter command with read-only permission mode", () => {
     env: { HEADLESS_ACP_ALLOW: "read-only" },
     stdinText: "hello",
   });
+});
+
+test("builds Antigravity one-shot command with explicit cwd", () => {
+  assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", workDir: "/repo/project" }, {}), {
+    command: "agy",
+    args: ["-p", "hello", "--cwd", "/repo/project", "--dangerously-skip-permissions"],
+  });
+});
+
+test("builds Antigravity command with binary override and sandboxed read-only mode", () => {
+  assert.deepEqual(
+    buildAgentCommand("antigravity", { prompt: "review", allow: "read-only", workDir: "/repo/project" }, {
+      ANTIGRAVITY_CLI_BIN: "/opt/agy",
+    }),
+    {
+      command: "/opt/agy",
+      args: ["-p", "review", "--cwd", "/repo/project", "--sandbox"],
+    },
+  );
+});
+
+test("builds interactive Antigravity resume command", () => {
+  assert.deepEqual(
+    buildInteractiveAgentCommand("antigravity", { prompt: "continue", sessionMode: "resume", sessionId: "conv-123" }, {}),
+    {
+      command: "agy",
+      args: ["--dangerously-skip-permissions", "--conversation", "conv-123"],
+    },
+  );
 });
 
 test("ACP client advertises read-only filesystem capability", () => {
@@ -440,6 +469,7 @@ test("each harness declares its tmux-wait resolution tier", () => {
   assert.equal(waitTierForAgent("opencode"), "tag");
   assert.equal(waitTierForAgent("pi"), "dir");
   assert.equal(waitTierForAgent("codex"), "claim");
+  assert.equal(waitTierForAgent("antigravity"), "unsupported");
 });
 
 test("interactive Claude and Gemini commands pin a new session id when provided", () => {
@@ -664,6 +694,26 @@ test("builds native session commands for supported agents", () => {
   ]);
 });
 
+test("CLI rejects Antigravity session aliases until conversation discovery exists", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["antigravity", "--session", "work", "--prompt", "hello", "--print-command"], {
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /--session is not supported by antigravity/);
+});
+
+test("CLI rejects Antigravity model selection until a model flag is documented", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["antigravity", "--model", "gemini-pro", "--prompt", "hello", "--print-command"], {
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /--model is not supported by antigravity/);
+});
+
 test("builds interactive commands for tmux mode", () => {
   assert.deepEqual(buildInteractiveAgentCommand("codex", { prompt: "hello", model: "gpt-next" }, {}), {
     command: "codex",
@@ -683,6 +733,11 @@ test("builds interactive commands for tmux mode", () => {
   assert.deepEqual(buildInteractiveAgentCommand("opencode", { prompt: "hello", model: "oc-model" }, {}), {
     command: "opencode",
     args: ["--model", "oc-model", "--dangerously-skip-permissions"],
+  });
+
+  assert.deepEqual(buildInteractiveAgentCommand("antigravity", { prompt: "hello" }, {}), {
+    command: "agy",
+    args: ["--dangerously-skip-permissions"],
   });
 
   assert.deepEqual(
@@ -821,6 +876,14 @@ test("exposes config metadata", () => {
     configRelDir: ".config/opencode",
     workspaceConfigRelDir: ".opencode",
     seedPaths: [".config/opencode"],
+  });
+
+  assert.deepEqual(getAgentConfig("antigravity"), {
+    name: "antigravity",
+    promptFileMode: "argument",
+    configRelDir: ".gemini/antigravity-cli",
+    workspaceConfigRelDir: ".agents",
+    seedPaths: [".gemini/antigravity-cli", ".gemini/config"],
   });
 });
 
@@ -2156,6 +2219,7 @@ test("CLI --json does not show a waiting spinner on stderr", async () => {
 
 test("CLI --json streams raw trace output for every provider", async () => {
   const providerBinaries: Record<AgentName, string> = {
+    antigravity: "agy",
     claude: "claude",
     codex: "codex",
     cursor: "agent",
@@ -3821,6 +3885,56 @@ test("CLI --tmux sends Enter after launching opencode prompt", async () => {
   }
 });
 
+test("CLI --tmux sends Enter after launching Antigravity prompt", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "tmux.jsonl");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const tmux = join(binDir, "tmux");
+      await writeFile(
+        tmux,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(tmux, 0o755);
+    });
+
+    const stdout: string[] = [];
+    const code = await runCli(["antigravity", "--prompt", "hello world", "--work-dir", dir, "--tmux"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_CAPTURE: captureFile,
+        HEADLESS_TMUX_ANTIGRAVITY_ENTER_DELAY_MS: "0",
+        HEADLESS_TMUX_ANTIGRAVITY_PASTE_DELAY_MS: "0",
+        HEADLESS_TMUX_ANTIGRAVITY_SUBMIT_DELAY_MS: "0",
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const sessionName = calls[0][3];
+    assert.equal(code, 0);
+    assert.deepEqual(calls, [
+      ["new-session", "-d", "-s", sessionName, "-c", dir, "agy --dangerously-skip-permissions"],
+      ["send-keys", "-t", sessionName, "Space", "BSpace"],
+      ["set-buffer", "-b", `${sessionName}-prompt`, "hello world"],
+      ["paste-buffer", "-d", "-b", `${sessionName}-prompt`, "-t", sessionName],
+      ["send-keys", "-t", sessionName, "Enter"],
+    ]);
+    assert.match(sessionName, /^headless-antigravity-\d+$/);
+    assert.match(stdout.join(""), new RegExp(`tmux attach-session -t ${sessionName}`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --tmux marks Claude workspaces trusted before launch", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
@@ -3947,6 +4061,36 @@ test("CLI --tmux --print-command includes opencode Enter submit command", async 
   assert.match(stdout.join(""), /\ntmux set-buffer -b headless-opencode-\d+-prompt 'hello world'\n/);
   assert.match(stdout.join(""), /\ntmux paste-buffer -d -b headless-opencode-\d+-prompt -t headless-opencode-\d+\n/);
   assert.match(stdout.join(""), /\ntmux send-keys -t headless-opencode-\d+ Enter\n$/);
+});
+
+test("CLI --tmux --print-command includes Antigravity Enter submit command", async () => {
+  const stdout: string[] = [];
+  const code = await runCli(["antigravity", "--prompt", "hello world", "--tmux", "--print-command"], {
+    env: {
+      ...process.env,
+      HEADLESS_TMUX_ANTIGRAVITY_ENTER_DELAY_MS: "0",
+      HEADLESS_TMUX_ANTIGRAVITY_PASTE_DELAY_MS: "0",
+      HEADLESS_TMUX_ANTIGRAVITY_SUBMIT_DELAY_MS: "0",
+    },
+    stdout: (text) => stdout.push(text),
+  });
+
+  assert.equal(code, 0);
+  assert.match(stdout.join(""), /^tmux new-session -d -s headless-antigravity-\d+ -c /);
+  assert.match(stdout.join(""), /\ntmux send-keys -t headless-antigravity-\d+ Space BSpace\n/);
+  assert.match(stdout.join(""), /\ntmux set-buffer -b headless-antigravity-\d+-prompt 'hello world'\n/);
+  assert.match(stdout.join(""), /\ntmux paste-buffer -d -b headless-antigravity-\d+-prompt -t headless-antigravity-\d+\n/);
+  assert.match(stdout.join(""), /\ntmux send-keys -t headless-antigravity-\d+ Enter\n$/);
+});
+
+test("CLI rejects Antigravity tmux wait until native transcript resolution exists", async () => {
+  const stderr: string[] = [];
+  const code = await runCli(["antigravity", "--prompt", "hello", "--tmux", "--wait", "--timeout", "1"], {
+    stderr: (text) => stderr.push(text),
+  });
+
+  assert.equal(code, 2);
+  assert.match(stderr.join(""), /--tmux --wait is not supported by antigravity/);
 });
 
 test("CLI --list lists active headless tmux sessions", async () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1526,7 +1526,10 @@ test("CLI --session stores and resumes Antigravity conversations from brain tran
           "  process.exit(17);",
           "}",
           "const id = args.includes('--conversation') ? args[args.indexOf('--conversation') + 1] : 'agy-session-1';",
-          "const transcript = path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'brain', id, 'transcript.jsonl');",
+          "const cache = path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'cache', 'last_conversations.json');",
+          "const transcript = path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'brain', id, '.system_generated', 'logs', 'transcript.jsonl');",
+          "fs.mkdirSync(path.dirname(cache), { recursive: true });",
+          "fs.writeFileSync(cache, JSON.stringify({ [process.cwd()]: id }));",
           "fs.mkdirSync(path.dirname(transcript), { recursive: true });",
           "fs.writeFileSync(transcript, [",
           "  JSON.stringify({ type: 'SESSION_META', payload: { cwd: process.cwd() } }),",
@@ -4155,8 +4158,19 @@ test("CLI Antigravity --tmux --wait claims its brain transcript without a marker
     const binDir = join(dir, "bin");
     const workDir = join(dir, "work");
     const captureFile = join(dir, "tmux.jsonl");
-    const transcriptPath = join(home, ".gemini", "antigravity-cli", "brain", "agy-wait-1", "transcript.jsonl");
+    const transcriptPath = join(home, ".gemini", "antigravity-cli", "brain", "agy-wait-1", ".system_generated", "logs", "transcript.jsonl");
+    const distractorPath = join(home, ".gemini", "antigravity-cli", "brain", "agy-distractor", ".system_generated", "logs", "transcript.jsonl");
+    const hasSessionMarker = join(dir, "has-session-once");
     mkdirSync(workDir, { recursive: true });
+    mkdirSync(dirname(distractorPath), { recursive: true });
+    writeFileSync(
+      distractorPath,
+      [
+        JSON.stringify({ timestamp: "2026-05-14T09:59:00.000Z", type: "PLANNER_RESPONSE", status: "DONE", content: "old distractor" }),
+        "",
+      ].join("\n"),
+    );
+    utimesSync(distractorPath, new Date("2026-05-14T09:59:00.000Z"), new Date("2026-05-14T09:59:00.000Z"));
     await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
       await mkdir(binDir);
       await writeFile(
@@ -4170,12 +4184,32 @@ test("CLI Antigravity --tmux --wait claims its brain transcript without a marker
           "if (args[0] === 'new-session') {",
           "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
           "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
-          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'SESSION_META', payload: { cwd: args[5] } }),",
-          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'PLANNER_RESPONSE', status: 'DONE', content: 'antigravity wait final' }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'USER_INPUT', status: 'DONE', content: 'hello' }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "  fs.writeFileSync(process.env.HEADLESS_DISTRACTOR_TRANSCRIPT, [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:02.000Z', type: 'PLANNER_RESPONSE', status: 'DONE', content: 'wrong distractor final' }),",
           "    '',",
           "  ].join('\\n'));",
           "}",
-          "if (args[0] === 'has-session') process.exit(0);",
+          "if (args[0] === 'has-session') {",
+          "  if (!fs.existsSync(process.env.HEADLESS_HAS_SESSION_MARKER)) {",
+          "    fs.writeFileSync(process.env.HEADLESS_HAS_SESSION_MARKER, '1');",
+          "    for (let index = 0; index < 25; index += 1) {",
+          "      const newer = path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'brain', `agy-newer-${index}`, '.system_generated', 'logs', 'transcript.jsonl');",
+          "      fs.mkdirSync(path.dirname(newer), { recursive: true });",
+          "      fs.writeFileSync(newer, [",
+          "        JSON.stringify({ timestamp: '2026-05-14T10:00:03.000Z', type: 'PLANNER_RESPONSE', status: 'DONE', content: `newer ${index}` }),",
+          "        '',",
+          "      ].join('\\n'));",
+          "    }",
+          "    fs.appendFileSync(process.env.HEADLESS_TRANSCRIPT, [",
+          "      JSON.stringify({ timestamp: '2026-05-14T10:00:04.000Z', type: 'PLANNER_RESPONSE', status: 'DONE', content: 'antigravity wait final' }),",
+          "      '',",
+          "    ].join('\\n'));",
+          "  }",
+          "  process.exit(0);",
+          "}",
           "",
         ].join("\n"),
       );
@@ -4188,6 +4222,8 @@ test("CLI Antigravity --tmux --wait claims its brain transcript without a marker
         ...process.env,
         HEADLESS_TMUX_CAPTURE: captureFile,
         HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+        HEADLESS_DISTRACTOR_TRANSCRIPT: distractorPath,
+        HEADLESS_HAS_SESSION_MARKER: hasSessionMarker,
         HEADLESS_TRANSCRIPT: transcriptPath,
         HOME: home,
         PATH: `${binDir}:${process.env.PATH ?? ""}`,

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -95,10 +95,10 @@ test("builds ACP adapter command with read-only permission mode", () => {
   });
 });
 
-test("builds Antigravity one-shot command with explicit cwd", () => {
+test("builds Antigravity one-shot command", () => {
   assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", model: "gemini-model", workDir: "/repo/project" }, {}), {
     command: "agy",
-    args: ["--model", "gemini-model", "-p", "hello", "--cwd", "/repo/project", "--dangerously-skip-permissions"],
+    args: ["--model", "gemini-model", "-p", "hello", "--dangerously-skip-permissions"],
   });
 });
 
@@ -109,7 +109,7 @@ test("builds Antigravity command with binary override and sandboxed read-only mo
     }),
     {
       command: "/opt/agy",
-      args: ["-p", "review", "--cwd", "/repo/project", "--sandbox"],
+      args: ["-p", "review", "--sandbox"],
     },
   );
 });
@@ -469,7 +469,7 @@ test("each harness declares its tmux-wait resolution tier", () => {
   assert.equal(waitTierForAgent("opencode"), "tag");
   assert.equal(waitTierForAgent("pi"), "dir");
   assert.equal(waitTierForAgent("codex"), "claim");
-  assert.equal(waitTierForAgent("antigravity"), "unsupported");
+  assert.equal(waitTierForAgent("antigravity"), "claim");
 });
 
 test("interactive Claude and Gemini commands pin a new session id when provided", () => {
@@ -694,16 +694,6 @@ test("builds native session commands for supported agents", () => {
   ]);
 });
 
-test("CLI rejects Antigravity session aliases until conversation discovery exists", async () => {
-  const stderr: string[] = [];
-  const code = await runCli(["antigravity", "--session", "work", "--prompt", "hello", "--print-command"], {
-    stderr: (text) => stderr.push(text),
-  });
-
-  assert.equal(code, 2);
-  assert.match(stderr.join(""), /--session is not supported by antigravity/);
-});
-
 test("CLI passes Antigravity model selection through to agy", async () => {
   const stdout: string[] = [];
   const code = await runCli(["antigravity", "--model", "gemini-pro", "--prompt", "hello", "--print-command"], {
@@ -711,8 +701,7 @@ test("CLI passes Antigravity model selection through to agy", async () => {
   });
 
   assert.equal(code, 0);
-  assert.match(stdout.join(""), /^agy --model gemini-pro -p hello --cwd /);
-  assert.match(stdout.join(""), / --dangerously-skip-permissions\n$/);
+  assert.match(stdout.join(""), /^agy --model gemini-pro -p hello --dangerously-skip-permissions\n$/);
 });
 
 test("builds interactive commands for tmux mode", () => {
@@ -1508,6 +1497,81 @@ test("CLI --session stores the newest Gemini session when list output is oldest 
     assert.equal(stdout.join(""), "gemini done\n");
     const store = JSON.parse(readFileSync(join(home, ".headless", "sessions.json"), "utf8"));
     assert.equal(store.agents.gemini.work.nativeId, "22222222-2222-4222-8222-222222222222");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --session stores and resumes Antigravity conversations from brain transcripts", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const workDir = join(dir, "work");
+    const captureFile = join(dir, "agy-args.jsonl");
+    mkdirSync(home);
+    mkdirSync(workDir);
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      await writeFile(
+        join(binDir, "agy"),
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify(args) + '\\n');",
+          "if (process.cwd() !== process.env.HEADLESS_EXPECT_CWD) {",
+          "  console.error(`unexpected cwd: ${process.cwd()}`);",
+          "  process.exit(17);",
+          "}",
+          "const id = args.includes('--conversation') ? args[args.indexOf('--conversation') + 1] : 'agy-session-1';",
+          "const transcript = path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'brain', id, 'transcript.jsonl');",
+          "fs.mkdirSync(path.dirname(transcript), { recursive: true });",
+          "fs.writeFileSync(transcript, [",
+          "  JSON.stringify({ type: 'SESSION_META', payload: { cwd: process.cwd() } }),",
+          "  JSON.stringify({ type: 'PLANNER_RESPONSE', status: 'DONE', content: args.includes('--conversation') ? 'resumed' : 'started' }),",
+          "  '',",
+          "].join('\\n'));",
+          "console.log(args.includes('--conversation') ? 'resumed' : 'started');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(join(binDir, "agy"), 0o755);
+    });
+
+    const stdout: string[] = [];
+    const env = {
+      ...process.env,
+      HEADLESS_CAPTURE: captureFile,
+      HEADLESS_EXPECT_CWD: realpathSync(workDir),
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    assert.equal(
+      await runCli(["antigravity", "--session", "work", "--prompt", "hello", "--work-dir", workDir], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "started\n");
+    const store = JSON.parse(readFileSync(join(home, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.antigravity.work.nativeId, "agy-session-1");
+
+    stdout.length = 0;
+    assert.equal(
+      await runCli(["antigravity", "--session", "work", "--prompt", "again", "--work-dir", workDir], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "resumed\n");
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(calls[0].includes("--cwd"), false);
+    assert.equal(calls[1].includes("--conversation"), true);
+    assert.equal(calls[1].includes("agy-session-1"), true);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -4084,14 +4148,60 @@ test("CLI --tmux --print-command includes Antigravity Enter submit command", asy
   assert.match(stdout.join(""), /\ntmux send-keys -t headless-antigravity-\d+ Enter\n$/);
 });
 
-test("CLI rejects Antigravity tmux wait until native transcript resolution exists", async () => {
-  const stderr: string[] = [];
-  const code = await runCli(["antigravity", "--prompt", "hello", "--tmux", "--wait", "--timeout", "1"], {
-    stderr: (text) => stderr.push(text),
-  });
+test("CLI Antigravity --tmux --wait claims its brain transcript without a marker", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    const workDir = join(dir, "work");
+    const captureFile = join(dir, "tmux.jsonl");
+    const transcriptPath = join(home, ".gemini", "antigravity-cli", "brain", "agy-wait-1", "transcript.jsonl");
+    mkdirSync(workDir, { recursive: true });
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      await writeFile(
+        join(binDir, "tmux"),
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "fs.appendFileSync(process.env.HEADLESS_TMUX_CAPTURE, JSON.stringify(args) + '\\n');",
+          "if (args[0] === 'new-session') {",
+          "  fs.mkdirSync(path.dirname(process.env.HEADLESS_TRANSCRIPT), { recursive: true });",
+          "  fs.writeFileSync(process.env.HEADLESS_TRANSCRIPT, [",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:00.000Z', type: 'SESSION_META', payload: { cwd: args[5] } }),",
+          "    JSON.stringify({ timestamp: '2026-05-14T10:00:01.000Z', type: 'PLANNER_RESPONSE', status: 'DONE', content: 'antigravity wait final' }),",
+          "    '',",
+          "  ].join('\\n'));",
+          "}",
+          "if (args[0] === 'has-session') process.exit(0);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(join(binDir, "tmux"), 0o755);
+    });
 
-  assert.equal(code, 2);
-  assert.match(stderr.join(""), /--tmux --wait is not supported by antigravity/);
+    const stdout: string[] = [];
+    const code = await runCli(["antigravity", "--prompt", "hello", "--work-dir", workDir, "--tmux", "--wait", "--timeout", "2"], {
+      env: {
+        ...process.env,
+        HEADLESS_TMUX_CAPTURE: captureFile,
+        HEADLESS_TMUX_WAIT_INTERVAL_MS: "10",
+        HEADLESS_TRANSCRIPT: transcriptPath,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: (text) => stdout.push(text),
+    });
+
+    const launchCommand = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line))[0][6];
+    assert.equal(code, 0);
+    assert.equal(stdout.join(""), "antigravity wait final\n");
+    assert.doesNotMatch(launchCommand, /headless-tmux-wait/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
 });
 
 test("CLI --list lists active headless tmux sessions", async () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -96,9 +96,9 @@ test("builds ACP adapter command with read-only permission mode", () => {
 });
 
 test("builds Antigravity one-shot command with explicit cwd", () => {
-  assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", workDir: "/repo/project" }, {}), {
+  assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", model: "gemini-model", workDir: "/repo/project" }, {}), {
     command: "agy",
-    args: ["-p", "hello", "--cwd", "/repo/project", "--dangerously-skip-permissions"],
+    args: ["--model", "gemini-model", "-p", "hello", "--cwd", "/repo/project", "--dangerously-skip-permissions"],
   });
 });
 
@@ -704,14 +704,15 @@ test("CLI rejects Antigravity session aliases until conversation discovery exist
   assert.match(stderr.join(""), /--session is not supported by antigravity/);
 });
 
-test("CLI rejects Antigravity model selection until a model flag is documented", async () => {
-  const stderr: string[] = [];
+test("CLI passes Antigravity model selection through to agy", async () => {
+  const stdout: string[] = [];
   const code = await runCli(["antigravity", "--model", "gemini-pro", "--prompt", "hello", "--print-command"], {
-    stderr: (text) => stderr.push(text),
+    stdout: (text) => stdout.push(text),
   });
 
-  assert.equal(code, 2);
-  assert.match(stderr.join(""), /--model is not supported by antigravity/);
+  assert.equal(code, 0);
+  assert.match(stdout.join(""), /^agy --model gemini-pro -p hello --cwd /);
+  assert.match(stdout.join(""), / --dangerously-skip-permissions\n$/);
 });
 
 test("builds interactive commands for tmux mode", () => {
@@ -735,9 +736,9 @@ test("builds interactive commands for tmux mode", () => {
     args: ["--model", "oc-model", "--dangerously-skip-permissions"],
   });
 
-  assert.deepEqual(buildInteractiveAgentCommand("antigravity", { prompt: "hello" }, {}), {
+  assert.deepEqual(buildInteractiveAgentCommand("antigravity", { prompt: "hello", model: "gemini-model" }, {}), {
     command: "agy",
-    args: ["--dangerously-skip-permissions"],
+    args: ["--model", "gemini-model", "--dangerously-skip-permissions"],
   });
 
   assert.deepEqual(

--- a/tests/native-transcripts.test.ts
+++ b/tests/native-transcripts.test.ts
@@ -20,6 +20,7 @@ test("resolves native transcript files for jsonl-backed agents", () => {
     mkdirSync(workDir, { recursive: true });
     const realWorkDir = realpathSync(workDir);
     const claudePath = join(home, ".claude", "projects", realWorkDir.replace(/\//g, "-"), "claude-session.jsonl");
+    const antigravityPath = join(home, ".gemini", "antigravity-cli", "brain", "antigravity-session", "transcript.jsonl");
     const codexPath = join(home, ".codex", "sessions", "2026", "05", "13", "rollout-2026-05-13T11-12-33-codex-thread.jsonl");
     const cursorPath = join(
       home,
@@ -32,7 +33,7 @@ test("resolves native transcript files for jsonl-backed agents", () => {
     );
     const geminiPath = join(home, ".gemini", "tmp", "gemini-7", "chats", "session-2026-05-13T09-12-gemini-s.jsonl");
     const piPath = join(home, ".pi", "agent", "sessions", "--work--", "pi-session.jsonl");
-    for (const path of [claudePath, codexPath, cursorPath, geminiPath, piPath]) {
+    for (const path of [claudePath, antigravityPath, codexPath, cursorPath, geminiPath, piPath]) {
       mkdirSync(dirname(path), { recursive: true });
       writeFileSync(path, `${JSON.stringify({ type: "assistant", content: "done" })}\n`);
     }
@@ -40,6 +41,7 @@ test("resolves native transcript files for jsonl-backed agents", () => {
     writeFileSync(join(home, ".gemini", "projects.json"), `${JSON.stringify({ [workDir]: "gemini-7" })}\n`);
 
     assert.deepEqual(resolveNativeTranscript("claude", "claude-session", workDir, { HOME: home })?.path, claudePath);
+    assert.deepEqual(resolveNativeTranscript("antigravity", "antigravity-session", workDir, { HOME: home })?.path, antigravityPath);
     assert.deepEqual(resolveNativeTranscript("codex", "codex-thread", workDir, { HOME: home })?.path, codexPath);
     assert.deepEqual(resolveNativeTranscript("cursor", "cursor-session", workDir, { HOME: home })?.path, cursorPath);
     assert.deepEqual(resolveNativeTranscript("gemini", "gemini-session", workDir, { HOME: home })?.path, geminiPath);
@@ -102,6 +104,80 @@ test("resolves the latest native transcript for a workspace", () => {
     utimesSync(otherPath, new Date("2026-05-13T10:02:00.000Z"), new Date("2026-05-13T10:02:00.000Z"));
 
     assert.equal(resolveLatestNativeTranscript("codex", workDir, { HOME: home })?.path, latestPath);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("resolves latest Antigravity brain transcript for a workspace", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const otherWorkDir = join(dir, "other");
+    mkdirSync(workDir, { recursive: true });
+    mkdirSync(otherWorkDir, { recursive: true });
+    const realWorkDir = realpathSync(workDir);
+    const brainRoot = join(home, ".gemini", "antigravity-cli", "brain");
+    const targetPath = join(brainRoot, "conversation-target", "transcript.jsonl");
+    const otherPath = join(brainRoot, "conversation-other", "transcript.jsonl");
+    for (const path of [targetPath, otherPath]) {
+      mkdirSync(dirname(path), { recursive: true });
+    }
+    writeFileSync(
+      targetPath,
+      [
+        JSON.stringify({ type: "SESSION_META", payload: { cwd: realWorkDir } }),
+        JSON.stringify({ type: "ASSISTANT_RESPONSE", status: "COMPLETED", content: "antigravity final" }),
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      otherPath,
+      `${JSON.stringify({ type: "SESSION_META", payload: { cwd: realpathSync(otherWorkDir) } })}\n`,
+    );
+    utimesSync(targetPath, new Date("2026-05-13T10:01:00.000Z"), new Date("2026-05-13T10:01:00.000Z"));
+    utimesSync(otherPath, new Date("2026-05-13T10:02:00.000Z"), new Date("2026-05-13T10:02:00.000Z"));
+
+    const transcript = resolveLatestNativeTranscript("antigravity", workDir, { HOME: home });
+    assert.equal(transcript?.path, targetPath);
+    assert.equal(transcript?.sessionId, "conversation-target");
+    assert.deepEqual(indexNativeAssistantCompletion("antigravity", transcript), {
+      message: "antigravity final",
+      source: "native-transcript",
+      path: targetPath,
+    });
+    const activity = deriveNativeTranscriptActivity("antigravity", transcript, { nowMs: Date.now() });
+    assert.equal(activity?.status, "idle");
+    assert.equal(activity?.reason, "terminal_done");
+    assert.equal(activity?.message, "antigravity final");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Antigravity transcript discovery requires a workspace match", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const otherWorkDir = join(dir, "other");
+    mkdirSync(workDir, { recursive: true });
+    mkdirSync(otherWorkDir, { recursive: true });
+    const otherPath = join(home, ".gemini", "antigravity-cli", "brain", "conversation-other", "transcript.jsonl");
+    mkdirSync(dirname(otherPath), { recursive: true });
+    writeFileSync(
+      otherPath,
+      [
+        JSON.stringify({ type: "SESSION_META", payload: { cwd: realpathSync(otherWorkDir) } }),
+        JSON.stringify({ type: "PLANNER_RESPONSE", status: "DONE", content: "wrong workspace" }),
+        "",
+      ].join("\n"),
+    );
+
+    assert.equal(resolveLatestNativeTranscript("antigravity", workDir, { HOME: home }), undefined);
+    assert.equal(resolveNativeTranscript("antigravity", "../outside", workDir, { HOME: home }), undefined);
+    assert.equal(resolveNativeTranscript("antigravity", join(otherPath), workDir, { HOME: home }), undefined);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/native-transcripts.test.ts
+++ b/tests/native-transcripts.test.ts
@@ -9,6 +9,7 @@ import {
   deriveNativeTranscriptActivity,
   indexNativeAssistantCompletion,
   resolveLatestNativeTranscript,
+  resolveLatestNativeTranscripts,
   resolveNativeTranscript,
 } from "../src/native-transcripts.ts";
 
@@ -20,7 +21,16 @@ test("resolves native transcript files for jsonl-backed agents", () => {
     mkdirSync(workDir, { recursive: true });
     const realWorkDir = realpathSync(workDir);
     const claudePath = join(home, ".claude", "projects", realWorkDir.replace(/\//g, "-"), "claude-session.jsonl");
-    const antigravityPath = join(home, ".gemini", "antigravity-cli", "brain", "antigravity-session", "transcript.jsonl");
+    const antigravityPath = join(
+      home,
+      ".gemini",
+      "antigravity-cli",
+      "brain",
+      "antigravity-session",
+      ".system_generated",
+      "logs",
+      "transcript.jsonl",
+    );
     const codexPath = join(home, ".codex", "sessions", "2026", "05", "13", "rollout-2026-05-13T11-12-33-codex-thread.jsonl");
     const cursorPath = join(
       home,
@@ -119,15 +129,19 @@ test("resolves latest Antigravity brain transcript for a workspace", () => {
     mkdirSync(otherWorkDir, { recursive: true });
     const realWorkDir = realpathSync(workDir);
     const brainRoot = join(home, ".gemini", "antigravity-cli", "brain");
-    const targetPath = join(brainRoot, "conversation-target", "transcript.jsonl");
-    const otherPath = join(brainRoot, "conversation-other", "transcript.jsonl");
+    const targetPath = join(brainRoot, "conversation-target", ".system_generated", "logs", "transcript.jsonl");
+    const otherPath = join(brainRoot, "conversation-other", ".system_generated", "logs", "transcript.jsonl");
     for (const path of [targetPath, otherPath]) {
       mkdirSync(dirname(path), { recursive: true });
     }
+    mkdirSync(join(home, ".gemini", "antigravity-cli", "cache"), { recursive: true });
+    writeFileSync(
+      join(home, ".gemini", "antigravity-cli", "cache", "last_conversations.json"),
+      `${JSON.stringify({ [realWorkDir]: "conversation-target" })}\n`,
+    );
     writeFileSync(
       targetPath,
       [
-        JSON.stringify({ type: "SESSION_META", payload: { cwd: realWorkDir } }),
         JSON.stringify({ type: "ASSISTANT_RESPONSE", status: "COMPLETED", content: "antigravity final" }),
         "",
       ].join("\n"),
@@ -164,7 +178,16 @@ test("Antigravity transcript discovery requires a workspace match", () => {
     const otherWorkDir = join(dir, "other");
     mkdirSync(workDir, { recursive: true });
     mkdirSync(otherWorkDir, { recursive: true });
-    const otherPath = join(home, ".gemini", "antigravity-cli", "brain", "conversation-other", "transcript.jsonl");
+    const otherPath = join(
+      home,
+      ".gemini",
+      "antigravity-cli",
+      "brain",
+      "conversation-other",
+      ".system_generated",
+      "logs",
+      "transcript.jsonl",
+    );
     mkdirSync(dirname(otherPath), { recursive: true });
     writeFileSync(
       otherPath,
@@ -178,6 +201,54 @@ test("Antigravity transcript discovery requires a workspace match", () => {
     assert.equal(resolveLatestNativeTranscript("antigravity", workDir, { HOME: home }), undefined);
     assert.equal(resolveNativeTranscript("antigravity", "../outside", workDir, { HOME: home }), undefined);
     assert.equal(resolveNativeTranscript("antigravity", join(otherPath), workDir, { HOME: home }), undefined);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Antigravity cache priority merges transcript workspace matches and rejects explicit mismatches", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const otherWorkDir = join(dir, "other");
+    mkdirSync(workDir, { recursive: true });
+    mkdirSync(otherWorkDir, { recursive: true });
+    const realWorkDir = realpathSync(workDir);
+    const realOtherWorkDir = realpathSync(otherWorkDir);
+    const root = join(home, ".gemini", "antigravity-cli");
+    const mappedPath = join(root, "brain", "conversation-mapped", ".system_generated", "logs", "transcript.jsonl");
+    const fallbackPath = join(root, "brain", "conversation-fallback", ".system_generated", "logs", "transcript.jsonl");
+    const stalePath = join(root, "brain", "conversation-stale", ".system_generated", "logs", "transcript.jsonl");
+    for (const path of [mappedPath, fallbackPath, stalePath]) {
+      mkdirSync(dirname(path), { recursive: true });
+    }
+    mkdirSync(join(root, "cache"), { recursive: true });
+    writeFileSync(join(root, "cache", "last_conversations.json"), `${JSON.stringify({ [realWorkDir]: "conversation-mapped" })}\n`);
+    writeFileSync(
+      mappedPath,
+      `${JSON.stringify({ type: "PLANNER_RESPONSE", status: "DONE", content: "mapped final" })}\n`,
+    );
+    writeFileSync(
+      fallbackPath,
+      `${JSON.stringify({ type: "SESSION_META", payload: { cwd: realWorkDir } })}\n`,
+    );
+    writeFileSync(
+      stalePath,
+      `${JSON.stringify({ type: "SESSION_META", payload: { cwd: realOtherWorkDir } })}\n`,
+    );
+    utimesSync(mappedPath, new Date("2026-05-13T10:00:00.000Z"), new Date("2026-05-13T10:00:00.000Z"));
+    utimesSync(fallbackPath, new Date("2026-05-13T10:02:00.000Z"), new Date("2026-05-13T10:02:00.000Z"));
+    utimesSync(stalePath, new Date("2026-05-13T10:03:00.000Z"), new Date("2026-05-13T10:03:00.000Z"));
+
+    const transcripts = resolveLatestNativeTranscripts("antigravity", workDir, { HOME: home }, {}, 5);
+    assert.deepEqual(
+      transcripts.map((transcript) => transcript.path),
+      [mappedPath, fallbackPath],
+    );
+
+    writeFileSync(join(root, "cache", "last_conversations.json"), `${JSON.stringify({ [realWorkDir]: "conversation-stale" })}\n`);
+    assert.equal(resolveLatestNativeTranscript("antigravity", workDir, { HOME: home })?.path, fallbackPath);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -83,6 +83,11 @@ test("extracts Antigravity final message from plain text output", () => {
   assert.equal(extractFinalMessage("antigravity", "\nfinal antigravity answer\n"), "final antigravity answer");
 });
 
+test("extracts Antigravity JSON-shaped plain text answers", () => {
+  assert.equal(extractFinalMessage("antigravity", '{"ok":true}\n'), '{"ok":true}');
+  assert.equal(extractFinalMessage("antigravity", "[1,2,3]\n"), "[1,2,3]");
+});
+
 test("extracts Antigravity final message from native transcript records", () => {
   assert.equal(
     extractFinalMessage(

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -79,6 +79,10 @@ test("extracts final Cursor assistant message from stream JSON trace", () => {
   assert.equal(extractFinalMessage("cursor", trace), "final cursor answer");
 });
 
+test("extracts Antigravity final message from plain text output", () => {
+  assert.equal(extractFinalMessage("antigravity", "\nfinal antigravity answer\n"), "final antigravity answer");
+});
+
 test("extracts final Gemini assistant message from JSON object trace", () => {
   const trace = JSON.stringify({
     type: "model",

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -83,6 +83,38 @@ test("extracts Antigravity final message from plain text output", () => {
   assert.equal(extractFinalMessage("antigravity", "\nfinal antigravity answer\n"), "final antigravity answer");
 });
 
+test("extracts Antigravity final message from native transcript records", () => {
+  assert.equal(
+    extractFinalMessage(
+      "antigravity",
+      [
+        JSON.stringify({ type: "USER_INPUT", content: "hello" }),
+        JSON.stringify({ type: "PLANNER_RESPONSE", status: "DONE", content: "final antigravity transcript answer" }),
+        "",
+      ].join("\n"),
+    ),
+    "final antigravity transcript answer",
+  );
+  assert.equal(
+    extractFinalMessage(
+      "antigravity",
+      [
+        JSON.stringify({ type: "USER_INPUT", content: "hello" }),
+        JSON.stringify({ type: "ASSISTANT_RESPONSE", status: "COMPLETED", content: "completed antigravity answer" }),
+        "",
+      ].join("\n"),
+    ),
+    "completed antigravity answer",
+  );
+});
+
+test("does not expose raw Antigravity JSON records without a final message", () => {
+  assert.equal(
+    extractFinalMessage("antigravity", JSON.stringify({ type: "SESSION_META", payload: { cwd: "/secret/workspace" } })),
+    "",
+  );
+});
+
 test("extracts final Gemini assistant message from JSON object trace", () => {
   const trace = JSON.stringify({
     type: "model",


### PR DESCRIPTION
## Summary
- add Antigravity CLI (`agy`) as a first-class Headless harness
- support one-shot prompts, model forwarding, read-only sandbox mode, native session aliases, tmux launch/wait/delete, setup checks, Docker packaging, and docs/config examples
- align transcript discovery with real Antigravity storage under `brain/<id>/.system_generated/logs/transcript.jsonl`, including delayed workspace-cache handling for live tmux waits
- document the feature in the TBD changelog section

## Verification
- `npm run check` (306/306)
- `npm run pack:check`
- focused Antigravity/transcript tests: `node --import tsx --test tests/native-transcripts.test.ts tests/headless.test.ts` (158/158)
- pre-push local integration hook on push: 9 passed, 1 expected skip
- live signed-in `agy` integration:
  - `agy --version && agy models`
  - `node dist/cli.js --check` shows `antigravity ✓` with version `1.0.9`
  - one-shot prompt returned `final live one shot ok`
  - `--session` resume remembered and returned `topaz`
  - `--tmux --wait --delete` returned `final live tmux ok`
