### PR TITLE
feat: combine JSON traces with usage accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+- Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.
+- Clarified accounting provenance with `usageStatus` and `costBasis`: missing usage stays unknown instead of becoming a priced zero, and native-reported costs are distinguished from API list-price estimates calculated from token counts and `models.dev` pricing.
+
 ## 0.4.0 - 2026-06-18
 
 - Added Antigravity CLI (`agy`) harness support for one-shot prompts, model selection, read-only sandbox mode, native session aliases, tmux launches, `--tmux --wait`, transcript final-message extraction, setup checks, Docker packaging, and README/config documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.
 - Clarified accounting provenance with `usageStatus` and `costBasis`: missing usage stays unknown instead of becoming a priced zero, and native-reported costs are distinguished from API list-price estimates calculated from token counts and `models.dev` pricing.
+- Thanks to Anant Garg (@anantgar) for contributing combined JSON traces with usage accounting.
 
 ## 0.4.0 - 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ headless acp --acp-command "atlas alta agent run" --prompt "Fix the failing test
 headless pi --prompt "Summarize this repo" --json
 headless codex --prompt "Fix the failing tests" --debug
 headless codex --prompt "Summarize this repo" --usage
+headless codex --prompt "Summarize this repo" --json --usage
 
 # Use read-only mode for review/planning work.
 headless codex --allow read-only --prompt "Review this repo"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,10 +69,11 @@ Raw mode is the default: Headless prints the extracted final assistant message.
 headless codex --prompt "Fix the failing tests"
 ```
 
-`--json` streams the native agent JSON trace for scripting. It cannot be combined with `--tmux`.
+`--json` streams the native agent JSON trace for scripting. It cannot be combined with `--tmux`. Combine it with `--usage` to keep the native trace unchanged and append one normalized usage object after the native process exits.
 
 ```bash
 headless pi --prompt "Summarize this repo" --json
+headless codex --prompt "Summarize this repo" --json --usage
 ```
 
 When combined with `--print-command`, `--json` prints a single structured object for wrappers that need the selected agent identity without parsing shell text.
@@ -87,10 +88,13 @@ headless --prompt "identity" --print-command --json
 headless codex --prompt "Fix the failing tests" --debug
 ```
 
-`--usage` appends normalized token usage and cost JSON after the final message for one-shot runs, including Docker and Modal runs. It reports input, cache read, cache write, output, reasoning output, total tokens, provider/model metadata, pricing status, and cost when available. Native costs are used when available; fallback pricing comes from `https://models.dev/api.json`. If a model cannot be priced, token counts are still returned with `cost: null`.
+`--usage` appends normalized token usage and cost JSON for one-shot runs, including Docker and Modal runs. In the default output mode it follows the extracted final message. With `--json`, it follows the streamed native trace and does not require Headless to extract a final assistant message.
+
+Usage reports input, cache read, cache write, output, reasoning output, total tokens, provider/model metadata, pricing status, and cost when available. `usageStatus` is `reported` only when Headless recognizes a native usage record; otherwise it is `missing`, with cost left null. `costBasis` distinguishes `native-reported` values from `api-list-price-estimate` values calculated from token counts and `https://models.dev/api.json`. The latter is an API-equivalent list-price estimate, not actual subscription spend. If usage or model pricing is unavailable, available token counts are still returned with `cost: null` and `costBasis: null`.
 
 ```bash
 headless codex --prompt "Summarize this repo" --model gpt-5 --usage
+headless codex --prompt "Summarize this repo" --model gpt-5 --json --usage
 ```
 
 ## Cron Jobs
@@ -277,7 +281,7 @@ Options:
 - `--timeout <s>`: stop one-shot local, Docker, Modal, or `--tmux --wait` execution after the given number of seconds.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.
 - `--debug`: stream the raw agent JSON trace and append the extracted final message.
-- `--usage`: append normalized token usage and cost JSON after the final message.
+- `--usage`: append normalized token usage and cost JSON after the final message or streamed `--json` trace.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
 - `--wait`: with `--tmux`, wait for native transcript completion and print the final message.
 - `--delete`: with `--tmux --wait`, kill the tmux session after completion.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,7 @@ import {
   resolvePiTranscriptInDir,
 } from "./native-transcripts.js";
 import { acquireLaunchLock } from "./launch-lock.js";
+import { compactOversizedTraceLine } from "./relevant-trace.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import { handleCronCommand as handleCronCommandImpl, type CronCommand } from "./cron-commands.js";
 import { runCronDaemon } from "./cron.js";
@@ -1420,6 +1421,7 @@ async function executeCommand(
       let stdoutReceived = false;
       let stdoutEndsWithNewline = false;
       let traceBuffer = "";
+      let traceRowDiscarded = false;
       const relevantTrace: string[] = [];
       let relevantTraceBytes = 0;
       let pinnedIdentityTrace = "";
@@ -1431,19 +1433,25 @@ async function executeCommand(
       let removeParentSignalHandlers = () => {};
       const terminationGraceMs = 1000;
       const maxRelevantTraceBytes = 256 * 1024;
+      const maxCapturedTraceRowBytes = 4 * 1024 * 1024;
       const maxPinnedIdentityBytes = 16 * 1024;
       const relevantTracePattern =
         /"(?:usage|stats|tokens|context_window|num_turns|duration_ms|duration_api_ms|total_cost_usd|thread_id|session_id|sessionId|sessionID)"\s*:|"type"\s*:\s*"(?:thread\.started|turn\.completed|result|step_finish|message_end|agent_message|response_item|item\.completed|assistant|model|text|planner_response|assistant_response)"|"role"\s*:\s*"assistant"/i;
       const codexIdentityPattern = /"type"\s*:\s*"thread\.started"/;
       const appendRelevantTrace = (line: string) => {
-        const trimmed = line.trim();
+        let trimmed = line.trim();
         if (!trimmed || !relevantTracePattern.test(trimmed)) return;
+        let entryBytes = Buffer.byteLength(trimmed, "utf8") + 1;
+        if (entryBytes > maxRelevantTraceBytes) {
+          trimmed = compactOversizedTraceLine(agent, trimmed);
+          if (!trimmed || !relevantTracePattern.test(trimmed)) return;
+          entryBytes = Buffer.byteLength(trimmed, "utf8") + 1;
+        }
+        if (entryBytes > maxRelevantTraceBytes) return;
         const entry = `${trimmed}\n`;
-        const entryBytes = Buffer.byteLength(entry, "utf8");
         if (agent === "codex" && codexIdentityPattern.test(trimmed) && entryBytes <= maxPinnedIdentityBytes) {
           pinnedIdentityTrace = entry;
         }
-        if (entryBytes > maxRelevantTraceBytes) return;
         relevantTrace.push(entry);
         relevantTraceBytes += entryBytes;
         while (relevantTraceBytes > maxRelevantTraceBytes && relevantTrace.length > 1) {
@@ -1453,16 +1461,27 @@ async function executeCommand(
       };
       const captureRelevantChunk = (chunk: string) => {
         if (!options.captureRelevantTrace) return;
-        traceBuffer += chunk;
-        if (Buffer.byteLength(traceBuffer, "utf8") > maxRelevantTraceBytes) {
-          traceBuffer = traceBuffer.slice(-maxRelevantTraceBytes);
+        const fragments = chunk.split("\n");
+        for (let index = 0; index < fragments.length; index += 1) {
+          if (!traceRowDiscarded) {
+            traceBuffer += fragments[index] ?? "";
+            if (Buffer.byteLength(traceBuffer, "utf8") > maxCapturedTraceRowBytes) {
+              traceBuffer = "";
+              traceRowDiscarded = true;
+            }
+          }
+          if (index < fragments.length - 1) {
+            if (!traceRowDiscarded) {
+              const line = traceBuffer.endsWith("\r") ? traceBuffer.slice(0, -1) : traceBuffer;
+              appendRelevantTrace(line);
+            }
+            traceBuffer = "";
+            traceRowDiscarded = false;
+          }
         }
-        const lines = traceBuffer.split(/\r?\n/);
-        traceBuffer = lines.pop() ?? "";
-        for (const line of lines) appendRelevantTrace(line);
       };
       const readRelevantTrace = () => {
-        if (traceBuffer) appendRelevantTrace(traceBuffer);
+        if (traceBuffer && !traceRowDiscarded) appendRelevantTrace(traceBuffer);
         const rollingTrace = relevantTrace.join("");
         return pinnedIdentityTrace && !rollingTrace.includes(pinnedIdentityTrace)
           ? `${pinnedIdentityTrace}${rollingTrace}`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -888,6 +888,9 @@ function selectDefaultAgent(env: Env, preferredAgent: AgentName | undefined): Ag
 interface ExecuteResult {
   code: number;
   stdout: string;
+  usageTrace?: string;
+  stdoutReceived?: boolean;
+  stdoutEndsWithNewline?: boolean;
 }
 
 function commandEnv(baseEnv: Env, command: BuiltCommand): Env {
@@ -1022,6 +1025,7 @@ interface ExecuteCommandOptions {
   stdoutLog?: (text: string) => void;
   stderr?: (text: string) => void;
   timeoutSeconds?: number;
+  captureRelevantTrace?: boolean;
 }
 
 interface WaitingSpinner {
@@ -1413,8 +1417,45 @@ async function executeCommand(
   try {
     return await new Promise<ExecuteResult>((resolve) => {
       let capturedStdout = "";
+      let stdoutReceived = false;
+      let stdoutEndsWithNewline = false;
+      let traceBuffer = "";
+      const relevantTrace: string[] = [];
+      let relevantTraceBytes = 0;
       let settled = false;
       let timeout: NodeJS.Timeout | undefined;
+      let termination: { code: number } | undefined;
+      let forceKill: NodeJS.Timeout | undefined;
+      const maxRelevantTraceBytes = 256 * 1024;
+      const relevantTracePattern =
+        /"(?:usage|stats|tokens|context_window|num_turns|duration_ms|duration_api_ms|total_cost_usd|thread_id|session_id|sessionId|sessionID)"\s*:|"type"\s*:\s*"(?:thread\.started|turn\.completed|result|step_finish|message_end|agent_message|response_item|item\.completed|assistant|model|text)"|"role"\s*:\s*"assistant"/;
+      const appendRelevantTrace = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed || !relevantTracePattern.test(trimmed)) return;
+        const entry = `${trimmed}\n`;
+        const entryBytes = Buffer.byteLength(entry, "utf8");
+        if (entryBytes > maxRelevantTraceBytes) return;
+        relevantTrace.push(entry);
+        relevantTraceBytes += entryBytes;
+        while (relevantTraceBytes > maxRelevantTraceBytes && relevantTrace.length > 1) {
+          const removed = relevantTrace.shift() ?? "";
+          relevantTraceBytes -= Buffer.byteLength(removed, "utf8");
+        }
+      };
+      const captureRelevantChunk = (chunk: string) => {
+        if (!options.captureRelevantTrace) return;
+        traceBuffer += chunk;
+        if (Buffer.byteLength(traceBuffer, "utf8") > maxRelevantTraceBytes) {
+          traceBuffer = traceBuffer.slice(-maxRelevantTraceBytes);
+        }
+        const lines = traceBuffer.split(/\r?\n/);
+        traceBuffer = lines.pop() ?? "";
+        for (const line of lines) appendRelevantTrace(line);
+      };
+      const readRelevantTrace = () => {
+        if (traceBuffer) appendRelevantTrace(traceBuffer);
+        return relevantTrace.join("");
+      };
       const finish = (result: ExecuteResult) => {
         if (settled) {
           return;
@@ -1423,6 +1464,12 @@ async function executeCommand(
         if (timeout) {
           clearTimeout(timeout);
         }
+        if (forceKill) {
+          clearTimeout(forceKill);
+        }
+        result.usageTrace = readRelevantTrace() || undefined;
+        result.stdoutReceived = stdoutReceived;
+        result.stdoutEndsWithNewline = stdoutEndsWithNewline;
         resolve(result);
       };
       const child = spawn(command.command, command.args, {
@@ -1431,14 +1478,22 @@ async function executeCommand(
         stdio,
       });
 
+      const terminateChild = (code: number) => {
+        if (settled || termination) return;
+        termination = { code };
+        child.kill("SIGTERM");
+        forceKill = setTimeout(() => {
+          if (!settled) child.kill("SIGKILL");
+        }, 1000);
+        forceKill.unref();
+      };
+
       if (options.timeoutSeconds !== undefined) {
         timeout = setTimeout(() => {
           const message = `headless: command timed out after ${options.timeoutSeconds}s\n`;
           options.stderr?.(message);
           stderr(message);
-          child.kill("SIGTERM");
-          setTimeout(() => child.kill("SIGKILL"), 1000).unref();
-          finish({ code: 124, stdout: capturedStdout });
+          terminateChild(124);
         }, options.timeoutSeconds * 1000);
       }
       if (command.stdinText !== undefined) {
@@ -1446,6 +1501,9 @@ async function executeCommand(
       }
       child.stdout?.setEncoding("utf8");
       child.stdout?.on("data", (chunk: string) => {
+        stdoutReceived = true;
+        stdoutEndsWithNewline = chunk.endsWith("\n");
+        captureRelevantChunk(chunk);
         if (options.stdoutHandling !== "stream") {
           capturedStdout += chunk;
         }
@@ -1466,14 +1524,14 @@ async function executeCommand(
         const message = `${error.message}\n`;
         options.stderr?.(message);
         stderr(message);
-        finish({ code: 127, stdout: capturedStdout });
+        finish({ code: termination?.code ?? 127, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
       });
       child.on("close", (code, signal) => {
         if (signal) {
-          finish({ code: 1, stdout: capturedStdout });
+          finish({ code: termination?.code ?? 1, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
           return;
         }
-        finish({ code: code ?? 1, stdout: capturedStdout });
+        finish({ code: termination?.code ?? code ?? 1, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
       });
     });
   } finally {
@@ -3503,9 +3561,11 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
 
     const stdoutHandling: StdoutHandling = parsed.json
-      ? parsed.usage || parsed.sessionAlias || parsed.runId
-        ? "capture-and-stream"
-        : "stream"
+      ? parsed.usage
+        ? "stream"
+        : parsed.sessionAlias || parsed.runId
+          ? "capture-and-stream"
+          : "stream"
       : parsed.debug
         ? "capture-and-stream"
         : "capture";
@@ -3571,13 +3631,15 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
             stdoutLog: commandStdoutLog,
             stderr: commandStderr,
             timeoutSeconds: commandTimeoutSeconds,
+            captureRelevantTrace: parsed.json && (parsed.usage || Boolean(parsed.runId) || Boolean(parsed.sessionAlias)),
           });
       if (parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
         appendNodeLog(env, parsed.runId, nodeId, "stdout", result.stdout);
       }
       if (parsed.runId && parsed.role && nodeId) {
-        const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
-        const metrics = extractRunNodeMetrics(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env));
+        const commandTrace = result.stdout || result.usageTrace || "";
+        const finalMessage = extractFinalMessage(parsed.agent, commandTrace);
+        const metrics = extractRunNodeMetrics(parsed.agent, commandTrace, usageContext(parsed.agent, configuredDefaults, env));
         updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined, metrics);
         if (result.code === 0 && parsed.role === "orchestrator" && finalMessage) {
           completeIdleRunNodes(env, parsed.runId, nodeId, finalMessage);
@@ -3590,15 +3652,18 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (!result) {
       throw new CliError("agent execution did not produce a result");
     }
+    const commandTrace = result.stdout || result.usageTrace || "";
     if (result.code === 0 && sessionPlan) {
-      await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);
+      await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env);
     }
     if (parsed.json) {
       if (parsed.usage) {
-        if (result.stdout && !result.stdout.endsWith("\n")) {
+        const stdoutEndsWithNewline = result.stdoutEndsWithNewline ?? result.stdout.endsWith("\n");
+        const stdoutReceived = result.stdoutReceived ?? Boolean(result.stdout);
+        if (stdoutReceived && !stdoutEndsWithNewline) {
           stdout("\n");
         }
-        stdout(await buildUsageOutput(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)));
+        stdout(await buildUsageOutput(parsed.agent, commandTrace, usageContext(parsed.agent, configuredDefaults, env)));
       }
       return result.code;
     }
@@ -3614,7 +3679,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         stdout(`${finalMessage}\n`);
       }
       if (parsed.usage) {
-        stdout(await buildUsageOutput(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)));
+        stdout(await buildUsageOutput(parsed.agent, commandTrace, usageContext(parsed.agent, configuredDefaults, env)));
       }
       return result.code;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,7 @@ import {
   resolvePiTranscriptInDir,
 } from "./native-transcripts.js";
 import { acquireLaunchLock } from "./launch-lock.js";
+import { forceKillWindowsProcessTree } from "./process-tree.js";
 import { compactOversizedTraceLine } from "./relevant-trace.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
 import { handleCronCommand as handleCronCommandImpl, type CronCommand } from "./cron-commands.js";
@@ -1528,14 +1529,13 @@ async function executeCommand(
       };
 
       if (ownsChildProcessGroup) {
-        const parentSignals: NodeJS.Signals[] = ["SIGHUP", "SIGINT", "SIGTERM", "SIGQUIT"];
         const handlers = new Map<NodeJS.Signals, () => void>();
         removeParentSignalHandlers = () => {
           for (const [signal, handler] of handlers) {
             process.off(signal, handler);
           }
         };
-        for (const signal of parentSignals) {
+        for (const signal of ["SIGHUP", "SIGINT", "SIGTERM", "SIGQUIT"] as NodeJS.Signals[]) {
           const handler = () => {
             signalChildTree(signal);
             removeParentSignalHandlers();
@@ -1544,15 +1544,34 @@ async function executeCommand(
           handlers.set(signal, handler);
           process.once(signal, handler);
         }
+        const suspendHandler = () => {
+          signalChildTree("SIGTSTP");
+          process.kill(process.pid, "SIGSTOP");
+        };
+        const continueHandler = () => {
+          signalChildTree("SIGCONT");
+        };
+        handlers.set("SIGTSTP", suspendHandler);
+        handlers.set("SIGCONT", continueHandler);
+        process.on("SIGTSTP", suspendHandler);
+        process.on("SIGCONT", continueHandler);
       }
 
       const terminateChild = (code: number) => {
         if (settled || termination) return;
         termination = { code };
-        signalChildTree("SIGTERM");
+        if (process.platform === "win32") {
+          forceKillWindowsProcessTree(child, terminationGraceMs);
+        } else {
+          signalChildTree("SIGTERM");
+        }
         forceKill = setTimeout(() => {
           if (settled) return;
-          signalChildTree("SIGKILL");
+          if (process.platform === "win32") {
+            forceKillWindowsProcessTree(child, terminationGraceMs);
+          } else {
+            signalChildTree("SIGKILL");
+          }
           forceFinish = setTimeout(() => {
             if (settled) return;
             child.stdout?.destroy();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -244,7 +244,7 @@ function usage(): string {
     "  --timeout <s>        One-shot command timeout in seconds.",
     "  --json               Stream raw agent JSON trace output.",
     "  --debug              Stream raw trace and print extracted final message.",
-    "  --usage              Print final message plus normalized token and cost JSON.",
+    "  --usage              Append normalized token and API-equivalent cost JSON.",
     "  --tmux               Launch an interactive agent in a tmux session.",
     "  --wait               With --tmux, wait for native transcript completion and print the final message.",
     "  --delete             With --tmux --wait, kill the tmux session after completion.",
@@ -927,7 +927,7 @@ function usageContext(agent: AgentName, defaults: InvocationDefaults, env: Env):
 
 async function buildUsageOutput(agent: AgentName, stdout: string, context: { provider?: string; model?: string }): Promise<string> {
   const summary = extractUsageSummary(agent, stdout, context);
-  if (summary.pricingStatus === "native") {
+  if (summary.usageStatus === "missing" || summary.pricingStatus === "native") {
     return `${JSON.stringify({ usage: priceUsageSummary(summary, {}) })}\n`;
   }
   try {
@@ -2521,9 +2521,6 @@ function validateCronAddCliOptions(parsed: ParsedArgs): void {
   if (parsed.docker && parsed.modal) {
     throw new CliError("--docker cannot be used with --modal");
   }
-  if (parsed.usage && parsed.json) {
-    throw new CliError("--usage cannot be used with --json");
-  }
   if (parsed.debug && parsed.json) {
     throw new CliError("--debug cannot be used with --json");
   }
@@ -3113,9 +3110,6 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.wait && parsed.printCommand) {
       throw new CliError("--wait cannot be used with --print-command");
     }
-    if (parsed.usage && parsed.json) {
-      throw new CliError("--usage cannot be used with --json");
-    }
     if (parsed.usage && parsed.tmux) {
       throw new CliError("--usage cannot be used with --tmux");
     }
@@ -3509,7 +3503,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
 
     const stdoutHandling: StdoutHandling = parsed.json
-      ? parsed.sessionAlias || parsed.runId
+      ? parsed.usage || parsed.sessionAlias || parsed.runId
         ? "capture-and-stream"
         : "stream"
       : parsed.debug
@@ -3600,6 +3594,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);
     }
     if (parsed.json) {
+      if (parsed.usage) {
+        if (result.stdout && !result.stdout.endsWith("\n")) {
+          stdout("\n");
+        }
+        stdout(await buildUsageOutput(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)));
+      }
       return result.code;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1433,7 +1433,7 @@ async function executeCommand(
       const maxRelevantTraceBytes = 256 * 1024;
       const maxPinnedIdentityBytes = 16 * 1024;
       const relevantTracePattern =
-        /"(?:usage|stats|tokens|context_window|num_turns|duration_ms|duration_api_ms|total_cost_usd|thread_id|session_id|sessionId|sessionID)"\s*:|"type"\s*:\s*"(?:thread\.started|turn\.completed|result|step_finish|message_end|agent_message|response_item|item\.completed|assistant|model|text)"|"role"\s*:\s*"assistant"/;
+        /"(?:usage|stats|tokens|context_window|num_turns|duration_ms|duration_api_ms|total_cost_usd|thread_id|session_id|sessionId|sessionID)"\s*:|"type"\s*:\s*"(?:thread\.started|turn\.completed|result|step_finish|message_end|agent_message|response_item|item\.completed|assistant|model|text|planner_response|assistant_response)"|"role"\s*:\s*"assistant"/i;
       const codexIdentityPattern = /"type"\s*:\s*"thread\.started"/;
       const appendRelevantTrace = (line: string) => {
         const trimmed = line.trim();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1426,6 +1426,9 @@ async function executeCommand(
       let timeout: NodeJS.Timeout | undefined;
       let termination: { code: number } | undefined;
       let forceKill: NodeJS.Timeout | undefined;
+      let forceFinish: NodeJS.Timeout | undefined;
+      let removeParentSignalHandlers = () => {};
+      const terminationGraceMs = 1000;
       const maxRelevantTraceBytes = 256 * 1024;
       const relevantTracePattern =
         /"(?:usage|stats|tokens|context_window|num_turns|duration_ms|duration_api_ms|total_cost_usd|thread_id|session_id|sessionId|sessionID)"\s*:|"type"\s*:\s*"(?:thread\.started|turn\.completed|result|step_finish|message_end|agent_message|response_item|item\.completed|assistant|model|text)"|"role"\s*:\s*"assistant"/;
@@ -1467,24 +1470,69 @@ async function executeCommand(
         if (forceKill) {
           clearTimeout(forceKill);
         }
+        if (forceFinish) {
+          clearTimeout(forceFinish);
+        }
+        removeParentSignalHandlers();
         result.usageTrace = readRelevantTrace() || undefined;
         result.stdoutReceived = stdoutReceived;
         result.stdoutEndsWithNewline = stdoutEndsWithNewline;
         resolve(result);
       };
+      const ownsChildProcessGroup = process.platform !== "win32" && options.timeoutSeconds !== undefined;
       const child = spawn(command.command, command.args, {
         cwd,
+        detached: ownsChildProcessGroup,
         env: commandEnv(env, command) as NodeJS.ProcessEnv,
         stdio,
       });
 
+      const signalChildTree = (signal: NodeJS.Signals) => {
+        if (ownsChildProcessGroup && child.pid) {
+          try {
+            process.kill(-child.pid, signal);
+            return;
+          } catch {
+            // Fall back to the direct child when the process group has already exited.
+          }
+        }
+        child.kill(signal);
+      };
+
+      if (ownsChildProcessGroup) {
+        const parentSignals: NodeJS.Signals[] = ["SIGHUP", "SIGINT", "SIGTERM", "SIGQUIT"];
+        const handlers = new Map<NodeJS.Signals, () => void>();
+        removeParentSignalHandlers = () => {
+          for (const [signal, handler] of handlers) {
+            process.off(signal, handler);
+          }
+        };
+        for (const signal of parentSignals) {
+          const handler = () => {
+            signalChildTree(signal);
+            removeParentSignalHandlers();
+            process.kill(process.pid, signal);
+          };
+          handlers.set(signal, handler);
+          process.once(signal, handler);
+        }
+      }
+
       const terminateChild = (code: number) => {
         if (settled || termination) return;
         termination = { code };
-        child.kill("SIGTERM");
+        signalChildTree("SIGTERM");
         forceKill = setTimeout(() => {
-          if (!settled) child.kill("SIGKILL");
-        }, 1000);
+          if (settled) return;
+          signalChildTree("SIGKILL");
+          forceFinish = setTimeout(() => {
+            if (settled) return;
+            child.stdout?.destroy();
+            child.stderr?.destroy();
+            finish({ code, stdout: capturedStdout });
+          }, terminationGraceMs);
+          forceFinish.unref();
+        }, terminationGraceMs);
         forceKill.unref();
       };
 
@@ -1527,6 +1575,9 @@ async function executeCommand(
         finish({ code: termination?.code ?? 127, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
       });
       child.on("close", (code, signal) => {
+        if (termination) {
+          signalChildTree("SIGKILL");
+        }
         if (signal) {
           finish({ code: termination?.code ?? 1, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
           return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1422,6 +1422,7 @@ async function executeCommand(
       let traceBuffer = "";
       const relevantTrace: string[] = [];
       let relevantTraceBytes = 0;
+      let pinnedIdentityTrace = "";
       let settled = false;
       let timeout: NodeJS.Timeout | undefined;
       let termination: { code: number } | undefined;
@@ -1430,13 +1431,18 @@ async function executeCommand(
       let removeParentSignalHandlers = () => {};
       const terminationGraceMs = 1000;
       const maxRelevantTraceBytes = 256 * 1024;
+      const maxPinnedIdentityBytes = 16 * 1024;
       const relevantTracePattern =
         /"(?:usage|stats|tokens|context_window|num_turns|duration_ms|duration_api_ms|total_cost_usd|thread_id|session_id|sessionId|sessionID)"\s*:|"type"\s*:\s*"(?:thread\.started|turn\.completed|result|step_finish|message_end|agent_message|response_item|item\.completed|assistant|model|text)"|"role"\s*:\s*"assistant"/;
+      const codexIdentityPattern = /"type"\s*:\s*"thread\.started"/;
       const appendRelevantTrace = (line: string) => {
         const trimmed = line.trim();
         if (!trimmed || !relevantTracePattern.test(trimmed)) return;
         const entry = `${trimmed}\n`;
         const entryBytes = Buffer.byteLength(entry, "utf8");
+        if (agent === "codex" && codexIdentityPattern.test(trimmed) && entryBytes <= maxPinnedIdentityBytes) {
+          pinnedIdentityTrace = entry;
+        }
         if (entryBytes > maxRelevantTraceBytes) return;
         relevantTrace.push(entry);
         relevantTraceBytes += entryBytes;
@@ -1457,7 +1463,10 @@ async function executeCommand(
       };
       const readRelevantTrace = () => {
         if (traceBuffer) appendRelevantTrace(traceBuffer);
-        return relevantTrace.join("");
+        const rollingTrace = relevantTrace.join("");
+        return pinnedIdentityTrace && !rollingTrace.includes(pinnedIdentityTrace)
+          ? `${pinnedIdentityTrace}${rollingTrace}`
+          : rollingTrace;
       };
       const finish = (result: ExecuteResult) => {
         if (settled) {

--- a/src/process-tree.ts
+++ b/src/process-tree.ts
@@ -1,0 +1,58 @@
+import { spawn } from "node:child_process";
+import { win32 } from "node:path";
+
+interface KillableProcess {
+  pid?: number;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+interface TaskkillProcess extends KillableProcess {
+  once(event: "error", listener: (error: Error) => void): this;
+  once(event: "close", listener: (code: number | null) => void): this;
+  unref(): void;
+}
+
+export type TaskkillLauncher = (
+  command: string,
+  args: string[],
+  options: { stdio: "ignore"; windowsHide: true },
+) => TaskkillProcess;
+
+const launchTaskkill: TaskkillLauncher = (command, args, options) => spawn(command, args, options);
+
+export function windowsTaskkillPath(systemRoot = process.env.SystemRoot): string {
+  const root = systemRoot && win32.isAbsolute(systemRoot) ? systemRoot : "C:\\Windows";
+  return win32.join(root, "System32", "taskkill.exe");
+}
+
+export function forceKillWindowsProcessTree(
+  child: KillableProcess,
+  timeoutMs: number,
+  launch: TaskkillLauncher = launchTaskkill,
+  systemRoot = process.env.SystemRoot,
+): void {
+  if (!child.pid) {
+    child.kill("SIGKILL");
+    return;
+  }
+
+  const taskkill = launch(windowsTaskkillPath(systemRoot), ["/pid", String(child.pid), "/T", "/F"], {
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  let finished = false;
+  const finish = (fallback: boolean) => {
+    if (finished) return;
+    finished = true;
+    clearTimeout(timeout);
+    if (fallback) child.kill("SIGKILL");
+  };
+  const timeout = setTimeout(() => {
+    taskkill.kill("SIGKILL");
+    finish(true);
+  }, timeoutMs);
+  timeout.unref();
+  taskkill.once("error", () => finish(true));
+  taskkill.once("close", (code) => finish(code !== 0));
+  taskkill.unref();
+}

--- a/src/relevant-trace.ts
+++ b/src/relevant-trace.ts
@@ -1,0 +1,140 @@
+import type { AgentName } from "./types.js";
+
+type JsonRecord = Record<string, unknown>;
+
+const directNumericFields = [
+  "input_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+  "cached_input_tokens",
+  "output_tokens",
+  "reasoning_output_tokens",
+  "inputTokens",
+  "cacheReadTokens",
+  "cacheWriteTokens",
+  "outputTokens",
+  "input",
+  "cacheRead",
+  "cacheWrite",
+  "cached",
+  "output",
+  "reasoning",
+  "read",
+  "write",
+] as const;
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function copyNumber(record: JsonRecord, field: string): number | undefined {
+  const value = record[field];
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function copyString(record: JsonRecord, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === "string" && Buffer.byteLength(value, "utf8") <= 16 * 1024 ? value : undefined;
+}
+
+function numericProjection(record: JsonRecord): JsonRecord {
+  const projection: JsonRecord = {};
+  for (const field of directNumericFields) {
+    const value = copyNumber(record, field);
+    if (value !== undefined) projection[field] = value;
+  }
+  return projection;
+}
+
+function geminiStatsProjection(record: JsonRecord): JsonRecord {
+  const projection = numericProjection(record);
+  const models = asRecord(record.models);
+  const projectedModels: JsonRecord = {};
+  let modelCount = 0;
+  for (const model in models) {
+    if (!Object.hasOwn(models, model) || Buffer.byteLength(model, "utf8") > 512) continue;
+    const usage = numericProjection(asRecord(models[model]));
+    if (Object.keys(usage).length === 0) continue;
+    projectedModels[model] = usage;
+    modelCount += 1;
+    if (modelCount === 100) break;
+  }
+  if (modelCount > 0) projection.models = projectedModels;
+  return projection;
+}
+
+function opencodePartProjection(record: JsonRecord): JsonRecord {
+  const projection: JsonRecord = {};
+  const cost = copyNumber(record, "cost");
+  if (cost !== undefined) projection.cost = cost;
+  const tokens = numericProjection(asRecord(record.tokens));
+  const cache = numericProjection(asRecord(asRecord(record.tokens).cache));
+  if (Object.keys(cache).length > 0) tokens.cache = cache;
+  if (Object.keys(tokens).length > 0) projection.tokens = tokens;
+  return projection;
+}
+
+function piMessageProjection(record: JsonRecord): JsonRecord {
+  const projection: JsonRecord = {};
+  for (const field of ["model", "provider"]) {
+    const value = copyString(record, field);
+    if (value !== undefined) projection[field] = value;
+  }
+  const sourceUsage = asRecord(record.usage);
+  const usage = numericProjection(sourceUsage);
+  const cost = numericProjection(asRecord(sourceUsage.cost));
+  const total = copyNumber(asRecord(sourceUsage.cost), "total");
+  if (total !== undefined) cost.total = total;
+  if (Object.keys(cost).length > 0) usage.cost = cost;
+  if (Object.keys(usage).length > 0) projection.usage = usage;
+  return projection;
+}
+
+export function compactOversizedTraceLine(agent: AgentName, line: string): string {
+  let record: JsonRecord;
+  try {
+    record = asRecord(JSON.parse(line) as unknown);
+  } catch {
+    return "";
+  }
+  if (Object.keys(record).length === 0) return "";
+
+  const projection: JsonRecord = {};
+  for (const field of [
+    "type",
+    "role",
+    "thread_id",
+    "session_id",
+    "sessionId",
+    "sessionID",
+    "model",
+    "provider",
+  ]) {
+    const value = copyString(record, field);
+    if (value !== undefined) projection[field] = value;
+  }
+  for (const field of ["num_turns", "duration_ms", "duration_api_ms", "total_cost_usd"]) {
+    const value = copyNumber(record, field);
+    if (value !== undefined) projection[field] = value;
+  }
+
+  if (agent === "gemini") {
+    const stats = geminiStatsProjection(asRecord(record.stats));
+    if (Object.keys(stats).length > 0) projection.stats = stats;
+  } else if (agent === "opencode") {
+    const part = opencodePartProjection(asRecord(record.part));
+    if (Object.keys(part).length > 0) projection.part = part;
+  } else if (agent === "pi") {
+    const message = piMessageProjection(asRecord(record.message));
+    if (Object.keys(message).length > 0) projection.message = message;
+  } else {
+    const usage = numericProjection(asRecord(record.usage));
+    if (Object.keys(usage).length > 0) projection.usage = usage;
+  }
+
+  const modelUsage = asRecord(record.modelUsage);
+  const firstModel = Object.keys(modelUsage).find((model) => Buffer.byteLength(model, "utf8") <= 512);
+  if (firstModel) projection.modelUsage = { [firstModel]: {} };
+
+  return Object.keys(projection).length > 0 ? JSON.stringify(projection) : "";
+}

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -57,8 +57,20 @@ function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function asNumber(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return isNonNegativeFiniteNumber(value) ? value : 0;
+}
+
+function asOptionalNumber(value: unknown): number | undefined {
+  return isNonNegativeFiniteNumber(value) ? value : undefined;
+}
+
+function hasNumericField(record: JsonRecord, fields: readonly string[]): boolean {
+  return fields.some((field) => isNonNegativeFiniteNumber(record[field]));
 }
 
 function nonOverlappingInputTokens(inputTokens: number, cacheReadTokens: number, cacheWriteTokens = 0): number {
@@ -201,11 +213,18 @@ function extractProvider(records: JsonRecord[], context: { provider?: string; mo
 }
 
 function extractClaudeUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(item.usage), [
+      "input_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "output_tokens",
+    ]),
+  );
   if (!record) return undefined;
   const usage = asRecord(record.usage);
   const model = extractModel(records, context) ?? firstModelFromUsage(record);
-  const totalCost = asNumber(record.total_cost_usd);
+  const totalCost = asOptionalNumber(record.total_cost_usd);
   return summarizeUsage({
     agent: "claude",
     provider: "anthropic",
@@ -214,15 +233,22 @@ function extractClaudeUsage(records: JsonRecord[], context: { provider?: string;
     cacheReadTokens: asNumber(usage.cache_read_input_tokens),
     cacheWriteTokens: asNumber(usage.cache_creation_input_tokens),
     outputTokens: asNumber(usage.output_tokens),
-    cost: totalCost > 0 ? nativeCost(totalCost) : null,
-    costBasis: totalCost > 0 ? "native-reported" : null,
-    pricingSource: totalCost > 0 ? "native" : null,
-    pricingStatus: totalCost > 0 ? "native" : "missing",
+    cost: totalCost === undefined ? null : nativeCost(totalCost),
+    costBasis: totalCost === undefined ? null : "native-reported",
+    pricingSource: totalCost === undefined ? null : "native",
+    pricingStatus: totalCost === undefined ? "missing" : "native",
   });
 }
 
 function extractCodexUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(item.usage), [
+      "input_tokens",
+      "cached_input_tokens",
+      "output_tokens",
+      "reasoning_output_tokens",
+    ]),
+  );
   if (!record) return undefined;
   const usage = asRecord(record.usage);
   const requested = requestedProviderModel(context);
@@ -239,7 +265,9 @@ function extractCodexUsage(records: JsonRecord[], context: { provider?: string; 
 }
 
 function extractCursorUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(item.usage), ["inputTokens", "cacheReadTokens", "cacheWriteTokens", "outputTokens"]),
+  );
   if (!record) return undefined;
   const usage = asRecord(record.usage);
   return summarizeUsage({
@@ -254,13 +282,20 @@ function extractCursorUsage(records: JsonRecord[], context: { provider?: string;
 }
 
 function extractGeminiUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.stats)).length > 0);
+  const record = latestRecordWith(records, (item) => {
+    const stats = asRecord(item.stats);
+    if (hasNumericField(stats, ["input_tokens", "input", "cached", "output_tokens"])) return true;
+    return Object.values(asRecord(stats.models)).some((value) =>
+      hasNumericField(asRecord(value), ["input_tokens", "cached", "output_tokens"]),
+    );
+  });
   if (!record) return undefined;
   const stats = asRecord(record.stats);
   const models = asRecord(stats.models);
   const modelEntries = Object.entries(models)
-    .map(([model, value]) => {
+    .map(([model, value]): UsagePart | undefined => {
       const usage = asRecord(value);
+      if (!hasNumericField(usage, ["input_tokens", "cached", "output_tokens"])) return undefined;
       const cacheReadTokens = asNumber(usage.cached);
       return {
         provider: "google",
@@ -271,7 +306,7 @@ function extractGeminiUsage(records: JsonRecord[], context: { provider?: string;
         outputTokens: asNumber(usage.output_tokens),
       };
     })
-    .filter((part) => part.inputTokens + part.cacheReadTokens + part.outputTokens > 0);
+    .filter((part): part is UsagePart => part !== undefined);
 
   if (modelEntries.length > 0) {
     return summarizeUsage({
@@ -285,6 +320,7 @@ function extractGeminiUsage(records: JsonRecord[], context: { provider?: string;
     });
   }
 
+  if (!hasNumericField(stats, ["input_tokens", "input", "cached", "output_tokens"])) return undefined;
   const cacheReadTokens = asNumber(stats.cached);
   return summarizeUsage({
     agent: "gemini",
@@ -297,13 +333,17 @@ function extractGeminiUsage(records: JsonRecord[], context: { provider?: string;
 }
 
 function extractOpencodeUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(asRecord(item.part).tokens)).length > 0);
+  const record = latestRecordWith(records, (item) => {
+    const tokens = asRecord(asRecord(item.part).tokens);
+    const cache = asRecord(tokens.cache);
+    return hasNumericField(tokens, ["input", "output", "reasoning"]) || hasNumericField(cache, ["read", "write"]);
+  });
   if (!record) return undefined;
   const part = asRecord(record.part);
   const tokens = asRecord(part.tokens);
   const cache = asRecord(tokens.cache);
   const requested = requestedProviderModel(context);
-  const totalCost = asNumber(part.cost);
+  const totalCost = asOptionalNumber(part.cost);
   return summarizeUsage({
     agent: "opencode",
     provider: requested.provider,
@@ -314,20 +354,22 @@ function extractOpencodeUsage(records: JsonRecord[], context: { provider?: strin
     outputTokens: asNumber(tokens.output),
     reasoningOutputTokens: asNumber(tokens.reasoning),
     reasoningOutputIncludedInOutput: false,
-    cost: totalCost > 0 ? nativeCost(totalCost) : null,
-    costBasis: totalCost > 0 ? "native-reported" : null,
-    pricingSource: totalCost > 0 ? "native" : null,
-    pricingStatus: totalCost > 0 ? "native" : "missing",
+    cost: totalCost === undefined ? null : nativeCost(totalCost),
+    costBasis: totalCost === undefined ? null : "native-reported",
+    pricingSource: totalCost === undefined ? null : "native",
+    pricingStatus: totalCost === undefined ? "missing" : "native",
   });
 }
 
 function extractPiUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(asRecord(item.message).usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(asRecord(item.message).usage), ["input", "cacheRead", "cacheWrite", "output"]),
+  );
   if (!record) return undefined;
   const message = asRecord(record.message);
   const usage = asRecord(message.usage);
   const cost = asRecord(usage.cost);
-  const totalCost = asNumber(cost.total);
+  const totalCost = asOptionalNumber(cost.total);
   return summarizeUsage({
     agent: "pi",
     provider: asString(message.provider).trim() || extractProvider(records, context, "pi"),
@@ -337,17 +379,17 @@ function extractPiUsage(records: JsonRecord[], context: { provider?: string; mod
     cacheWriteTokens: asNumber(usage.cacheWrite),
     outputTokens: asNumber(usage.output),
     cost:
-      totalCost > 0
-        ? nativeCost(totalCost, {
-            input: asNumber(cost.input),
-            cacheRead: asNumber(cost.cacheRead),
-            cacheWrite: asNumber(cost.cacheWrite),
-            output: asNumber(cost.output),
-          })
-        : null,
-    costBasis: totalCost > 0 ? "native-reported" : null,
-    pricingSource: totalCost > 0 ? "native" : null,
-    pricingStatus: totalCost > 0 ? "native" : "missing",
+      totalCost === undefined
+        ? null
+        : nativeCost(totalCost, {
+            input: asOptionalNumber(cost.input),
+            cacheRead: asOptionalNumber(cost.cacheRead),
+            cacheWrite: asOptionalNumber(cost.cacheWrite),
+            output: asOptionalNumber(cost.output),
+          }),
+    costBasis: totalCost === undefined ? null : "native-reported",
+    pricingSource: totalCost === undefined ? null : "native",
+    pricingStatus: totalCost === undefined ? "missing" : "native",
   });
 }
 

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -41,7 +41,9 @@ export interface UsageSummary {
   outputTokens: number;
   reasoningOutputTokens: number;
   totalTokens: number;
+  usageStatus: "reported" | "missing";
   cost: UsageCostBreakdown | null;
+  costBasis: "native-reported" | "api-list-price-estimate" | null;
   pricingSource: "native" | "models.dev" | null;
   pricingStatus: "native" | "priced" | "missing";
   modelBreakdowns?: UsagePart[];
@@ -136,7 +138,9 @@ function summarizeUsage(options: {
   cacheWriteTokens?: number;
   outputTokens: number;
   reasoningOutputTokens?: number;
+  usageStatus?: UsageSummary["usageStatus"];
   cost?: UsageCostBreakdown | null;
+  costBasis?: UsageSummary["costBasis"];
   pricingSource?: UsageSummary["pricingSource"];
   pricingStatus?: UsageSummary["pricingStatus"];
   reasoningOutputIncludedInOutput?: boolean;
@@ -157,7 +161,9 @@ function summarizeUsage(options: {
     outputTokens: options.outputTokens,
     reasoningOutputTokens,
     totalTokens,
+    usageStatus: options.usageStatus ?? "reported",
     cost: options.cost ?? null,
+    costBasis: options.costBasis ?? null,
     pricingSource: options.pricingSource ?? null,
     pricingStatus: options.pricingStatus ?? "missing",
     ...(options.modelBreakdowns ? { modelBreakdowns: options.modelBreakdowns } : {}),
@@ -209,6 +215,7 @@ function extractClaudeUsage(records: JsonRecord[], context: { provider?: string;
     cacheWriteTokens: asNumber(usage.cache_creation_input_tokens),
     outputTokens: asNumber(usage.output_tokens),
     cost: totalCost > 0 ? nativeCost(totalCost) : null,
+    costBasis: totalCost > 0 ? "native-reported" : null,
     pricingSource: totalCost > 0 ? "native" : null,
     pricingStatus: totalCost > 0 ? "native" : "missing",
   });
@@ -308,6 +315,7 @@ function extractOpencodeUsage(records: JsonRecord[], context: { provider?: strin
     reasoningOutputTokens: asNumber(tokens.reasoning),
     reasoningOutputIncludedInOutput: false,
     cost: totalCost > 0 ? nativeCost(totalCost) : null,
+    costBasis: totalCost > 0 ? "native-reported" : null,
     pricingSource: totalCost > 0 ? "native" : null,
     pricingStatus: totalCost > 0 ? "native" : "missing",
   });
@@ -337,6 +345,7 @@ function extractPiUsage(records: JsonRecord[], context: { provider?: string; mod
             output: asNumber(cost.output),
           })
         : null,
+    costBasis: totalCost > 0 ? "native-reported" : null,
     pricingSource: totalCost > 0 ? "native" : null,
     pricingStatus: totalCost > 0 ? "native" : "missing",
   });
@@ -369,6 +378,7 @@ export function extractUsageSummary(
       model: extractModel(records, context),
       inputTokens: 0,
       outputTokens: 0,
+      usageStatus: "missing",
     })
   );
 }
@@ -455,6 +465,9 @@ function priceUsagePart(part: UsagePart, pricingData: PricingData): UsageCostBre
 
 export function priceUsageSummary(summary: UsageSummary, pricingData: PricingData): UsageSummary {
   const { modelBreakdowns: _modelBreakdowns, ...publicSummary } = summary;
+  if (summary.usageStatus === "missing") {
+    return { ...publicSummary, cost: null, costBasis: null, pricingSource: null, pricingStatus: "missing" };
+  }
   if (summary.pricingStatus === "native") {
     return publicSummary;
   }
@@ -473,13 +486,19 @@ export function priceUsageSummary(summary: UsageSummary, pricingData: PricingDat
     ];
   const pricedParts = parts.map((part) => priceUsagePart(part, pricingData));
   if (pricedParts.some((part) => part === undefined)) {
-    return { ...publicSummary, cost: null, pricingSource: null, pricingStatus: "missing" };
+    return { ...publicSummary, cost: null, costBasis: null, pricingSource: null, pricingStatus: "missing" };
   }
   const cost = (pricedParts as UsageCostBreakdown[]).reduce(
     (sum, part) => addCost(sum, part),
     { input: 0, cacheRead: 0, cacheWrite: 0, output: 0, total: 0 },
   );
-  return { ...publicSummary, cost, pricingSource: "models.dev", pricingStatus: "priced" };
+  return {
+    ...publicSummary,
+    cost,
+    costBasis: "api-list-price-estimate",
+    pricingSource: "models.dev",
+    pricingStatus: "priced",
+  };
 }
 
 export async function fetchModelsDevPricing(): Promise<PricingData> {

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -125,6 +125,7 @@ test("cron add persists safe detached command options and rejects unsafe tmux/se
         "read-only",
         "--work-dir",
         dir,
+        "--json",
         "--usage",
       ],
       {
@@ -152,6 +153,7 @@ test("cron add persists safe detached command options and rejects unsafe tmux/se
       "read-only",
       "--work-dir",
       dir,
+      "--json",
       "--usage",
     ]);
 
@@ -173,15 +175,6 @@ test("cron add persists safe detached command options and rejects unsafe tmux/se
     );
     assert.match(stderr, /require --docker/);
 
-    stderr = "";
-    assert.equal(
-      await runCli(
-        ["cron", "add", "codex", "--every", "1h", "--prompt", "x", "--json", "--usage"],
-        { env, stderr: (text) => { stderr += text; } },
-      ),
-      2,
-    );
-    assert.match(stderr, /--usage cannot be used with --json/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2438,6 +2438,7 @@ test("CLI --usage prints final message and normalized usage JSON", async () => {
         outputTokens: 100,
         reasoningOutputTokens: 0,
         totalTokens: 1100,
+        usageStatus: "reported",
         cost: {
           input: 0.00075,
           cacheRead: 0.00005,
@@ -2445,10 +2446,116 @@ test("CLI --usage prints final message and normalized usage JSON", async () => {
           output: 0.001,
           total: 0.0018,
         },
+        costBasis: "api-list-price-estimate",
         pricingSource: "models.dev",
         pricingStatus: "priced",
       },
     });
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --json --usage streams raw trace and appends usage without requiring a final message", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    const firstRecord = { type: "thread.started", thread_id: "thread-1" };
+    const usageRecord = {
+      type: "turn.completed",
+      usage: { input_tokens: 1000, cached_input_tokens: 400, output_tokens: 100 },
+    };
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          `console.log(${JSON.stringify(JSON.stringify(firstRecord))});`,
+          `setTimeout(() => console.log(${JSON.stringify(JSON.stringify(usageRecord))}), 150);`,
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          openai: {
+            models: {
+              "gpt-5": { cost: { input: 1.25, cache_read: 0.125, output: 10 } },
+            },
+          },
+        }),
+      );
+
+    const stdout: string[] = [];
+    let completed = false;
+    const result = runCli(["codex", "--model", "gpt-5", "--prompt", "hello", "--json", "--usage"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    }).finally(() => {
+      completed = true;
+    });
+
+    await waitFor(() => stdout.join("").startsWith(`${JSON.stringify(firstRecord)}\n`) && !completed);
+    assert.equal(completed, false);
+    assert.equal(await result, 0);
+
+    const lines = stdout.join("").trim().split("\n");
+    assert.deepEqual(JSON.parse(lines[0] ?? ""), firstRecord);
+    assert.deepEqual(JSON.parse(lines[1] ?? ""), usageRecord);
+    const usage = JSON.parse(lines[2] ?? "").usage;
+    assert.equal(usage.inputTokens, 600);
+    assert.equal(usage.cacheReadTokens, 400);
+    assert.equal(usage.outputTokens, 100);
+    assert.equal(usage.usageStatus, "reported");
+    assert.equal(usage.cost.total, 0.0018);
+    assert.equal(usage.costBasis, "api-list-price-estimate");
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --json --usage appends partial usage and preserves a nonzero agent status", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } }));",
+          "process.exitCode = 7;",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 7);
+    const lines = stdout.join("").trim().split("\n");
+    assert.equal(JSON.parse(lines[0] ?? "").type, "turn.completed");
+    const usage = JSON.parse(lines[1] ?? "").usage;
+    assert.equal(usage.totalTokens, 12);
+    assert.equal(usage.usageStatus, "reported");
+    assert.equal(usage.cost, null);
+    assert.equal(usage.costBasis, null);
   } finally {
     globalThis.fetch = originalFetch;
     rmSync(dir, { force: true, recursive: true });
@@ -2503,6 +2610,7 @@ test("CLI --usage prices Codex hard default model", async () => {
     const usage = JSON.parse(stdout.join("").trim().split("\n")[1]).usage;
     assert.equal(usage.model, "gpt-5.5");
     assert.equal(usage.pricingStatus, "priced");
+    assert.equal(usage.costBasis, "api-list-price-estimate");
     assert.deepEqual(usage.cost, {
       input: 0.002,
       cacheRead: 0,
@@ -2564,6 +2672,7 @@ test("CLI --usage reports Cursor reasoning model variant", async () => {
     const usage = JSON.parse(stdout.join("").trim().split("\n")[1]).usage;
     assert.equal(usage.model, "gpt-5.5-extra-high");
     assert.equal(usage.pricingStatus, "priced");
+    assert.equal(usage.costBasis, "api-list-price-estimate");
     assert.deepEqual(usage.cost, {
       input: 0.0002,
       cacheRead: 0,
@@ -2644,22 +2753,14 @@ test("CLI --usage reports OpenCode hard default model", async () => {
     assert.equal(usage.provider, "openai");
     assert.equal(usage.model, "gpt-5.4");
     assert.equal(usage.pricingStatus, "native");
+    assert.equal(usage.costBasis, "native-reported");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
 });
 
-test("CLI rejects --usage in raw json and tmux modes", async () => {
+test("CLI rejects --usage in tmux mode", async () => {
   const stderr: string[] = [];
-  assert.equal(
-    await runCli(["codex", "--prompt", "hello", "--usage", "--json"], {
-      stderr: (text) => stderr.push(text),
-    }),
-    2,
-  );
-  assert.match(stderr.join(""), /--usage cannot be used with --json/);
-
-  stderr.length = 0;
   assert.equal(
     await runCli(["codex", "--prompt", "hello", "--usage", "--tmux"], {
       stderr: (text) => stderr.push(text),

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1479,6 +1479,45 @@ test("CLI --json --usage keeps usage accounting bounded around a large native tr
   }
 });
 
+test("CLI --json --usage preserves Codex session identity across a large relevant trace", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    const home = join(dir, "home");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-large' }));",
+          "for (let index = 0; index < 4_000; index += 1) {",
+          "  console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'x'.repeat(100) } }));",
+          "}",
+          "console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } }));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const code = await runCli(["codex", "--prompt", "hello", "--session", "work", "--json", "--usage"], {
+      env: { ...process.env, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: () => {},
+    });
+
+    assert.equal(code, 0);
+    const store = JSON.parse(readFileSync(join(home, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.codex.work.nativeId, "thread-large");
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI flags override configured role allow and reasoning effort", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1479,6 +1479,107 @@ test("CLI --json --usage keeps usage accounting bounded around a large native tr
   }
 });
 
+test("CLI --json --usage preserves terminal usage from oversized JSON rows", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+    const cases: Array<{
+      agent: "claude" | "cursor" | "opencode" | "pi";
+      binaryName: string;
+      row: Record<string, unknown>;
+      expectedTotalTokens: number;
+      expectedCost?: number;
+    }> = [
+      {
+        agent: "claude",
+        binaryName: "claude",
+        row: {
+          type: "result",
+          total_cost_usd: 0.25,
+          usage: { input_tokens: 10, cache_read_input_tokens: 3, output_tokens: 2 },
+        },
+        expectedTotalTokens: 15,
+        expectedCost: 0.25,
+      },
+      {
+        agent: "cursor",
+        binaryName: "agent",
+        row: {
+          type: "result",
+          usage: { inputTokens: 10, cacheReadTokens: 3, outputTokens: 2 },
+        },
+        expectedTotalTokens: 15,
+      },
+      {
+        agent: "opencode",
+        binaryName: "opencode",
+        row: {
+          type: "step_finish",
+          part: { cost: 0.2, tokens: { input: 10, output: 2, reasoning: 1, cache: { read: 3 } } },
+        },
+        expectedTotalTokens: 16,
+        expectedCost: 0.2,
+      },
+      {
+        agent: "pi",
+        binaryName: "pi",
+        row: {
+          type: "message_end",
+          message: {
+            model: "gpt-test",
+            provider: "openai",
+            usage: { input: 10, cacheRead: 3, output: 2, cost: { total: 0.15 } },
+          },
+        },
+        expectedTotalTokens: 15,
+        expectedCost: 0.15,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+      try {
+        const binDir = join(dir, "bin");
+        await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+          await mkdir(binDir);
+          const binary = join(binDir, testCase.binaryName);
+          await writeFile(
+            binary,
+            [
+              "#!/usr/bin/env node",
+              `const metadata = ${JSON.stringify(testCase.row)};`,
+              "const row = { type: metadata.type, result: 'x'.repeat(300_000), ...metadata };",
+              "process.stdout.write(JSON.stringify(row) + '\\n');",
+              "",
+            ].join("\n"),
+          );
+          await chmod(binary, 0o755);
+        });
+
+        const stdout: string[] = [];
+        const code = await runCli([testCase.agent, "--prompt", "hello", "--json", "--usage"], {
+          env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+          stdout: (text) => stdout.push(text),
+        });
+
+        assert.equal(code, 0);
+        assert.ok(stdout.join("").length > 300_000);
+        const usage = JSON.parse(stdout.join("").trim().split("\n").at(-1) ?? "").usage;
+        assert.equal(usage.totalTokens, testCase.expectedTotalTokens);
+        assert.equal(usage.usageStatus, "reported");
+        if (testCase.expectedCost !== undefined) {
+          assert.equal(usage.cost.total, testCase.expectedCost);
+          assert.equal(usage.costBasis, "native-reported");
+        }
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("CLI --json --usage preserves Codex session identity across a large relevant trace", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const originalFetch = globalThis.fetch;

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -32,6 +32,15 @@ async function waitFor(assertion: () => boolean): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   assert.equal(assertion(), true);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 test("lists all supported agents", () => {
@@ -1262,6 +1271,172 @@ test("CLI waits for timed-out child stdout to drain before appending usage", asy
     assert.equal(JSON.parse(lines[1] ?? "").usage.usageStatus, "reported");
   } finally {
     globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI bounds timeout drain when a descendant retains stdout", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const pidFile = join(dir, "grandchild.pid");
+  let grandchildPid: number | undefined;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "const { spawn } = require('node:child_process');",
+          "const { writeFileSync } = require('node:fs');",
+          "process.on('SIGTERM', () => {",
+          "  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'], { stdio: ['ignore', 'inherit', 'inherit'] });",
+          "  writeFileSync(process.env.HEADLESS_TEST_GRANDCHILD_PID, String(child.pid));",
+          "  child.unref();",
+          "  process.exit(0);",
+          "});",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+
+    const startedAt = Date.now();
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "1"], {
+      env: {
+        ...process.env,
+        HEADLESS_TEST_GRANDCHILD_PID: pidFile,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: () => {},
+    });
+
+    assert.equal(code, 124);
+    assert.ok(Date.now() - startedAt < 4_000, "timeout drain should finish before the descendant exits");
+    grandchildPid = Number(readFileSync(pidFile, "utf8"));
+    assert.ok(Number.isInteger(grandchildPid) && grandchildPid > 0);
+    if (process.platform !== "win32") {
+      await waitFor(() => !processIsAlive(grandchildPid as number));
+    }
+  } finally {
+    try {
+      grandchildPid = Number(readFileSync(pidFile, "utf8"));
+      if (Number.isInteger(grandchildPid) && grandchildPid > 0) process.kill(grandchildPid, "SIGKILL");
+    } catch {
+      // The child may fail before creating its descendant.
+    }
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI kills timeout descendants after the direct child closes", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const pidFile = join(dir, "grandchild.pid");
+  let grandchildPid: number | undefined;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "const { spawn } = require('node:child_process');",
+          "const { writeFileSync } = require('node:fs');",
+          "process.on('SIGTERM', () => {",
+          "  const child = spawn(process.execPath, ['-e', \"process.on('SIGTERM', () => {}); setTimeout(() => {}, 10_000)\"], { stdio: 'ignore' });",
+          "  writeFileSync(process.env.HEADLESS_TEST_GRANDCHILD_PID, String(child.pid));",
+          "  child.unref();",
+          "  process.exit(0);",
+          "});",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--timeout", "1"], {
+      env: {
+        ...process.env,
+        HEADLESS_TEST_GRANDCHILD_PID: pidFile,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdout: () => {},
+    });
+
+    assert.equal(code, 124);
+    grandchildPid = Number(readFileSync(pidFile, "utf8"));
+    assert.ok(Number.isInteger(grandchildPid) && grandchildPid > 0);
+    if (process.platform !== "win32") {
+      await waitFor(() => !processIsAlive(grandchildPid as number));
+    }
+  } finally {
+    if (grandchildPid && processIsAlive(grandchildPid)) process.kill(grandchildPid, "SIGKILL");
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI forwards parent signals to timeout-enabled agents", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const agentPidFile = join(dir, "agent.pid");
+  const signalFile = join(dir, "signal.txt");
+  let agentPid: number | undefined;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "const { writeFileSync } = require('node:fs');",
+          "writeFileSync(process.env.HEADLESS_TEST_AGENT_PID, String(process.pid));",
+          "process.on('SIGINT', () => {",
+          "  writeFileSync(process.env.HEADLESS_TEST_SIGNAL_FILE, 'SIGINT');",
+          "  process.exit(130);",
+          "});",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+
+    const headless = spawn(
+      process.execPath,
+      ["--import", "tsx", join(repoRoot, "src", "cli.ts"), "codex", "--prompt", "hello", "--json", "--timeout", "30"],
+      {
+        env: {
+          ...process.env,
+          HEADLESS_TEST_AGENT_PID: agentPidFile,
+          HEADLESS_TEST_SIGNAL_FILE: signalFile,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdio: "ignore",
+      },
+    );
+    await waitFor(() => existsSync(agentPidFile));
+
+    headless.kill("SIGINT");
+    const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      headless.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+
+    assert.deepEqual(exit, { code: null, signal: "SIGINT" });
+    await waitFor(() => existsSync(signalFile));
+    assert.equal(readFileSync(signalFile, "utf8"), "SIGINT");
+  } finally {
+    try {
+      agentPid = Number(readFileSync(agentPidFile, "utf8"));
+      if (Number.isInteger(agentPid) && agentPid > 0 && processIsAlive(agentPid)) process.kill(agentPid, "SIGKILL");
+    } catch {
+      // The wrapper may fail before launching its agent.
+    }
     rmSync(dir, { force: true, recursive: true });
   }
 });

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1441,6 +1441,72 @@ test("CLI forwards parent signals to timeout-enabled agents", async () => {
   }
 });
 
+test("CLI forwards suspend and continue signals to timeout-enabled agents", { skip: process.platform === "win32" }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const agentPidFile = join(dir, "agent.pid");
+  const signalFile = join(dir, "signals.txt");
+  let agentPid: number | undefined;
+  let headless: ReturnType<typeof spawn> | undefined;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "const { appendFileSync, writeFileSync } = require('node:fs');",
+          "writeFileSync(process.env.HEADLESS_TEST_AGENT_PID, String(process.pid));",
+          "process.on('SIGTSTP', () => {",
+          "  appendFileSync(process.env.HEADLESS_TEST_SIGNAL_FILE, 'SIGTSTP\\n');",
+          "  process.kill(process.pid, 'SIGSTOP');",
+          "});",
+          "process.on('SIGCONT', () => appendFileSync(process.env.HEADLESS_TEST_SIGNAL_FILE, 'SIGCONT\\n'));",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+
+    headless = spawn(
+      process.execPath,
+      ["--import", "tsx", join(repoRoot, "src", "cli.ts"), "codex", "--prompt", "hello", "--json", "--timeout", "30"],
+      {
+        env: {
+          ...process.env,
+          HEADLESS_TEST_AGENT_PID: agentPidFile,
+          HEADLESS_TEST_SIGNAL_FILE: signalFile,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdio: "ignore",
+      },
+    );
+    await waitFor(() => existsSync(agentPidFile));
+
+    headless.kill("SIGTSTP");
+    await waitFor(() => existsSync(signalFile) && readFileSync(signalFile, "utf8").includes("SIGTSTP"));
+    headless.kill("SIGCONT");
+    await waitFor(() => readFileSync(signalFile, "utf8").includes("SIGCONT"));
+
+    const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      headless?.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+    headless.kill("SIGTERM");
+    assert.deepEqual(await exit, { code: null, signal: "SIGTERM" });
+  } finally {
+    if (headless && headless.exitCode === null && headless.signalCode === null) headless.kill("SIGKILL");
+    try {
+      agentPid = Number(readFileSync(agentPidFile, "utf8"));
+      if (Number.isInteger(agentPid) && agentPid > 0 && processIsAlive(agentPid)) process.kill(agentPid, "SIGKILL");
+    } catch {
+      // The wrapper may fail before launching its agent.
+    }
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --json --usage keeps usage accounting bounded around a large native trace", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const originalFetch = globalThis.fetch;

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1229,6 +1229,81 @@ test("CLI exits 124 when a one-shot command exceeds --timeout", async () => {
   }
 });
 
+test("CLI waits for timed-out child stdout to drain before appending usage", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "process.on('SIGTERM', () => { process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } }) + '\\n'); setTimeout(() => process.exit(0), 200); });",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "1"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 124);
+    const lines = stdout.join("").trim().split("\n");
+    assert.equal(JSON.parse(lines[0] ?? "").type, "turn.completed");
+    assert.equal(JSON.parse(lines[1] ?? "").usage.usageStatus, "reported");
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --json --usage keeps usage accounting bounded around a large native trace", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          `process.stdout.write(JSON.stringify({ type: 'tool', text: '${"x".repeat(300_000)}' }) + '\\n');`,
+          "process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } }) + '\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.ok(stdout.join("").length > 300_000);
+    const usage = JSON.parse(stdout.join("").trim().split("\n").at(-1) ?? "").usage;
+    assert.equal(usage.totalTokens, 12);
+    assert.equal(usage.usageStatus, "reported");
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI flags override configured role allow and reasoning effort", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -244,6 +244,7 @@ test("extracts Codex usage from turn completed trace and prices with models.dev 
     outputTokens: 100,
     reasoningOutputTokens: 25,
     totalTokens: 1100,
+    usageStatus: "reported",
     cost: {
       input: 0.00075,
       cacheRead: 0.00005,
@@ -251,6 +252,7 @@ test("extracts Codex usage from turn completed trace and prices with models.dev 
       output: 0.001,
       total: 0.0018,
     },
+    costBasis: "api-list-price-estimate",
     pricingSource: "models.dev",
     pricingStatus: "priced",
   });
@@ -287,6 +289,7 @@ test("extracts Claude usage and preserves native cost", () => {
     outputTokens: 8,
     reasoningOutputTokens: 0,
     totalTokens: 29242,
+    usageStatus: "reported",
     cost: {
       input: null,
       cacheRead: null,
@@ -294,6 +297,7 @@ test("extracts Claude usage and preserves native cost", () => {
       output: null,
       total: 0.18331675,
     },
+    costBasis: "native-reported",
     pricingSource: "native",
     pricingStatus: "native",
   });
@@ -380,6 +384,22 @@ test("extracts Cursor usage and returns null cost when model pricing is missing"
   assert.equal(summary.outputTokens, 43);
   assert.equal(summary.model, "Composer 2 Fast");
   assert.equal(summary.cost, null);
+  assert.equal(summary.costBasis, null);
+  assert.equal(summary.pricingStatus, "missing");
+});
+
+test("does not price missing usage as zero", () => {
+  const summary = priceUsageSummary(
+    extractUsageSummary("codex", JSON.stringify({ type: "thread.started" }), {
+      provider: "openai",
+      model: "gpt-5",
+    }),
+    pricingFixture(),
+  );
+
+  assert.equal(summary.usageStatus, "missing");
+  assert.equal(summary.cost, null);
+  assert.equal(summary.costBasis, null);
   assert.equal(summary.pricingStatus, "missing");
 });
 
@@ -419,6 +439,7 @@ test("prices Cursor effort model variants with base model rates", () => {
     output: 0.0004,
     total: 0.00248,
   });
+  assert.equal(summary.costBasis, "api-list-price-estimate");
   assert.equal(summary.pricingStatus, "priced");
 });
 
@@ -455,6 +476,7 @@ test("extracts Gemini multi-model usage and sums priced costs", () => {
     output: 0.000028,
     total: 0.001113,
   });
+  assert.equal(summary.costBasis, "api-list-price-estimate");
   assert.equal(summary.pricingStatus, "priced");
 });
 
@@ -485,6 +507,7 @@ test("extracts OpenCode native usage cost", () => {
     output: null,
     total: 0.00087525,
   });
+  assert.equal(summary.costBasis, "native-reported");
   assert.equal(summary.pricingStatus, "native");
 });
 
@@ -521,6 +544,7 @@ test("extracts Pi usage and native cost", () => {
     outputTokens: 7,
     reasoningOutputTokens: 0,
     totalTokens: 2347,
+    usageStatus: "reported",
     cost: {
       input: 0.01155,
       output: 0.000175,
@@ -528,6 +552,7 @@ test("extracts Pi usage and native cost", () => {
       cacheWrite: 0.000125,
       total: 0.011855,
     },
+    costBasis: "native-reported",
     pricingSource: "native",
     pricingStatus: "native",
   });

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { extractAgentError, extractFinalMessage, extractUsageSummary, priceUsageSummary } from "../src/output.ts";
 import { extractRunNodeMetrics } from "../src/run-metrics.ts";
+import type { AgentName } from "../src/types.ts";
 
 test("extracts final Codex assistant message from JSONL trace", () => {
   const trace = [
@@ -401,6 +402,40 @@ test("does not price missing usage as zero", () => {
   assert.equal(summary.cost, null);
   assert.equal(summary.costBasis, null);
   assert.equal(summary.pricingStatus, "missing");
+});
+
+test("classifies malformed usage-shaped records as missing", () => {
+  const cases: Array<[AgentName, unknown]> = [
+    ["claude", { type: "result", usage: { unexpected: true } }],
+    ["codex", { type: "turn.completed", usage: { unexpected: true } }],
+    ["cursor", { type: "result", usage: { unexpected: true } }],
+    ["gemini", { type: "result", stats: { unexpected: true } }],
+    ["opencode", { type: "step_finish", part: { tokens: { unexpected: true } } }],
+    ["pi", { type: "message_end", message: { usage: { unexpected: true } } }],
+  ];
+
+  for (const [agent, record] of cases) {
+    const summary = extractUsageSummary(agent, JSON.stringify(record), { model: "test-model" });
+    assert.equal(summary.usageStatus, "missing", agent);
+    assert.equal(summary.cost, null, agent);
+  }
+});
+
+test("preserves valid native zero-cost reports", () => {
+  const cases: Array<[AgentName, unknown]> = [
+    ["claude", { type: "result", total_cost_usd: 0, usage: { input_tokens: 0 } }],
+    ["opencode", { type: "step_finish", part: { cost: 0, tokens: { input: 0 } } }],
+    ["pi", { type: "message_end", message: { usage: { input: 0, cost: { total: 0 } } } }],
+  ];
+
+  for (const [agent, record] of cases) {
+    const summary = extractUsageSummary(agent, JSON.stringify(record), { model: "test-model" });
+    assert.equal(summary.usageStatus, "reported", agent);
+    assert.equal(summary.cost?.total, 0, agent);
+    assert.equal(summary.costBasis, "native-reported", agent);
+    assert.equal(summary.pricingSource, "native", agent);
+    assert.equal(summary.pricingStatus, "native", agent);
+  }
 });
 
 test("prices Cursor effort model variants with base model rates", () => {

--- a/tests/process-tree.test.ts
+++ b/tests/process-tree.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { forceKillWindowsProcessTree, windowsTaskkillPath, type TaskkillLauncher } from "../src/process-tree.ts";
+
+class FakeTaskkill extends EventEmitter {
+  readonly signals: Array<NodeJS.Signals | number | undefined> = [];
+  unrefCalled = false;
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.signals.push(signal);
+    return true;
+  }
+
+  unref(): void {
+    this.unrefCalled = true;
+  }
+}
+
+test("Windows tree cleanup launches trusted taskkill with numeric arguments", () => {
+  const taskkill = new FakeTaskkill();
+  let invocation: { command: string; args: string[] } | undefined;
+  const launch: TaskkillLauncher = (command, args) => {
+    invocation = { command, args };
+    return taskkill;
+  };
+  const childSignals: Array<NodeJS.Signals | number | undefined> = [];
+
+  forceKillWindowsProcessTree(
+    {
+      pid: 1234,
+      kill: (signal) => {
+        childSignals.push(signal);
+        return true;
+      },
+    },
+    100,
+    launch,
+  );
+  taskkill.emit("close", 0);
+
+  assert.deepEqual(invocation, {
+    command: "C:\\Windows\\System32\\taskkill.exe",
+    args: ["/pid", "1234", "/T", "/F"],
+  });
+  assert.equal(taskkill.unrefCalled, true);
+  assert.deepEqual(childSignals, []);
+});
+
+test("Windows tree cleanup resolves taskkill from a non-default system root", () => {
+  assert.equal(windowsTaskkillPath("D:\\WinNT"), "D:\\WinNT\\System32\\taskkill.exe");
+});
+
+test("Windows tree cleanup bounds a hung taskkill and falls back to the direct child", async () => {
+  const taskkill = new FakeTaskkill();
+  const childSignals: Array<NodeJS.Signals | number | undefined> = [];
+
+  forceKillWindowsProcessTree(
+    {
+      pid: 1234,
+      kill: (signal) => {
+        childSignals.push(signal);
+        return true;
+      },
+    },
+    1,
+    () => taskkill,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.deepEqual(taskkill.signals, ["SIGKILL"]);
+  assert.deepEqual(childSignals, ["SIGKILL"]);
+});

--- a/tests/relevant-trace.test.ts
+++ b/tests/relevant-trace.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { compactOversizedTraceLine } from "../src/relevant-trace.ts";
+
+test("oversized trace compaction preserves only valid top-level usage", () => {
+  assert.equal(compactOversizedTraceLine("claude", '{"type":"result","usage":'), "");
+
+  const compacted = compactOversizedTraceLine(
+    "claude",
+    JSON.stringify({
+      type: "tool",
+      payload: { usage: { input_tokens: 999 }, total_cost_usd: 99 },
+      result: "x".repeat(300_000),
+    }),
+  );
+
+  assert.deepEqual(JSON.parse(compacted), { type: "tool" });
+});

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -379,6 +379,69 @@ test("orchestrator run status reporter stays off for json runs", async () => {
   }
 });
 
+test("Antigravity json orchestrators preserve terminal responses for run completion", async () => {
+  for (const responseType of ["planner_response", "ASSISTANT_RESPONSE"]) {
+    const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+    try {
+      const home = join(dir, "home");
+      const binDir = join(dir, "bin");
+      mkdirSync(home);
+      await writeExecutable(
+        join(binDir, "agy"),
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const runFile = process.env.HOME + '/.headless/runs/antigravity-run/run.json';",
+          "const run = JSON.parse(fs.readFileSync(runFile, 'utf8'));",
+          "run.nodes.worker.status = 'idle';",
+          "fs.writeFileSync(runFile, JSON.stringify(run, null, 2) + '\\n');",
+          `console.log(JSON.stringify({ type: '${responseType}', status: 'COMPLETED', content: 'antigravity final' }));`,
+          "",
+        ].join("\n"),
+      );
+
+      const env = {
+        ...process.env,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      };
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+
+      const code = await runCli(
+        [
+          "antigravity",
+          "--role",
+          "orchestrator",
+          "--run",
+          "antigravity-run",
+          "--coordination",
+          "oneshot",
+          "--team",
+          "worker=1",
+          "--prompt",
+          "Build auth",
+          "--json",
+          "--usage",
+        ],
+        {
+          env,
+          stdout: (text) => stdout.push(text),
+          stderr: (text) => stderr.push(text),
+        },
+      );
+
+      assert.equal(code, 0, stderr.join(""));
+      assert.match(stdout.join(""), /"antigravity final"/);
+      const run = readRun(env, "antigravity-run");
+      assert.equal(run?.nodes.orchestrator.lastMessage, "antigravity final");
+      assert.equal(run?.nodes.worker.status, "done");
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
 test("orchestrator run rejects read-only mode because it must update run state", async () => {
   const stderr: string[] = [];
   const code = await runCli(


### PR DESCRIPTION
## What changed

Allow `--json --usage` together for one-shot runs. Headless streams the native trace unchanged, then appends normalized usage after the process exits, without requiring final-message extraction.

Usage output now makes accounting provenance explicit:

- `usageStatus` distinguishes reported usage from missing usage.
- `costBasis` distinguishes native-reported cost from an API list-price estimate.
- Missing usage remains unpriced instead of becoming a misleading $0 estimate.

The estimate is not actual subscription spend.

## Validation

- TypeScript build passed.
- 310 non-Modal tests passed on the combined branch.
- Package dry-run passed.
- Four pre-existing Modal tests still fail with `invalid pax header`; Modal is not part of this change.
