### PR TITLE
fix: report Antigravity usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.
 - Clarified accounting provenance with `usageStatus` and `costBasis`: missing usage stays unknown instead of becoming a priced zero, and native-reported costs are distinguished from API list-price estimates calculated from token counts and `models.dev` pricing.
+- Fixed local Antigravity `--usage` output to collect input, cache-read, cache-write, and output tokens from the documented status-line payload and price known models with API-equivalent models.dev rates, without modifying the user's Antigravity settings.
 
 ## 0.4.0 - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+- Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.
+- Clarified accounting provenance with `usageStatus` and `costBasis`: missing usage stays unknown instead of becoming a priced zero, and native-reported costs are distinguished from API list-price estimates calculated from token counts and `models.dev` pricing.
+
 ## 0.4.0 - 2026-06-18
 
 - Added Antigravity CLI (`agy`) harness support for one-shot prompts, model selection, read-only sandbox mode, native session aliases, tmux launches, `--tmux --wait`, transcript final-message extraction, setup checks, Docker packaging, and README/config documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.
 - Clarified accounting provenance with `usageStatus` and `costBasis`: missing usage stays unknown instead of becoming a priced zero, and native-reported costs are distinguished from API list-price estimates calculated from token counts and `models.dev` pricing.
+- Fixed local Antigravity `--usage` output to collect input, cache-read, cache-write, and output tokens from the documented status-line payload and price known models with API-equivalent models.dev rates, without modifying the user's Antigravity settings.
 - Thanks to Anant Garg (@anantgar) for contributing combined JSON traces with usage accounting.
 
 ## 0.4.0 - 2026-06-18

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ headless acp --acp-command "atlas alta agent run" --prompt "Fix the failing test
 headless pi --prompt "Summarize this repo" --json
 headless codex --prompt "Fix the failing tests" --debug
 headless codex --prompt "Summarize this repo" --usage
+headless codex --prompt "Summarize this repo" --json --usage
 
 # Use read-only mode for review/planning work.
 headless codex --allow read-only --prompt "Review this repo"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ headless pi --prompt "Summarize this repo" --json
 headless codex --prompt "Fix the failing tests" --debug
 headless codex --prompt "Summarize this repo" --usage
 headless codex --prompt "Summarize this repo" --json --usage
+headless antigravity --prompt "Summarize this repo" --usage
 
 # Use read-only mode for review/planning work.
 headless codex --allow read-only --prompt "Review this repo"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,8 @@ headless codex --prompt "Summarize this repo" --model gpt-5 --usage
 headless codex --prompt "Summarize this repo" --model gpt-5 --json --usage
 ```
 
+For local Antigravity one-shot runs, Headless collects Antigravity's [documented `context_window.current_usage` status payload](https://antigravity.google/docs/cli-statusline) because `agy -p` does not print token counts. It gives `agy` a temporary overlay home that preserves the real home and Antigravity data through symlinks while replacing only the child process's status-line command. The real `~/.gemini/antigravity-cli/settings.json` is not changed, existing custom status-line output is preserved, and the temporary payload excludes account fields such as email and plan tier. Antigravity Docker and Modal usage capture is not yet available.
+
 ## Cron Jobs
 
 Use `headless cron add` to schedule the same detached one-shot invocation at fixed intervals or with a five-field cron expression. `--every` accepts positive `s`, `m`, `h`, and `d` durations. `--schedule` accepts `minute hour day-of-month month day-of-week` expressions evaluated in the local system timezone.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,7 +97,7 @@ headless codex --prompt "Summarize this repo" --model gpt-5 --usage
 headless codex --prompt "Summarize this repo" --model gpt-5 --json --usage
 ```
 
-For local Antigravity one-shot runs, Headless collects Antigravity's [documented `context_window.current_usage` status payload](https://antigravity.google/docs/cli-statusline) because `agy -p` does not print token counts. It gives `agy` a temporary overlay home that preserves the real home and Antigravity data through symlinks while replacing only the child process's status-line command. The real `~/.gemini/antigravity-cli/settings.json` is not changed, existing custom status-line output is preserved, and the temporary payload excludes account fields such as email and plan tier. Antigravity Docker and Modal usage capture is not yet available.
+For local Antigravity one-shot runs on macOS and Linux, Headless collects Antigravity's [documented `context_window.current_usage` status payload](https://antigravity.google/docs/cli-statusline) because `agy -p` does not print token counts. It gives `agy` a temporary overlay home that preserves the real home and Antigravity data through symlinks while replacing only the child process's status-line command. The real `~/.gemini/antigravity-cli/settings.json` is not changed, existing custom status-line output is preserved, and the temporary payload excludes account fields such as email and plan tier. Antigravity usage capture is not yet available on Windows, Docker, or Modal.
 
 ## Cron Jobs
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,10 +69,11 @@ Raw mode is the default: Headless prints the extracted final assistant message.
 headless codex --prompt "Fix the failing tests"
 ```
 
-`--json` streams the native agent JSON trace for scripting. It cannot be combined with `--tmux`.
+`--json` streams the native agent JSON trace for scripting. It cannot be combined with `--tmux`. Combine it with `--usage` to keep the native trace unchanged and append one normalized usage object after the native process exits.
 
 ```bash
 headless pi --prompt "Summarize this repo" --json
+headless codex --prompt "Summarize this repo" --json --usage
 ```
 
 When combined with `--print-command`, `--json` prints a single structured object for wrappers that need the selected agent identity without parsing shell text.
@@ -87,10 +88,13 @@ headless --prompt "identity" --print-command --json
 headless codex --prompt "Fix the failing tests" --debug
 ```
 
-`--usage` appends normalized token usage and cost JSON after the final message for one-shot runs, including Docker and Modal runs. It reports input, cache read, cache write, output, reasoning output, total tokens, provider/model metadata, pricing status, and cost when available. Native costs are used when available; fallback pricing comes from `https://models.dev/api.json`. If a model cannot be priced, token counts are still returned with `cost: null`.
+`--usage` appends normalized token usage and cost JSON for one-shot runs, including Docker and Modal runs. In the default output mode it follows the extracted final message. With `--json`, it follows the streamed native trace and does not require Headless to extract a final assistant message.
+
+Usage reports input, cache read, cache write, output, reasoning output, total tokens, provider/model metadata, pricing status, and cost when available. `usageStatus` is `reported` only when Headless recognizes a native usage record; otherwise it is `missing`, with cost left null. `costBasis` distinguishes `native-reported` values from `api-list-price-estimate` values calculated from token counts and `https://models.dev/api.json`. The latter is an API-equivalent list-price estimate, not actual subscription spend. If usage or model pricing is unavailable, available token counts are still returned with `cost: null` and `costBasis: null`.
 
 ```bash
 headless codex --prompt "Summarize this repo" --model gpt-5 --usage
+headless codex --prompt "Summarize this repo" --model gpt-5 --json --usage
 ```
 
 ## Cron Jobs
@@ -277,7 +281,7 @@ Options:
 - `--timeout <s>`: stop one-shot local, Docker, Modal, or `--tmux --wait` execution after the given number of seconds.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.
 - `--debug`: stream the raw agent JSON trace and append the extracted final message.
-- `--usage`: append normalized token usage and cost JSON after the final message.
+- `--usage`: append normalized token usage and cost JSON after the final message or streamed `--json` trace.
 - `--tmux`: launch an interactive agent in a detached tmux session with the prompt as its initial message.
 - `--wait`: with `--tmux`, wait for native transcript completion and print the final message.
 - `--delete`: with `--tmux --wait`, kill the tmux session after completion.

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -160,6 +160,31 @@ export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCaptur
       { mode: 0o600 },
     );
 
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      process.off("exit", cleanup);
+      process.off("SIGINT", onInterrupt);
+      process.off("SIGTERM", onTerminate);
+      try {
+        rmSync(root, { force: true, recursive: true });
+      } catch {
+        // Cleanup failure must not replace the agent's result.
+      }
+    };
+    const onInterrupt = () => {
+      cleanup();
+      process.kill(process.pid, "SIGINT");
+    };
+    const onTerminate = () => {
+      cleanup();
+      process.kill(process.pid, "SIGTERM");
+    };
+    process.on("exit", cleanup);
+    process.once("SIGINT", onInterrupt);
+    process.once("SIGTERM", onTerminate);
+
     return {
       commandEnv: {
         HOME: overlayHome,
@@ -173,13 +198,7 @@ export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCaptur
           return "";
         }
       },
-      cleanup: () => {
-        try {
-          rmSync(root, { force: true, recursive: true });
-        } catch {
-          // Cleanup failure must not replace the agent's result.
-        }
-      },
+      cleanup,
     };
   } catch (error) {
     rmSync(root, { force: true, recursive: true });

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -127,6 +127,10 @@ function readSettings(path: string): AntigravitySettings {
   return value as AntigravitySettings;
 }
 
+function nonEmptyPath(value: string | undefined): string | undefined {
+  return value?.trim() ? value : undefined;
+}
+
 export function prepareAntigravityUsageCapture(env: Env, cwd?: string): AntigravityUsageCapture | undefined {
   if (process.platform === "win32") return undefined;
   if (!env.HOME) return undefined;
@@ -134,7 +138,7 @@ export function prepareAntigravityUsageCapture(env: Env, cwd?: string): Antigrav
   const realHome = resolve(baseDir, env.HOME);
 
   const realGeminiDir = join(realHome, ".gemini");
-  const configuredAppDir = env.ANTIGRAVITY_HOME?.trim() || env.AGY_HOME?.trim() || undefined;
+  const configuredAppDir = nonEmptyPath(env.ANTIGRAVITY_HOME) ?? nonEmptyPath(env.AGY_HOME);
   const realAppDir = resolve(baseDir, configuredAppDir ?? join(realGeminiDir, "antigravity-cli"));
   if (!existsSync(realAppDir)) return undefined;
 

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { quoteArg } from "./shell.js";
 import type { Env } from "./types.js";
@@ -105,19 +105,23 @@ function readSettings(path: string): AntigravitySettings {
   return value as AntigravitySettings;
 }
 
-export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCapture | undefined {
-  const realHome = env.HOME;
-  if (!realHome) return undefined;
+export function prepareAntigravityUsageCapture(env: Env, cwd?: string): AntigravityUsageCapture | undefined {
+  if (!env.HOME) return undefined;
+  const baseDir = cwd ?? process.cwd();
+  const realHome = resolve(baseDir, env.HOME);
 
   const realGeminiDir = join(realHome, ".gemini");
-  const realAppDir = join(realGeminiDir, "antigravity-cli");
+  const configuredAppDir = env.ANTIGRAVITY_HOME?.trim() || env.AGY_HOME?.trim() || undefined;
+  const realAppDir = resolve(baseDir, configuredAppDir ?? join(realGeminiDir, "antigravity-cli"));
   if (!existsSync(realAppDir)) return undefined;
 
   const root = mkdtempSync(join(tmpdir(), "headless-antigravity-usage-"));
   try {
     const overlayHome = join(root, "home");
     const overlayGeminiDir = join(overlayHome, ".gemini");
-    const overlayAppDir = join(overlayGeminiDir, "antigravity-cli");
+    const overlayAppDir = configuredAppDir
+      ? join(root, "antigravity-profile")
+      : join(overlayGeminiDir, "antigravity-cli");
     const capturePath = join(root, "usage.jsonl");
     const scriptPath = join(root, "capture.mjs");
     const statusCommandPath = join(root, "status-command");
@@ -163,6 +167,8 @@ export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCaptur
     return {
       commandEnv: {
         HOME: overlayHome,
+        ...(env.ANTIGRAVITY_HOME !== undefined ? { ANTIGRAVITY_HOME: overlayAppDir } : {}),
+        ...(env.AGY_HOME !== undefined ? { AGY_HOME: overlayAppDir } : {}),
         HEADLESS_ANTIGRAVITY_USAGE_FILE: capturePath,
         HEADLESS_ANTIGRAVITY_STATUS_COMMAND: undefined,
       },

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -1,0 +1,175 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { quoteArg } from "./shell.js";
+import type { Env } from "./types.js";
+
+interface StatusLineConfig {
+  type?: string;
+  command?: string;
+  enabled?: boolean;
+  [key: string]: unknown;
+}
+
+interface AntigravitySettings {
+  statusLine?: StatusLineConfig;
+  [key: string]: unknown;
+}
+
+export interface AntigravityUsageCapture {
+  commandEnv: Env;
+  read(): string;
+  cleanup(): void;
+}
+
+const captureScript = `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+
+try {
+  const value = JSON.parse(input);
+  const model = value?.model && typeof value.model === "object" ? value.model : {};
+  const contextWindow = value?.context_window && typeof value.context_window === "object" ? value.context_window : {};
+  const usage = contextWindow.current_usage && typeof contextWindow.current_usage === "object"
+    ? contextWindow.current_usage
+    : {};
+  const record = {
+    type: "headless.antigravity.usage",
+    conversation_id: typeof value?.conversation_id === "string" ? value.conversation_id : "",
+    model: {
+      id: typeof model.id === "string" ? model.id : "",
+      display_name: typeof model.display_name === "string" ? model.display_name : "",
+    },
+    context_window: {
+      current_usage: {
+        input_tokens: Number.isFinite(usage.input_tokens) ? usage.input_tokens : 0,
+        output_tokens: Number.isFinite(usage.output_tokens) ? usage.output_tokens : 0,
+        cache_creation_input_tokens: Number.isFinite(usage.cache_creation_input_tokens)
+          ? usage.cache_creation_input_tokens
+          : 0,
+        cache_read_input_tokens: Number.isFinite(usage.cache_read_input_tokens)
+          ? usage.cache_read_input_tokens
+          : 0,
+      },
+    },
+  };
+  appendFileSync(process.env.HEADLESS_ANTIGRAVITY_USAGE_FILE, JSON.stringify(record) + "\\n", { mode: 0o600 });
+} catch {
+  // Usage collection must never interfere with the agent run.
+}
+
+const originalCommand = process.env.HEADLESS_ANTIGRAVITY_STATUS_COMMAND;
+if (originalCommand) {
+  const child = spawnSync("/bin/sh", ["-c", originalCommand], { input, encoding: "utf8" });
+  if (child.stdout) process.stdout.write(child.stdout);
+  if (child.stderr) process.stderr.write(child.stderr);
+}
+`;
+
+function linkChildren(source: string, target: string, excluded: Set<string>): void {
+  mkdirSync(target, { recursive: true, mode: 0o700 });
+  if (!existsSync(source)) return;
+  for (const entry of readdirSync(source)) {
+    if (excluded.has(entry)) continue;
+    symlinkSync(join(source, entry), join(target, entry));
+  }
+}
+
+function readSettings(path: string): AntigravitySettings {
+  if (!existsSync(path)) return {};
+  const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Antigravity settings must contain a JSON object");
+  }
+  return value as AntigravitySettings;
+}
+
+export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCapture | undefined {
+  const realHome = env.HOME;
+  if (!realHome) return undefined;
+
+  const realGeminiDir = join(realHome, ".gemini");
+  const realAppDir = join(realGeminiDir, "antigravity-cli");
+  if (!existsSync(realAppDir)) return undefined;
+
+  const root = mkdtempSync(join(tmpdir(), "headless-antigravity-usage-"));
+  try {
+    const overlayHome = join(root, "home");
+    const overlayGeminiDir = join(overlayHome, ".gemini");
+    const overlayAppDir = join(overlayGeminiDir, "antigravity-cli");
+    const capturePath = join(root, "usage.jsonl");
+    const scriptPath = join(root, "capture.mjs");
+
+    linkChildren(realHome, overlayHome, new Set([".gemini"]));
+    linkChildren(realGeminiDir, overlayGeminiDir, new Set(["antigravity-cli"]));
+    linkChildren(realAppDir, overlayAppDir, new Set(["settings.json"]));
+
+    const settingsPath = join(realAppDir, "settings.json");
+    const settings = readSettings(settingsPath);
+    const originalStatusLine = settings.statusLine;
+    const originalCommand =
+      originalStatusLine?.type === "command" && originalStatusLine.enabled !== false
+        ? originalStatusLine.command?.trim()
+        : undefined;
+
+    writeFileSync(capturePath, "", { mode: 0o600 });
+    writeFileSync(scriptPath, captureScript, { mode: 0o700 });
+    chmodSync(scriptPath, 0o700);
+    writeFileSync(
+      join(overlayAppDir, "settings.json"),
+      `${JSON.stringify(
+        {
+          ...settings,
+          statusLine: {
+            ...originalStatusLine,
+            type: "command",
+            command: quoteArg(scriptPath),
+            enabled: true,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      { mode: 0o600 },
+    );
+
+    return {
+      commandEnv: {
+        HOME: overlayHome,
+        HEADLESS_ANTIGRAVITY_USAGE_FILE: capturePath,
+        HEADLESS_ANTIGRAVITY_STATUS_COMMAND: originalCommand,
+      },
+      read: () => {
+        try {
+          return readFileSync(capturePath, "utf8");
+        } catch {
+          return "";
+        }
+      },
+      cleanup: () => {
+        try {
+          rmSync(root, { force: true, recursive: true });
+        } catch {
+          // Cleanup failure must not replace the agent's result.
+        }
+      },
+    };
+  } catch (error) {
+    rmSync(root, { force: true, recursive: true });
+    throw error;
+  }
+}

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -81,9 +81,23 @@ try {
   // The user's status command is optional.
 }
 if (originalCommand) {
-  const child = spawnSync("/bin/sh", ["-c", originalCommand], { input, encoding: "utf8" });
+  const environment = { ...process.env };
+  try {
+    const originalEnvironment = JSON.parse(
+      readFileSync(join(dirname(fileURLToPath(import.meta.url)), "status-environment.json"), "utf8"),
+    );
+    for (const [key, value] of Object.entries(originalEnvironment)) {
+      if (typeof value === "string") environment[key] = value;
+      else delete environment[key];
+    }
+  } catch {
+    // Fall back to the wrapper environment if the snapshot is unavailable.
+  }
+  const child = spawnSync("/bin/sh", ["-c", originalCommand], { input, encoding: "utf8", env: environment });
   if (child.stdout) process.stdout.write(child.stdout);
   if (child.stderr) process.stderr.write(child.stderr);
+  if (child.signal) process.kill(process.pid, child.signal);
+  else process.exitCode = child.status ?? 1;
 }
 `;
 
@@ -125,6 +139,7 @@ export function prepareAntigravityUsageCapture(env: Env, cwd?: string): Antigrav
     const capturePath = join(root, "usage.jsonl");
     const scriptPath = join(root, "capture.mjs");
     const statusCommandPath = join(root, "status-command");
+    const statusEnvironmentPath = join(root, "status-environment.json");
 
     for (const stateRoot of ["brain", "cache"]) {
       mkdirSync(join(realAppDir, stateRoot), { recursive: true, mode: 0o700 });
@@ -144,6 +159,16 @@ export function prepareAntigravityUsageCapture(env: Env, cwd?: string): Antigrav
 
     writeFileSync(capturePath, "", { mode: 0o600 });
     writeFileSync(statusCommandPath, originalCommand ?? "", { mode: 0o600 });
+    writeFileSync(
+      statusEnvironmentPath,
+      JSON.stringify({
+        HOME: env.HOME ?? null,
+        ANTIGRAVITY_HOME: env.ANTIGRAVITY_HOME ?? null,
+        AGY_HOME: env.AGY_HOME ?? null,
+        HEADLESS_ANTIGRAVITY_USAGE_FILE: env.HEADLESS_ANTIGRAVITY_USAGE_FILE ?? null,
+      }),
+      { mode: 0o600 },
+    );
     writeFileSync(scriptPath, captureScript, { mode: 0o700 });
     chmodSync(scriptPath, 0o700);
     writeFileSync(

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -34,7 +34,7 @@ export interface AntigravityUsageCapture {
 }
 
 const captureScript = `#!/usr/bin/env node
-import { appendFileSync, readFileSync } from "node:fs";
+import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -44,6 +44,7 @@ for await (const chunk of process.stdin) input += chunk;
 
 try {
   const value = JSON.parse(input);
+  const boundedString = (candidate) => typeof candidate === "string" ? candidate.slice(0, 1024) : "";
   const model = value?.model && typeof value.model === "object" ? value.model : {};
   const contextWindow = value?.context_window && typeof value.context_window === "object" ? value.context_window : {};
   const usage = contextWindow.current_usage && typeof contextWindow.current_usage === "object"
@@ -51,10 +52,10 @@ try {
     : {};
   const record = {
     type: "headless.antigravity.usage",
-    conversation_id: typeof value?.conversation_id === "string" ? value.conversation_id : "",
+    conversation_id: boundedString(value?.conversation_id),
     model: {
-      id: typeof model.id === "string" ? model.id : "",
-      display_name: typeof model.display_name === "string" ? model.display_name : "",
+      id: boundedString(model.id),
+      display_name: boundedString(model.display_name),
     },
     context_window: {
       current_usage: {
@@ -69,7 +70,14 @@ try {
       },
     },
   };
-  appendFileSync(process.env.HEADLESS_ANTIGRAVITY_USAGE_FILE, JSON.stringify(record) + "\\n", { mode: 0o600 });
+  const capturePath = process.env.HEADLESS_ANTIGRAVITY_USAGE_FILE;
+  const temporaryPath = capturePath + "." + process.pid + ".tmp";
+  try {
+    writeFileSync(temporaryPath, JSON.stringify(record) + "\\n", { mode: 0o600 });
+    renameSync(temporaryPath, capturePath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
 } catch {
   // Usage collection must never interfere with the agent run.
 }

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -34,8 +34,10 @@ export interface AntigravityUsageCapture {
 }
 
 const captureScript = `#!/usr/bin/env node
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 let input = "";
 for await (const chunk of process.stdin) input += chunk;
@@ -72,7 +74,12 @@ try {
   // Usage collection must never interfere with the agent run.
 }
 
-const originalCommand = process.env.HEADLESS_ANTIGRAVITY_STATUS_COMMAND;
+let originalCommand = "";
+try {
+  originalCommand = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "status-command"), "utf8");
+} catch {
+  // The user's status command is optional.
+}
 if (originalCommand) {
   const child = spawnSync("/bin/sh", ["-c", originalCommand], { input, encoding: "utf8" });
   if (child.stdout) process.stdout.write(child.stdout);
@@ -113,6 +120,11 @@ export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCaptur
     const overlayAppDir = join(overlayGeminiDir, "antigravity-cli");
     const capturePath = join(root, "usage.jsonl");
     const scriptPath = join(root, "capture.mjs");
+    const statusCommandPath = join(root, "status-command");
+
+    for (const stateRoot of ["brain", "cache"]) {
+      mkdirSync(join(realAppDir, stateRoot), { recursive: true, mode: 0o700 });
+    }
 
     linkChildren(realHome, overlayHome, new Set([".gemini"]));
     linkChildren(realGeminiDir, overlayGeminiDir, new Set(["antigravity-cli"]));
@@ -127,6 +139,7 @@ export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCaptur
         : undefined;
 
     writeFileSync(capturePath, "", { mode: 0o600 });
+    writeFileSync(statusCommandPath, originalCommand ?? "", { mode: 0o600 });
     writeFileSync(scriptPath, captureScript, { mode: 0o700 });
     chmodSync(scriptPath, 0o700);
     writeFileSync(
@@ -151,7 +164,7 @@ export function prepareAntigravityUsageCapture(env: Env): AntigravityUsageCaptur
       commandEnv: {
         HOME: overlayHome,
         HEADLESS_ANTIGRAVITY_USAGE_FILE: capturePath,
-        HEADLESS_ANTIGRAVITY_STATUS_COMMAND: originalCommand,
+        HEADLESS_ANTIGRAVITY_STATUS_COMMAND: undefined,
       },
       read: () => {
         try {

--- a/src/antigravity-usage.ts
+++ b/src/antigravity-usage.ts
@@ -128,6 +128,7 @@ function readSettings(path: string): AntigravitySettings {
 }
 
 export function prepareAntigravityUsageCapture(env: Env, cwd?: string): AntigravityUsageCapture | undefined {
+  if (process.platform === "win32") return undefined;
   if (!env.HOME) return undefined;
   const baseDir = cwd ?? process.cwd();
   const realHome = resolve(baseDir, env.HOME);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import {
   listAgents,
   waitTierForAgent,
 } from "./agents.js";
+import { prepareAntigravityUsageCapture, type AntigravityUsageCapture } from "./antigravity-usage.js";
 import { checkAgents, checkDocker, commandExists, commandForAgent, renderAgentChecks, renderDockerCheck } from "./check.js";
 import {
   BUILTIN_AGENT_DEFAULTS,
@@ -3531,6 +3532,22 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     statusReporter?.start();
     waitingSpinner?.start();
     let result: ExecuteResult | undefined;
+    let antigravityUsageTrace = "";
+    let antigravityUsageCapture: AntigravityUsageCapture | undefined;
+    if (parsed.agent === "antigravity" && parsed.usage && !parsed.docker && !parsed.modal) {
+      try {
+        antigravityUsageCapture = prepareAntigravityUsageCapture(env);
+        if (antigravityUsageCapture) {
+          command = {
+            ...command,
+            env: { ...(command.env ?? {}), ...antigravityUsageCapture.commandEnv },
+          };
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        displayStderr(`headless: could not prepare Antigravity usage capture: ${message}\n`);
+      }
+    }
     try {
       if (parsed.runId && parsed.role && nodeId) {
         updateNodeStatus(env, parsed.runId, nodeId, "busy");
@@ -3586,6 +3603,8 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     } finally {
       waitingSpinner?.stop();
       statusReporter?.stop();
+      antigravityUsageTrace = antigravityUsageCapture?.read() ?? "";
+      antigravityUsageCapture?.cleanup();
     }
     if (!result) {
       throw new CliError("agent execution did not produce a result");
@@ -3593,12 +3612,13 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (result.code === 0 && sessionPlan) {
       await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);
     }
+    const usageTrace = antigravityUsageTrace ? `${result.stdout}\n${antigravityUsageTrace}` : result.stdout;
     if (parsed.json) {
       if (parsed.usage) {
         if (result.stdout && !result.stdout.endsWith("\n")) {
           stdout("\n");
         }
-        stdout(await buildUsageOutput(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)));
+        stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
       }
       return result.code;
     }
@@ -3614,7 +3634,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         stdout(`${finalMessage}\n`);
       }
       if (parsed.usage) {
-        stdout(await buildUsageOutput(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)));
+        stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
       }
       return result.code;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import {
   listAgents,
   waitTierForAgent,
 } from "./agents.js";
+import { prepareAntigravityUsageCapture, type AntigravityUsageCapture } from "./antigravity-usage.js";
 import { checkAgents, checkDocker, commandExists, commandForAgent, renderAgentChecks, renderDockerCheck } from "./check.js";
 import {
   BUILTIN_AGENT_DEFAULTS,
@@ -3689,6 +3690,22 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     statusReporter?.start();
     waitingSpinner?.start();
     let result: ExecuteResult | undefined;
+    let antigravityUsageTrace = "";
+    let antigravityUsageCapture: AntigravityUsageCapture | undefined;
+    if (parsed.agent === "antigravity" && parsed.usage && !parsed.docker && !parsed.modal) {
+      try {
+        antigravityUsageCapture = prepareAntigravityUsageCapture(env);
+        if (antigravityUsageCapture) {
+          command = {
+            ...command,
+            env: { ...(command.env ?? {}), ...antigravityUsageCapture.commandEnv },
+          };
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        displayStderr(`headless: could not prepare Antigravity usage capture: ${message}\n`);
+      }
+    }
     try {
       if (parsed.runId && parsed.role && nodeId) {
         updateNodeStatus(env, parsed.runId, nodeId, "busy");
@@ -3731,66 +3748,71 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
             timeoutSeconds: commandTimeoutSeconds,
             captureRelevantTrace: parsed.json && (parsed.usage || Boolean(parsed.runId) || Boolean(parsed.sessionAlias)),
           });
-      if (parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
+      if (result && parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
         appendNodeLog(env, parsed.runId, nodeId, "stdout", result.stdout);
       }
+    } finally {
+      waitingSpinner?.stop();
+      antigravityUsageTrace = antigravityUsageCapture?.read() ?? "";
+      antigravityUsageCapture?.cleanup();
+    }
+    try {
+      if (!result) {
+        throw new CliError("agent execution did not produce a result");
+      }
+      const commandTrace = result.stdout || result.usageTrace || "";
+      const usageTrace = antigravityUsageTrace ? `${commandTrace}\n${antigravityUsageTrace}` : commandTrace;
+      if (result.code === 0 && sessionPlan) {
+        await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env);
+      }
       if (parsed.runId && parsed.role && nodeId) {
-        const commandTrace = result.stdout || result.usageTrace || "";
-        const finalMessage = extractFinalMessage(parsed.agent, commandTrace);
-        const metrics = extractRunNodeMetrics(parsed.agent, commandTrace, usageContext(parsed.agent, configuredDefaults, env));
+        const finalMessage = extractFinalMessage(parsed.agent, usageTrace);
+        const metrics = extractRunNodeMetrics(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env));
         updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined, metrics);
         if (result.code === 0 && parsed.role === "orchestrator" && finalMessage) {
           completeIdleRunNodes(env, parsed.runId, nodeId, finalMessage);
         }
       }
+      if (parsed.json) {
+        if (parsed.usage) {
+          const stdoutEndsWithNewline = result.stdoutEndsWithNewline ?? result.stdout.endsWith("\n");
+          const stdoutReceived = result.stdoutReceived ?? Boolean(result.stdout);
+          if (stdoutReceived && !stdoutEndsWithNewline) {
+            stdout("\n");
+          }
+          stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
+        }
+        return result.code;
+      }
+
+      const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
+      if (finalMessage) {
+        if (parsed.debug) {
+          if (!result.stdout.endsWith("\n")) {
+            stdout("\n");
+          }
+          stdout(`--- final message ---\n${finalMessage}\n`);
+        } else {
+          stdout(`${finalMessage}\n`);
+        }
+        if (parsed.usage) {
+          stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
+        }
+        return result.code;
+      }
+      const agentError = extractAgentError(parsed.agent, result.stdout);
+      if (agentError) {
+        stderr(`headless: ${agentError}\n`);
+        return result.code === 0 ? 1 : result.code;
+      }
+      if (result.code === 0) {
+        stderr("headless: could not extract final message; rerun with --json for raw trace\n");
+        return 1;
+      }
+      return result.code;
     } finally {
-      waitingSpinner?.stop();
       statusReporter?.stop();
     }
-    if (!result) {
-      throw new CliError("agent execution did not produce a result");
-    }
-    const commandTrace = result.stdout || result.usageTrace || "";
-    if (result.code === 0 && sessionPlan) {
-      await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env);
-    }
-    if (parsed.json) {
-      if (parsed.usage) {
-        const stdoutEndsWithNewline = result.stdoutEndsWithNewline ?? result.stdout.endsWith("\n");
-        const stdoutReceived = result.stdoutReceived ?? Boolean(result.stdout);
-        if (stdoutReceived && !stdoutEndsWithNewline) {
-          stdout("\n");
-        }
-        stdout(await buildUsageOutput(parsed.agent, commandTrace, usageContext(parsed.agent, configuredDefaults, env)));
-      }
-      return result.code;
-    }
-
-    const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
-    if (finalMessage) {
-      if (parsed.debug) {
-        if (!result.stdout.endsWith("\n")) {
-          stdout("\n");
-        }
-        stdout(`--- final message ---\n${finalMessage}\n`);
-      } else {
-        stdout(`${finalMessage}\n`);
-      }
-      if (parsed.usage) {
-        stdout(await buildUsageOutput(parsed.agent, commandTrace, usageContext(parsed.agent, configuredDefaults, env)));
-      }
-      return result.code;
-    }
-    const agentError = extractAgentError(parsed.agent, result.stdout);
-    if (agentError) {
-      stderr(`headless: ${agentError}\n`);
-      return result.code === 0 ? 1 : result.code;
-    }
-    if (result.code === 0) {
-      stderr("headless: could not extract final message; rerun with --json for raw trace\n");
-      return 1;
-    }
-    return result.code;
   } catch (error) {
     if (registeredRunNode) {
       try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ import {
   extractNativeSessionId,
   extractUsageSummary,
   fetchModelsDevPricing,
+  isAntigravityStructuredOutput,
   priceUsageSummary,
 } from "./output.js";
 import {
@@ -891,6 +892,7 @@ function selectDefaultAgent(env: Env, preferredAgent: AgentName | undefined): Ag
 interface ExecuteResult {
   code: number;
   stdout: string;
+  finalMessageTrace?: string;
   usageTrace?: string;
   stdoutReceived?: boolean;
   stdoutEndsWithNewline?: boolean;
@@ -1028,6 +1030,7 @@ interface ExecuteCommandOptions {
   stdoutLog?: (text: string) => void;
   stderr?: (text: string) => void;
   timeoutSeconds?: number;
+  captureFinalMessageTrace?: boolean;
   captureRelevantTrace?: boolean;
   cleanupBeforeParentSignalExit?: () => void;
 }
@@ -1398,6 +1401,16 @@ function suppressKnownStderr(agent: AgentName, text: string): string {
     .join("");
 }
 
+function boundedUtf8Tail(text: string, maxBytes: number): string {
+  const encoded = Buffer.from(text, "utf8");
+  if (encoded.byteLength <= maxBytes) return text;
+  let start = encoded.byteLength - maxBytes;
+  while (start < encoded.byteLength && (encoded[start] & 0xc0) === 0x80) {
+    start += 1;
+  }
+  return encoded.subarray(start).toString("utf8");
+}
+
 async function executeCommand(
   agent: AgentName,
   command: BuiltCommand,
@@ -1427,6 +1440,8 @@ async function executeCommand(
       let traceRowDiscarded = false;
       const relevantTrace: string[] = [];
       let relevantTraceBytes = 0;
+      const finalMessageTrace: string[] = [];
+      let finalMessageTraceBytes = 0;
       let pinnedIdentityTrace = "";
       let settled = false;
       let timeout: NodeJS.Timeout | undefined;
@@ -1437,6 +1452,7 @@ async function executeCommand(
       let removeParentSignalHandlers = () => {};
       const terminationGraceMs = 1000;
       const maxRelevantTraceBytes = 256 * 1024;
+      const maxFinalMessageTraceBytes = 64 * 1024;
       const maxCapturedTraceRowBytes = 4 * 1024 * 1024;
       const maxPinnedIdentityBytes = 16 * 1024;
       const relevantTracePattern =
@@ -1463,8 +1479,24 @@ async function executeCommand(
           relevantTraceBytes -= Buffer.byteLength(removed, "utf8");
         }
       };
+      const appendFinalMessageLine = (line: string) => {
+        let capturedLine = line;
+        let entryBytes = Buffer.byteLength(capturedLine, "utf8") + 1;
+        if (entryBytes > maxFinalMessageTraceBytes) {
+          if (isAntigravityStructuredOutput(capturedLine)) return;
+          capturedLine = boundedUtf8Tail(capturedLine, maxFinalMessageTraceBytes - 1);
+          entryBytes = Buffer.byteLength(capturedLine, "utf8") + 1;
+        }
+        const entry = `${capturedLine}\n`;
+        finalMessageTrace.push(entry);
+        finalMessageTraceBytes += entryBytes;
+        while (finalMessageTraceBytes > maxFinalMessageTraceBytes && finalMessageTrace.length > 1) {
+          const removed = finalMessageTrace.shift() ?? "";
+          finalMessageTraceBytes -= Buffer.byteLength(removed, "utf8");
+        }
+      };
       const captureRelevantChunk = (chunk: string) => {
-        if (!options.captureRelevantTrace) return;
+        if (!options.captureRelevantTrace && !options.captureFinalMessageTrace) return;
         const fragments = chunk.split("\n");
         for (let index = 0; index < fragments.length; index += 1) {
           if (!traceRowDiscarded) {
@@ -1477,15 +1509,22 @@ async function executeCommand(
           if (index < fragments.length - 1) {
             if (!traceRowDiscarded) {
               const line = traceBuffer.endsWith("\r") ? traceBuffer.slice(0, -1) : traceBuffer;
-              appendRelevantTrace(line);
+              if (options.captureRelevantTrace) appendRelevantTrace(line);
+              if (options.captureFinalMessageTrace) appendFinalMessageLine(line);
             }
             traceBuffer = "";
             traceRowDiscarded = false;
           }
         }
       };
+      const flushTraceBuffer = () => {
+        if (traceBuffer && !traceRowDiscarded) {
+          if (options.captureRelevantTrace) appendRelevantTrace(traceBuffer);
+          if (options.captureFinalMessageTrace) appendFinalMessageLine(traceBuffer);
+        }
+        traceBuffer = "";
+      };
       const readRelevantTrace = () => {
-        if (traceBuffer && !traceRowDiscarded) appendRelevantTrace(traceBuffer);
         const rollingTrace = relevantTrace.join("");
         return pinnedIdentityTrace && !rollingTrace.includes(pinnedIdentityTrace)
           ? `${pinnedIdentityTrace}${rollingTrace}`
@@ -1509,6 +1548,8 @@ async function executeCommand(
           clearTimeout(forceDrain);
         }
         removeParentSignalHandlers();
+        flushTraceBuffer();
+        result.finalMessageTrace = finalMessageTrace.join("") || undefined;
         result.usageTrace = readRelevantTrace() || undefined;
         result.stdoutReceived = stdoutReceived;
         result.stdoutEndsWithNewline = stdoutEndsWithNewline;
@@ -3786,6 +3827,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
               stdoutLog: commandStdoutLog,
               stderr: commandStderr,
               timeoutSeconds: commandTimeoutSeconds,
+              captureFinalMessageTrace: parsed.agent === "antigravity" && parsed.json && Boolean(parsed.runId),
               captureRelevantTrace: parsed.json && (parsed.usage || Boolean(parsed.runId) || Boolean(parsed.sessionAlias)),
               cleanupBeforeParentSignalExit: antigravityUsageCapture?.cleanup,
             });
@@ -3801,13 +3843,20 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       if (!result) {
         throw new CliError("agent execution did not produce a result");
       }
-      const commandTrace = result.stdout || result.usageTrace || "";
-      const usageTrace = antigravityUsageTrace ? `${commandTrace}\n${antigravityUsageTrace}` : commandTrace;
+      const commandTrace = result.stdout || result.finalMessageTrace || result.usageTrace || "";
+      const usageCommandTrace = result.stdout || result.usageTrace || result.finalMessageTrace || "";
+      const usageTrace = antigravityUsageTrace
+        ? `${usageCommandTrace}\n${antigravityUsageTrace}`
+        : usageCommandTrace;
       if (result.code === 0 && sessionPlan) {
         await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env);
       }
       if (parsed.runId && parsed.role && nodeId) {
-        const finalMessage = extractFinalMessage(parsed.agent, usageTrace);
+        const finalMessage =
+          extractFinalMessage(parsed.agent, commandTrace) ||
+          (result.usageTrace && result.usageTrace !== commandTrace
+            ? extractFinalMessage(parsed.agent, result.usageTrace)
+            : "");
         const metrics = extractRunNodeMetrics(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env));
         updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined, metrics);
         if (result.code === 0 && parsed.role === "orchestrator" && finalMessage) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -244,7 +244,7 @@ function usage(): string {
     "  --timeout <s>        One-shot command timeout in seconds.",
     "  --json               Stream raw agent JSON trace output.",
     "  --debug              Stream raw trace and print extracted final message.",
-    "  --usage              Print final message plus normalized token and cost JSON.",
+    "  --usage              Append normalized token and API-equivalent cost JSON.",
     "  --tmux               Launch an interactive agent in a tmux session.",
     "  --wait               With --tmux, wait for native transcript completion and print the final message.",
     "  --delete             With --tmux --wait, kill the tmux session after completion.",
@@ -927,7 +927,7 @@ function usageContext(agent: AgentName, defaults: InvocationDefaults, env: Env):
 
 async function buildUsageOutput(agent: AgentName, stdout: string, context: { provider?: string; model?: string }): Promise<string> {
   const summary = extractUsageSummary(agent, stdout, context);
-  if (summary.pricingStatus === "native") {
+  if (summary.usageStatus === "missing" || summary.pricingStatus === "native") {
     return `${JSON.stringify({ usage: priceUsageSummary(summary, {}) })}\n`;
   }
   try {
@@ -2521,9 +2521,6 @@ function validateCronAddCliOptions(parsed: ParsedArgs): void {
   if (parsed.docker && parsed.modal) {
     throw new CliError("--docker cannot be used with --modal");
   }
-  if (parsed.usage && parsed.json) {
-    throw new CliError("--usage cannot be used with --json");
-  }
   if (parsed.debug && parsed.json) {
     throw new CliError("--debug cannot be used with --json");
   }
@@ -3113,9 +3110,6 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.wait && parsed.printCommand) {
       throw new CliError("--wait cannot be used with --print-command");
     }
-    if (parsed.usage && parsed.json) {
-      throw new CliError("--usage cannot be used with --json");
-    }
     if (parsed.usage && parsed.tmux) {
       throw new CliError("--usage cannot be used with --tmux");
     }
@@ -3509,7 +3503,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
 
     const stdoutHandling: StdoutHandling = parsed.json
-      ? parsed.sessionAlias || parsed.runId
+      ? parsed.usage || parsed.sessionAlias || parsed.runId
         ? "capture-and-stream"
         : "stream"
       : parsed.debug
@@ -3600,6 +3594,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);
     }
     if (parsed.json) {
+      if (parsed.usage) {
+        if (result.stdout && !result.stdout.endsWith("\n")) {
+          stdout("\n");
+        }
+        stdout(await buildUsageOutput(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env)));
+      }
       return result.code;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -889,6 +889,9 @@ function selectDefaultAgent(env: Env, preferredAgent: AgentName | undefined): Ag
 interface ExecuteResult {
   code: number;
   stdout: string;
+  usageTrace?: string;
+  stdoutReceived?: boolean;
+  stdoutEndsWithNewline?: boolean;
 }
 
 function commandEnv(baseEnv: Env, command: BuiltCommand): Env {
@@ -1023,6 +1026,7 @@ interface ExecuteCommandOptions {
   stdoutLog?: (text: string) => void;
   stderr?: (text: string) => void;
   timeoutSeconds?: number;
+  captureRelevantTrace?: boolean;
 }
 
 interface WaitingSpinner {
@@ -1414,8 +1418,51 @@ async function executeCommand(
   try {
     return await new Promise<ExecuteResult>((resolve) => {
       let capturedStdout = "";
+      let stdoutReceived = false;
+      let stdoutEndsWithNewline = false;
+      let traceBuffer = "";
+      const relevantTrace: string[] = [];
+      let relevantTraceBytes = 0;
       let settled = false;
       let timeout: NodeJS.Timeout | undefined;
+      let termination: { code: number; signal: NodeJS.Signals } | undefined;
+      let forceKill: NodeJS.Timeout | undefined;
+      const maxRelevantTraceBytes = 256 * 1024;
+      const relevantTracePattern =
+        /"(?:usage|stats|tokens|context_window|num_turns|duration_ms|duration_api_ms|total_cost_usd|thread_id|session_id|sessionId|sessionID)"\s*:|"type"\s*:\s*"(?:thread\.started|turn\.completed|result|step_finish|message_end|agent_message|response_item|item\.completed|assistant|model|text)"|"role"\s*:\s*"assistant"/;
+      const appendRelevantTrace = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed || !relevantTracePattern.test(trimmed)) return;
+        const entry = `${trimmed}\n`;
+        const entryBytes = Buffer.byteLength(entry, "utf8");
+        if (entryBytes > maxRelevantTraceBytes) return;
+        relevantTrace.push(entry);
+        relevantTraceBytes += entryBytes;
+        while (relevantTraceBytes > maxRelevantTraceBytes && relevantTrace.length > 1) {
+          const removed = relevantTrace.shift() ?? "";
+          relevantTraceBytes -= Buffer.byteLength(removed, "utf8");
+        }
+      };
+      const captureRelevantChunk = (chunk: string) => {
+        if (!options.captureRelevantTrace) return;
+        traceBuffer += chunk;
+        if (Buffer.byteLength(traceBuffer, "utf8") > maxRelevantTraceBytes) {
+          traceBuffer = traceBuffer.slice(-maxRelevantTraceBytes);
+        }
+        const lines = traceBuffer.split(/\r?\n/);
+        traceBuffer = lines.pop() ?? "";
+        for (const line of lines) appendRelevantTrace(line);
+      };
+      const readRelevantTrace = () => {
+        if (traceBuffer) appendRelevantTrace(traceBuffer);
+        return relevantTrace.join("");
+      };
+      const signalExitCode = (signal: NodeJS.Signals): number => {
+        if (signal === "SIGINT") return 130;
+        if (signal === "SIGTERM") return 143;
+        return 1;
+      };
+      let removeSignalHandlers = () => {};
       const finish = (result: ExecuteResult) => {
         if (settled) {
           return;
@@ -1424,6 +1471,13 @@ async function executeCommand(
         if (timeout) {
           clearTimeout(timeout);
         }
+        if (forceKill) {
+          clearTimeout(forceKill);
+        }
+        removeSignalHandlers();
+        result.usageTrace = readRelevantTrace() || undefined;
+        result.stdoutReceived = stdoutReceived;
+        result.stdoutEndsWithNewline = stdoutEndsWithNewline;
         resolve(result);
       };
       const child = spawn(command.command, command.args, {
@@ -1432,14 +1486,30 @@ async function executeCommand(
         stdio,
       });
 
+      const terminateChild = (signal: NodeJS.Signals, code: number) => {
+        if (settled || termination) return;
+        termination = { code, signal };
+        child.kill(signal);
+        forceKill = setTimeout(() => {
+          if (!settled) child.kill("SIGKILL");
+        }, 1000);
+        forceKill.unref();
+      };
+      const onInterrupt = () => terminateChild("SIGINT", signalExitCode("SIGINT"));
+      const onTerminate = () => terminateChild("SIGTERM", signalExitCode("SIGTERM"));
+      process.once("SIGINT", onInterrupt);
+      process.once("SIGTERM", onTerminate);
+      removeSignalHandlers = () => {
+        process.removeListener("SIGINT", onInterrupt);
+        process.removeListener("SIGTERM", onTerminate);
+      };
+
       if (options.timeoutSeconds !== undefined) {
         timeout = setTimeout(() => {
           const message = `headless: command timed out after ${options.timeoutSeconds}s\n`;
           options.stderr?.(message);
           stderr(message);
-          child.kill("SIGTERM");
-          setTimeout(() => child.kill("SIGKILL"), 1000).unref();
-          finish({ code: 124, stdout: capturedStdout });
+          terminateChild("SIGTERM", 124);
         }, options.timeoutSeconds * 1000);
       }
       if (command.stdinText !== undefined) {
@@ -1447,6 +1517,9 @@ async function executeCommand(
       }
       child.stdout?.setEncoding("utf8");
       child.stdout?.on("data", (chunk: string) => {
+        stdoutReceived = true;
+        stdoutEndsWithNewline = chunk.endsWith("\n");
+        captureRelevantChunk(chunk);
         if (options.stdoutHandling !== "stream") {
           capturedStdout += chunk;
         }
@@ -1467,14 +1540,14 @@ async function executeCommand(
         const message = `${error.message}\n`;
         options.stderr?.(message);
         stderr(message);
-        finish({ code: 127, stdout: capturedStdout });
+        finish({ code: termination?.code ?? 127, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
       });
       child.on("close", (code, signal) => {
         if (signal) {
-          finish({ code: 1, stdout: capturedStdout });
+          finish({ code: termination?.code ?? 1, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
           return;
         }
-        finish({ code: code ?? 1, stdout: capturedStdout });
+        finish({ code: termination?.code ?? code ?? 1, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
       });
     });
   } finally {
@@ -3504,9 +3577,11 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
 
     const stdoutHandling: StdoutHandling = parsed.json
-      ? parsed.usage || parsed.sessionAlias || parsed.runId
-        ? "capture-and-stream"
-        : "stream"
+      ? parsed.usage
+        ? "stream"
+        : parsed.sessionAlias || parsed.runId
+          ? "capture-and-stream"
+          : "stream"
       : parsed.debug
         ? "capture-and-stream"
         : "capture";
@@ -3588,66 +3663,73 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
             stdoutLog: commandStdoutLog,
             stderr: commandStderr,
             timeoutSeconds: commandTimeoutSeconds,
+            captureRelevantTrace: parsed.json && (parsed.usage || Boolean(parsed.runId) || Boolean(parsed.sessionAlias)),
           });
-      if (parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
+      if (result && parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
         appendNodeLog(env, parsed.runId, nodeId, "stdout", result.stdout);
       }
+    } finally {
+      waitingSpinner?.stop();
+      antigravityUsageTrace = antigravityUsageCapture?.read() ?? "";
+      antigravityUsageCapture?.cleanup();
+    }
+    try {
+      if (!result) {
+        throw new CliError("agent execution did not produce a result");
+      }
+      const commandTrace = result.stdout || result.usageTrace || "";
+      const usageTrace = antigravityUsageTrace ? `${commandTrace}\n${antigravityUsageTrace}` : commandTrace;
+      if (result.code === 0 && sessionPlan) {
+        await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env);
+      }
       if (parsed.runId && parsed.role && nodeId) {
-        const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
-        const metrics = extractRunNodeMetrics(parsed.agent, result.stdout, usageContext(parsed.agent, configuredDefaults, env));
+        const finalMessage = extractFinalMessage(parsed.agent, usageTrace);
+        const metrics = extractRunNodeMetrics(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env));
         updateNodeStatus(env, parsed.runId, nodeId, result.code === 0 ? "idle" : "failed", finalMessage || undefined, metrics);
         if (result.code === 0 && parsed.role === "orchestrator" && finalMessage) {
           completeIdleRunNodes(env, parsed.runId, nodeId, finalMessage);
         }
       }
-    } finally {
-      waitingSpinner?.stop();
-      statusReporter?.stop();
-      antigravityUsageTrace = antigravityUsageCapture?.read() ?? "";
-      antigravityUsageCapture?.cleanup();
-    }
-    if (!result) {
-      throw new CliError("agent execution did not produce a result");
-    }
-    if (result.code === 0 && sessionPlan) {
-      await persistSessionPlan(parsed.agent, sessionPlan, result.stdout, cwd, env);
-    }
-    const usageTrace = antigravityUsageTrace ? `${result.stdout}\n${antigravityUsageTrace}` : result.stdout;
-    if (parsed.json) {
-      if (parsed.usage) {
-        if (result.stdout && !result.stdout.endsWith("\n")) {
-          stdout("\n");
+      if (parsed.json) {
+        if (parsed.usage) {
+          const stdoutEndsWithNewline = result.stdoutEndsWithNewline ?? result.stdout.endsWith("\n");
+          const stdoutReceived = result.stdoutReceived ?? Boolean(result.stdout);
+          if (stdoutReceived && !stdoutEndsWithNewline) {
+            stdout("\n");
+          }
+          stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
         }
-        stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
+        return result.code;
       }
-      return result.code;
-    }
 
-    const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
-    if (finalMessage) {
-      if (parsed.debug) {
-        if (!result.stdout.endsWith("\n")) {
-          stdout("\n");
+      const finalMessage = extractFinalMessage(parsed.agent, result.stdout);
+      if (finalMessage) {
+        if (parsed.debug) {
+          if (!result.stdout.endsWith("\n")) {
+            stdout("\n");
+          }
+          stdout(`--- final message ---\n${finalMessage}\n`);
+        } else {
+          stdout(`${finalMessage}\n`);
         }
-        stdout(`--- final message ---\n${finalMessage}\n`);
-      } else {
-        stdout(`${finalMessage}\n`);
+        if (parsed.usage) {
+          stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
+        }
+        return result.code;
       }
-      if (parsed.usage) {
-        stdout(await buildUsageOutput(parsed.agent, usageTrace, usageContext(parsed.agent, configuredDefaults, env)));
+      const agentError = extractAgentError(parsed.agent, result.stdout);
+      if (agentError) {
+        stderr(`headless: ${agentError}\n`);
+        return result.code === 0 ? 1 : result.code;
+      }
+      if (result.code === 0) {
+        stderr("headless: could not extract final message; rerun with --json for raw trace\n");
+        return 1;
       }
       return result.code;
+    } finally {
+      statusReporter?.stop();
     }
-    const agentError = extractAgentError(parsed.agent, result.stdout);
-    if (agentError) {
-      stderr(`headless: ${agentError}\n`);
-      return result.code === 0 ? 1 : result.code;
-    }
-    if (result.code === 0) {
-      stderr("headless: could not extract final message; rerun with --json for raw trace\n");
-      return 1;
-    }
-    return result.code;
   } catch (error) {
     if (registeredRunNode) {
       try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3774,7 +3774,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     let antigravityUsageCapture: AntigravityUsageCapture | undefined;
     if (parsed.agent === "antigravity" && parsed.usage && !parsed.docker && !parsed.modal) {
       try {
-        antigravityUsageCapture = prepareAntigravityUsageCapture(env);
+        antigravityUsageCapture = prepareAntigravityUsageCapture(env, cwd);
         if (antigravityUsageCapture) {
           command = {
             ...command,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1685,11 +1685,11 @@ async function executeCommand(
         finish({ code: termination?.code ?? 127, stdout: capturedStdout, stdoutReceived, stdoutEndsWithNewline });
       });
       child.on("exit", (code, signal) => {
-        if (options.cleanupBeforeParentSignalExit === undefined || options.timeoutSeconds !== undefined || settled) {
+        if (options.cleanupBeforeParentSignalExit === undefined || termination !== undefined || settled) {
           return;
         }
         forceDrain = setTimeout(() => {
-          if (settled) return;
+          if (settled || termination) return;
           signalChildTree("SIGKILL");
           child.stdout?.destroy();
           child.stderr?.destroy();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1703,6 +1703,9 @@ async function executeCommand(
         forceDrain.unref();
       });
       child.on("close", (code, signal) => {
+        if (ownsChildProcessGroup && options.cleanupBeforeParentSignalExit !== undefined) {
+          signalChildTree("SIGKILL");
+        }
         if (termination) {
           signalChildTree("SIGKILL");
         }

--- a/src/output.ts
+++ b/src/output.ts
@@ -16,6 +16,7 @@ const skippedItemTypes = new Set([
 const antigravityTraceTypes = new Set([
   "assistant response",
   "conversation history",
+  "headless.antigravity.usage",
   "planner response",
   "session meta",
   "system message",
@@ -228,6 +229,15 @@ function isAntigravityTraceValue(value: unknown): boolean {
   );
 }
 
+export function isAntigravityStructuredOutput(line: string): boolean {
+  try {
+    const value = JSON.parse(line) as unknown;
+    return collectCandidates(value, "antigravity").length > 0 || isAntigravityTraceValue(value);
+  } catch {
+    return false;
+  }
+}
+
 function flattenRecords(value: unknown): JsonRecord[] {
   if (Array.isArray(value)) {
     return value.flatMap((item) => flattenRecords(item));
@@ -283,14 +293,66 @@ function extractGeminiDeltaMessage(values: unknown[]): string {
   return latest.trim();
 }
 
-export function extractFinalMessage(agent: AgentName, stdout: string): string {
-  const values = parseJsonValues(stdout);
-  if (agent === "antigravity") {
-    const candidates = values.flatMap((value) => collectCandidates(value, agent));
-    if (candidates.length > 0) return candidates.at(-1)?.trim() ?? "";
-    return values.some(isAntigravityTraceValue) ? "" : stdout.trim();
+function extractAntigravityFinalMessage(stdout: string): string {
+  let latest = "";
+  let latestIsNativeResponse = false;
+  let sawNativeTrace = false;
+  let plainLines: string[] = [];
+  const finishPlainResponse = () => {
+    const response = plainLines.join("\n").trim();
+    if (response) {
+      latest = response;
+      latestIsNativeResponse = false;
+    }
+    plainLines = [];
+  };
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      if (plainLines.length > 0) plainLines.push("");
+      continue;
+    }
+
+    let value: unknown;
+    try {
+      value = JSON.parse(trimmed) as unknown;
+    } catch {
+      plainLines.push(line);
+      continue;
+    }
+
+    const candidates = collectCandidates(value, "antigravity");
+    if (candidates.length > 0) {
+      plainLines = [];
+      latest = candidates.at(-1)?.trim() ?? latest;
+      latestIsNativeResponse = true;
+      sawNativeTrace = true;
+      continue;
+    }
+    if (isAntigravityTraceValue(value)) {
+      if (sawNativeTrace) {
+        finishPlainResponse();
+      } else {
+        plainLines = [];
+        if (!latestIsNativeResponse) latest = "";
+      }
+      sawNativeTrace = true;
+      continue;
+    }
+    plainLines.push(line);
   }
 
+  finishPlainResponse();
+  return latest;
+}
+
+export function extractFinalMessage(agent: AgentName, stdout: string): string {
+  if (agent === "antigravity") {
+    return extractAntigravityFinalMessage(stdout);
+  }
+
+  const values = parseJsonValues(stdout);
   if (agent === "gemini") {
     const deltaMessage = extractGeminiDeltaMessage(values);
     if (deltaMessage) return deltaMessage;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -200,6 +200,64 @@ function extractProvider(records: JsonRecord[], context: { provider?: string; mo
   return defaultProvider(agent);
 }
 
+function antigravityPricingModel(model: string): { provider?: string; model?: string } {
+  const baseModel = model.replace(/\s+\((?:low|medium|high|thinking)\)$/i, "").trim();
+  const normalized = baseModel.toLowerCase();
+  if (normalized === "gemini 3.5 flash") return { provider: "google", model: "gemini-3.5-flash" };
+  if (normalized === "gemini 3.1 pro") return { provider: "google", model: "gemini-3.1-pro-preview" };
+  if (normalized === "claude sonnet 4.6") return { provider: "anthropic", model: "claude-sonnet-4-6" };
+  if (normalized === "claude opus 4.6") return { provider: "anthropic", model: "claude-opus-4-6" };
+  return {};
+}
+
+function extractAntigravityUsage(
+  records: JsonRecord[],
+  context: { provider?: string; model?: string },
+): UsageSummary | undefined {
+  const record = latestRecordWith(records, (item) => {
+    if (asString(item.type) !== "headless.antigravity.usage") return false;
+    const usage = asRecord(asRecord(item.context_window).current_usage);
+    return (
+      asNumber(usage.input_tokens) +
+        asNumber(usage.output_tokens) +
+        asNumber(usage.cache_creation_input_tokens) +
+        asNumber(usage.cache_read_input_tokens) >
+      0
+    );
+  });
+  if (!record) return undefined;
+
+  const usage = asRecord(asRecord(record.context_window).current_usage);
+  const statusModel = asRecord(record.model);
+  const model =
+    asString(statusModel.display_name).trim() || asString(statusModel.id).trim() || requestedProviderModel(context).model;
+  const pricingModel = antigravityPricingModel(model ?? "");
+  const inputTokens = asNumber(usage.input_tokens);
+  const cacheReadTokens = asNumber(usage.cache_read_input_tokens);
+  const cacheWriteTokens = asNumber(usage.cache_creation_input_tokens);
+  const outputTokens = asNumber(usage.output_tokens);
+
+  return summarizeUsage({
+    agent: "antigravity",
+    provider: pricingModel.provider,
+    model,
+    inputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    outputTokens,
+    modelBreakdowns: [
+      {
+        provider: pricingModel.provider,
+        model: pricingModel.model,
+        inputTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        outputTokens,
+      },
+    ],
+  });
+}
+
 function extractClaudeUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
   const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.usage)).length > 0);
   if (!record) return undefined;
@@ -358,17 +416,19 @@ export function extractUsageSummary(
 ): UsageSummary {
   const records = parseJsonValues(stdout).flatMap(flattenRecords);
   const summary =
-    agent === "claude"
-      ? extractClaudeUsage(records, context)
-      : agent === "codex"
-        ? extractCodexUsage(records, context)
-        : agent === "cursor"
-          ? extractCursorUsage(records, context)
-          : agent === "gemini"
-            ? extractGeminiUsage(records, context)
-            : agent === "opencode"
-              ? extractOpencodeUsage(records, context)
-              : extractPiUsage(records, context);
+    agent === "antigravity"
+      ? extractAntigravityUsage(records, context)
+      : agent === "claude"
+        ? extractClaudeUsage(records, context)
+        : agent === "codex"
+          ? extractCodexUsage(records, context)
+          : agent === "cursor"
+            ? extractCursorUsage(records, context)
+            : agent === "gemini"
+              ? extractGeminiUsage(records, context)
+              : agent === "opencode"
+                ? extractOpencodeUsage(records, context)
+                : extractPiUsage(records, context);
 
   return (
     summary ??

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -212,6 +212,64 @@ function extractProvider(records: JsonRecord[], context: { provider?: string; mo
   return defaultProvider(agent);
 }
 
+function antigravityPricingModel(model: string): { provider?: string; model?: string } {
+  const baseModel = model.replace(/\s+\((?:low|medium|high|thinking)\)$/i, "").trim();
+  const normalized = baseModel.toLowerCase();
+  if (normalized === "gemini 3.5 flash") return { provider: "google", model: "gemini-3.5-flash" };
+  if (normalized === "gemini 3.1 pro") return { provider: "google", model: "gemini-3.1-pro-preview" };
+  if (normalized === "claude sonnet 4.6") return { provider: "anthropic", model: "claude-sonnet-4-6" };
+  if (normalized === "claude opus 4.6") return { provider: "anthropic", model: "claude-opus-4-6" };
+  return {};
+}
+
+function extractAntigravityUsage(
+  records: JsonRecord[],
+  context: { provider?: string; model?: string },
+): UsageSummary | undefined {
+  const record = latestRecordWith(records, (item) => {
+    if (asString(item.type) !== "headless.antigravity.usage") return false;
+    const usage = asRecord(asRecord(item.context_window).current_usage);
+    return (
+      asNumber(usage.input_tokens) +
+        asNumber(usage.output_tokens) +
+        asNumber(usage.cache_creation_input_tokens) +
+        asNumber(usage.cache_read_input_tokens) >
+      0
+    );
+  });
+  if (!record) return undefined;
+
+  const usage = asRecord(asRecord(record.context_window).current_usage);
+  const statusModel = asRecord(record.model);
+  const model =
+    asString(statusModel.display_name).trim() || asString(statusModel.id).trim() || requestedProviderModel(context).model;
+  const pricingModel = antigravityPricingModel(model ?? "");
+  const inputTokens = asNumber(usage.input_tokens);
+  const cacheReadTokens = asNumber(usage.cache_read_input_tokens);
+  const cacheWriteTokens = asNumber(usage.cache_creation_input_tokens);
+  const outputTokens = asNumber(usage.output_tokens);
+
+  return summarizeUsage({
+    agent: "antigravity",
+    provider: pricingModel.provider,
+    model,
+    inputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    outputTokens,
+    modelBreakdowns: [
+      {
+        provider: pricingModel.provider,
+        model: pricingModel.model,
+        inputTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        outputTokens,
+      },
+    ],
+  });
+}
+
 function extractClaudeUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
   const record = latestRecordWith(records, (item) =>
     hasNumericField(asRecord(item.usage), [
@@ -400,17 +458,19 @@ export function extractUsageSummary(
 ): UsageSummary {
   const records = parseJsonValues(stdout).flatMap(flattenRecords);
   const summary =
-    agent === "claude"
-      ? extractClaudeUsage(records, context)
-      : agent === "codex"
-        ? extractCodexUsage(records, context)
-        : agent === "cursor"
-          ? extractCursorUsage(records, context)
-          : agent === "gemini"
-            ? extractGeminiUsage(records, context)
-            : agent === "opencode"
-              ? extractOpencodeUsage(records, context)
-              : extractPiUsage(records, context);
+    agent === "antigravity"
+      ? extractAntigravityUsage(records, context)
+      : agent === "claude"
+        ? extractClaudeUsage(records, context)
+        : agent === "codex"
+          ? extractCodexUsage(records, context)
+          : agent === "cursor"
+            ? extractCursorUsage(records, context)
+            : agent === "gemini"
+              ? extractGeminiUsage(records, context)
+              : agent === "opencode"
+                ? extractOpencodeUsage(records, context)
+                : extractPiUsage(records, context);
 
   return (
     summary ??

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -57,8 +57,20 @@ function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function asNumber(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return isNonNegativeFiniteNumber(value) ? value : 0;
+}
+
+function asOptionalNumber(value: unknown): number | undefined {
+  return isNonNegativeFiniteNumber(value) ? value : undefined;
+}
+
+function hasNumericField(record: JsonRecord, fields: readonly string[]): boolean {
+  return fields.some((field) => isNonNegativeFiniteNumber(record[field]));
 }
 
 function nonOverlappingInputTokens(inputTokens: number, cacheReadTokens: number, cacheWriteTokens = 0): number {
@@ -217,13 +229,12 @@ function extractAntigravityUsage(
   const record = latestRecordWith(records, (item) => {
     if (asString(item.type) !== "headless.antigravity.usage") return false;
     const usage = asRecord(asRecord(item.context_window).current_usage);
-    return (
-      asNumber(usage.input_tokens) +
-        asNumber(usage.output_tokens) +
-        asNumber(usage.cache_creation_input_tokens) +
-        asNumber(usage.cache_read_input_tokens) >
-      0
-    );
+    return hasNumericField(usage, [
+      "input_tokens",
+      "output_tokens",
+      "cache_creation_input_tokens",
+      "cache_read_input_tokens",
+    ]);
   });
   if (!record) return undefined;
 
@@ -259,11 +270,18 @@ function extractAntigravityUsage(
 }
 
 function extractClaudeUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(item.usage), [
+      "input_tokens",
+      "cache_read_input_tokens",
+      "cache_creation_input_tokens",
+      "output_tokens",
+    ]),
+  );
   if (!record) return undefined;
   const usage = asRecord(record.usage);
   const model = extractModel(records, context) ?? firstModelFromUsage(record);
-  const totalCost = asNumber(record.total_cost_usd);
+  const totalCost = asOptionalNumber(record.total_cost_usd);
   return summarizeUsage({
     agent: "claude",
     provider: "anthropic",
@@ -272,15 +290,22 @@ function extractClaudeUsage(records: JsonRecord[], context: { provider?: string;
     cacheReadTokens: asNumber(usage.cache_read_input_tokens),
     cacheWriteTokens: asNumber(usage.cache_creation_input_tokens),
     outputTokens: asNumber(usage.output_tokens),
-    cost: totalCost > 0 ? nativeCost(totalCost) : null,
-    costBasis: totalCost > 0 ? "native-reported" : null,
-    pricingSource: totalCost > 0 ? "native" : null,
-    pricingStatus: totalCost > 0 ? "native" : "missing",
+    cost: totalCost === undefined ? null : nativeCost(totalCost),
+    costBasis: totalCost === undefined ? null : "native-reported",
+    pricingSource: totalCost === undefined ? null : "native",
+    pricingStatus: totalCost === undefined ? "missing" : "native",
   });
 }
 
 function extractCodexUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(item.usage), [
+      "input_tokens",
+      "cached_input_tokens",
+      "output_tokens",
+      "reasoning_output_tokens",
+    ]),
+  );
   if (!record) return undefined;
   const usage = asRecord(record.usage);
   const requested = requestedProviderModel(context);
@@ -297,7 +322,9 @@ function extractCodexUsage(records: JsonRecord[], context: { provider?: string; 
 }
 
 function extractCursorUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(item.usage), ["inputTokens", "cacheReadTokens", "cacheWriteTokens", "outputTokens"]),
+  );
   if (!record) return undefined;
   const usage = asRecord(record.usage);
   return summarizeUsage({
@@ -312,13 +339,20 @@ function extractCursorUsage(records: JsonRecord[], context: { provider?: string;
 }
 
 function extractGeminiUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(item.stats)).length > 0);
+  const record = latestRecordWith(records, (item) => {
+    const stats = asRecord(item.stats);
+    if (hasNumericField(stats, ["input_tokens", "input", "cached", "output_tokens"])) return true;
+    return Object.values(asRecord(stats.models)).some((value) =>
+      hasNumericField(asRecord(value), ["input_tokens", "cached", "output_tokens"]),
+    );
+  });
   if (!record) return undefined;
   const stats = asRecord(record.stats);
   const models = asRecord(stats.models);
   const modelEntries = Object.entries(models)
-    .map(([model, value]) => {
+    .map(([model, value]): UsagePart | undefined => {
       const usage = asRecord(value);
+      if (!hasNumericField(usage, ["input_tokens", "cached", "output_tokens"])) return undefined;
       const cacheReadTokens = asNumber(usage.cached);
       return {
         provider: "google",
@@ -329,7 +363,7 @@ function extractGeminiUsage(records: JsonRecord[], context: { provider?: string;
         outputTokens: asNumber(usage.output_tokens),
       };
     })
-    .filter((part) => part.inputTokens + part.cacheReadTokens + part.outputTokens > 0);
+    .filter((part): part is UsagePart => part !== undefined);
 
   if (modelEntries.length > 0) {
     return summarizeUsage({
@@ -343,6 +377,7 @@ function extractGeminiUsage(records: JsonRecord[], context: { provider?: string;
     });
   }
 
+  if (!hasNumericField(stats, ["input_tokens", "input", "cached", "output_tokens"])) return undefined;
   const cacheReadTokens = asNumber(stats.cached);
   return summarizeUsage({
     agent: "gemini",
@@ -355,13 +390,17 @@ function extractGeminiUsage(records: JsonRecord[], context: { provider?: string;
 }
 
 function extractOpencodeUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(asRecord(item.part).tokens)).length > 0);
+  const record = latestRecordWith(records, (item) => {
+    const tokens = asRecord(asRecord(item.part).tokens);
+    const cache = asRecord(tokens.cache);
+    return hasNumericField(tokens, ["input", "output", "reasoning"]) || hasNumericField(cache, ["read", "write"]);
+  });
   if (!record) return undefined;
   const part = asRecord(record.part);
   const tokens = asRecord(part.tokens);
   const cache = asRecord(tokens.cache);
   const requested = requestedProviderModel(context);
-  const totalCost = asNumber(part.cost);
+  const totalCost = asOptionalNumber(part.cost);
   return summarizeUsage({
     agent: "opencode",
     provider: requested.provider,
@@ -372,20 +411,22 @@ function extractOpencodeUsage(records: JsonRecord[], context: { provider?: strin
     outputTokens: asNumber(tokens.output),
     reasoningOutputTokens: asNumber(tokens.reasoning),
     reasoningOutputIncludedInOutput: false,
-    cost: totalCost > 0 ? nativeCost(totalCost) : null,
-    costBasis: totalCost > 0 ? "native-reported" : null,
-    pricingSource: totalCost > 0 ? "native" : null,
-    pricingStatus: totalCost > 0 ? "native" : "missing",
+    cost: totalCost === undefined ? null : nativeCost(totalCost),
+    costBasis: totalCost === undefined ? null : "native-reported",
+    pricingSource: totalCost === undefined ? null : "native",
+    pricingStatus: totalCost === undefined ? "missing" : "native",
   });
 }
 
 function extractPiUsage(records: JsonRecord[], context: { provider?: string; model?: string }): UsageSummary | undefined {
-  const record = latestRecordWith(records, (item) => Object.keys(asRecord(asRecord(item.message).usage)).length > 0);
+  const record = latestRecordWith(records, (item) =>
+    hasNumericField(asRecord(asRecord(item.message).usage), ["input", "cacheRead", "cacheWrite", "output"]),
+  );
   if (!record) return undefined;
   const message = asRecord(record.message);
   const usage = asRecord(message.usage);
   const cost = asRecord(usage.cost);
-  const totalCost = asNumber(cost.total);
+  const totalCost = asOptionalNumber(cost.total);
   return summarizeUsage({
     agent: "pi",
     provider: asString(message.provider).trim() || extractProvider(records, context, "pi"),
@@ -395,17 +436,17 @@ function extractPiUsage(records: JsonRecord[], context: { provider?: string; mod
     cacheWriteTokens: asNumber(usage.cacheWrite),
     outputTokens: asNumber(usage.output),
     cost:
-      totalCost > 0
-        ? nativeCost(totalCost, {
-            input: asNumber(cost.input),
-            cacheRead: asNumber(cost.cacheRead),
-            cacheWrite: asNumber(cost.cacheWrite),
-            output: asNumber(cost.output),
-          })
-        : null,
-    costBasis: totalCost > 0 ? "native-reported" : null,
-    pricingSource: totalCost > 0 ? "native" : null,
-    pricingStatus: totalCost > 0 ? "native" : "missing",
+      totalCost === undefined
+        ? null
+        : nativeCost(totalCost, {
+            input: asOptionalNumber(cost.input),
+            cacheRead: asOptionalNumber(cost.cacheRead),
+            cacheWrite: asOptionalNumber(cost.cacheWrite),
+            output: asOptionalNumber(cost.output),
+          }),
+    costBasis: totalCost === undefined ? null : "native-reported",
+    pricingSource: totalCost === undefined ? null : "native",
+    pricingStatus: totalCost === undefined ? "missing" : "native",
   });
 }
 

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -41,7 +41,9 @@ export interface UsageSummary {
   outputTokens: number;
   reasoningOutputTokens: number;
   totalTokens: number;
+  usageStatus: "reported" | "missing";
   cost: UsageCostBreakdown | null;
+  costBasis: "native-reported" | "api-list-price-estimate" | null;
   pricingSource: "native" | "models.dev" | null;
   pricingStatus: "native" | "priced" | "missing";
   modelBreakdowns?: UsagePart[];
@@ -136,7 +138,9 @@ function summarizeUsage(options: {
   cacheWriteTokens?: number;
   outputTokens: number;
   reasoningOutputTokens?: number;
+  usageStatus?: UsageSummary["usageStatus"];
   cost?: UsageCostBreakdown | null;
+  costBasis?: UsageSummary["costBasis"];
   pricingSource?: UsageSummary["pricingSource"];
   pricingStatus?: UsageSummary["pricingStatus"];
   reasoningOutputIncludedInOutput?: boolean;
@@ -157,7 +161,9 @@ function summarizeUsage(options: {
     outputTokens: options.outputTokens,
     reasoningOutputTokens,
     totalTokens,
+    usageStatus: options.usageStatus ?? "reported",
     cost: options.cost ?? null,
+    costBasis: options.costBasis ?? null,
     pricingSource: options.pricingSource ?? null,
     pricingStatus: options.pricingStatus ?? "missing",
     ...(options.modelBreakdowns ? { modelBreakdowns: options.modelBreakdowns } : {}),
@@ -209,6 +215,7 @@ function extractClaudeUsage(records: JsonRecord[], context: { provider?: string;
     cacheWriteTokens: asNumber(usage.cache_creation_input_tokens),
     outputTokens: asNumber(usage.output_tokens),
     cost: totalCost > 0 ? nativeCost(totalCost) : null,
+    costBasis: totalCost > 0 ? "native-reported" : null,
     pricingSource: totalCost > 0 ? "native" : null,
     pricingStatus: totalCost > 0 ? "native" : "missing",
   });
@@ -308,6 +315,7 @@ function extractOpencodeUsage(records: JsonRecord[], context: { provider?: strin
     reasoningOutputTokens: asNumber(tokens.reasoning),
     reasoningOutputIncludedInOutput: false,
     cost: totalCost > 0 ? nativeCost(totalCost) : null,
+    costBasis: totalCost > 0 ? "native-reported" : null,
     pricingSource: totalCost > 0 ? "native" : null,
     pricingStatus: totalCost > 0 ? "native" : "missing",
   });
@@ -337,6 +345,7 @@ function extractPiUsage(records: JsonRecord[], context: { provider?: string; mod
             output: asNumber(cost.output),
           })
         : null,
+    costBasis: totalCost > 0 ? "native-reported" : null,
     pricingSource: totalCost > 0 ? "native" : null,
     pricingStatus: totalCost > 0 ? "native" : "missing",
   });
@@ -369,6 +378,7 @@ export function extractUsageSummary(
       model: extractModel(records, context),
       inputTokens: 0,
       outputTokens: 0,
+      usageStatus: "missing",
     })
   );
 }
@@ -455,6 +465,9 @@ function priceUsagePart(part: UsagePart, pricingData: PricingData): UsageCostBre
 
 export function priceUsageSummary(summary: UsageSummary, pricingData: PricingData): UsageSummary {
   const { modelBreakdowns: _modelBreakdowns, ...publicSummary } = summary;
+  if (summary.usageStatus === "missing") {
+    return { ...publicSummary, cost: null, costBasis: null, pricingSource: null, pricingStatus: "missing" };
+  }
   if (summary.pricingStatus === "native") {
     return publicSummary;
   }
@@ -473,13 +486,19 @@ export function priceUsageSummary(summary: UsageSummary, pricingData: PricingDat
     ];
   const pricedParts = parts.map((part) => priceUsagePart(part, pricingData));
   if (pricedParts.some((part) => part === undefined)) {
-    return { ...publicSummary, cost: null, pricingSource: null, pricingStatus: "missing" };
+    return { ...publicSummary, cost: null, costBasis: null, pricingSource: null, pricingStatus: "missing" };
   }
   const cost = (pricedParts as UsageCostBreakdown[]).reduce(
     (sum, part) => addCost(sum, part),
     { input: 0, cacheRead: 0, cacheWrite: 0, output: 0, total: 0 },
   );
-  return { ...publicSummary, cost, pricingSource: "models.dev", pricingStatus: "priced" };
+  return {
+    ...publicSummary,
+    cost,
+    costBasis: "api-list-price-estimate",
+    pricingSource: "models.dev",
+    pricingStatus: "priced",
+  };
 }
 
 export async function fetchModelsDevPricing(): Promise<PricingData> {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -229,13 +229,12 @@ function extractAntigravityUsage(
   const record = latestRecordWith(records, (item) => {
     if (asString(item.type) !== "headless.antigravity.usage") return false;
     const usage = asRecord(asRecord(item.context_window).current_usage);
-    return (
-      asNumber(usage.input_tokens) +
-        asNumber(usage.output_tokens) +
-        asNumber(usage.cache_creation_input_tokens) +
-        asNumber(usage.cache_read_input_tokens) >
-      0
-    );
+    return hasNumericField(usage, [
+      "input_tokens",
+      "output_tokens",
+      "cache_creation_input_tokens",
+      "cache_read_input_tokens",
+    ]);
   });
   if (!record) return undefined;
 

--- a/tests/antigravity-usage.test.ts
+++ b/tests/antigravity-usage.test.ts
@@ -273,8 +273,8 @@ test("Antigravity usage capture preserves original status command signals", () =
       input: "{}",
     });
 
-    assert.equal(status.status, null);
-    assert.equal(status.signal, "SIGTERM");
+    const terminatedBySigterm = status.signal === "SIGTERM" || status.status === 128 + 15;
+    assert.equal(terminatedBySigterm, true);
     assert.equal(capture.read().trim().length > 0, true);
     capture.cleanup();
   } finally {

--- a/tests/antigravity-usage.test.ts
+++ b/tests/antigravity-usage.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import test from "node:test";
 
 import { prepareAntigravityUsageCapture } from "../src/antigravity-usage.ts";
@@ -132,6 +132,58 @@ test("Antigravity capture preserves state created by a fresh profile and hides t
     writeFileSync(createdState, "persisted\n");
     capture.cleanup();
     assert.equal(readFileSync(join(home, ".gemini", "antigravity-cli", "brain", "conversation.json"), "utf8"), "persisted\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Antigravity usage capture honors configured profile roots", () => {
+  for (const variable of ["ANTIGRAVITY_HOME", "AGY_HOME"] as const) {
+    const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-profile-test-"));
+    try {
+      const home = join(dir, "home");
+      const workDir = join(dir, "work");
+      const appDir = variable === "AGY_HOME" ? join(workDir, "custom-profile") : join(dir, "custom-profile");
+      const configuredAppDir = variable === "AGY_HOME" ? relative(workDir, appDir) : appDir;
+      mkdirSync(join(appDir, "brain"), { recursive: true });
+      writeFileSync(join(appDir, "settings.json"), `${JSON.stringify({ enableTelemetry: false })}\n`);
+
+      const capture = prepareAntigravityUsageCapture({ HOME: home, [variable]: configuredAppDir }, workDir);
+      assert.ok(capture);
+      const overlayAppDir = capture.commandEnv[variable] ?? "";
+      assert.notEqual(overlayAppDir, appDir);
+      assert.equal(realpathSync(join(overlayAppDir, "brain")), realpathSync(join(appDir, "brain")));
+      assert.equal(
+        JSON.parse(readFileSync(join(overlayAppDir, "settings.json"), "utf8")).statusLine.enabled,
+        true,
+      );
+
+      capture.cleanup();
+      assert.equal(existsSync(overlayAppDir), false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+test("Antigravity usage capture ignores empty preferred profile roots", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-empty-profile-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(dir, "legacy-profile");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(join(appDir, "settings.json"), "{}\n");
+
+    const capture = prepareAntigravityUsageCapture({
+      HOME: home,
+      ANTIGRAVITY_HOME: " ",
+      AGY_HOME: appDir,
+    });
+    assert.ok(capture);
+    assert.equal(realpathSync(capture.commandEnv.AGY_HOME ?? ""), realpathSync(capture.commandEnv.ANTIGRAVITY_HOME ?? ""));
+    assert.equal(existsSync(join(process.cwd(), "brain")), false);
+    assert.equal(existsSync(join(process.cwd(), "cache")), false);
+    capture.cleanup();
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/antigravity-usage.test.ts
+++ b/tests/antigravity-usage.test.ts
@@ -90,3 +90,49 @@ test("Antigravity usage capture overlays settings and preserves the real home", 
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("Antigravity capture preserves state created by a fresh profile and hides the original command env", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-fresh-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({ statusLine: { type: "command", command: "printf original", enabled: true } })}\n`,
+    );
+
+    const capture = prepareAntigravityUsageCapture({
+      HOME: home,
+      HEADLESS_ANTIGRAVITY_STATUS_COMMAND: "secret-from-agent-env",
+    });
+    assert.ok(capture);
+    const overlayHome = capture.commandEnv.HOME ?? "";
+    for (const stateRoot of ["brain", "cache"]) {
+      assert.equal(existsSync(join(home, ".gemini", "antigravity-cli", stateRoot)), true);
+      assert.equal(
+        realpathSync(join(overlayHome, ".gemini", "antigravity-cli", stateRoot)),
+        realpathSync(join(home, ".gemini", "antigravity-cli", stateRoot)),
+      );
+    }
+    assert.equal(capture.commandEnv.HEADLESS_ANTIGRAVITY_STATUS_COMMAND, undefined);
+
+    const overlaySettings = JSON.parse(
+      readFileSync(join(overlayHome, ".gemini", "antigravity-cli", "settings.json"), "utf8"),
+    );
+    const status = spawnSync("/bin/sh", ["-c", overlaySettings.statusLine.command], {
+      encoding: "utf8",
+      env: { ...process.env, HEADLESS_ANTIGRAVITY_STATUS_COMMAND: "secret-from-agent-env", ...capture.commandEnv },
+      input: "{}",
+    });
+    assert.equal(status.status, 0);
+    assert.equal(status.stdout, "original");
+
+    const createdState = join(overlayHome, ".gemini", "antigravity-cli", "brain", "conversation.json");
+    writeFileSync(createdState, "persisted\n");
+    capture.cleanup();
+    assert.equal(readFileSync(join(home, ".gemini", "antigravity-cli", "brain", "conversation.json"), "utf8"), "persisted\n");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/antigravity-usage.test.ts
+++ b/tests/antigravity-usage.test.ts
@@ -261,3 +261,73 @@ test("Antigravity usage capture preserves original status command signals", () =
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("Antigravity usage capture keeps only one bounded latest record", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-bounded-capture-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(join(appDir, "settings.json"), "{}\n");
+    const capture = prepareAntigravityUsageCapture({ HOME: home });
+    assert.ok(capture);
+    const overlaySettings = JSON.parse(
+      readFileSync(join(capture.commandEnv.HOME ?? "", ".gemini", "antigravity-cli", "settings.json"), "utf8"),
+    );
+
+    for (const index of [1, 2, 3]) {
+      const status = spawnSync("/bin/sh", ["-c", overlaySettings.statusLine.command], {
+        encoding: "utf8",
+        env: { ...process.env, ...capture.commandEnv },
+        input: JSON.stringify({
+          conversation_id: `conversation-${index}`,
+          model: { id: index === 3 ? "x".repeat(100_000) : `model-${index}` },
+          context_window: { current_usage: { input_tokens: index } },
+        }),
+      });
+      assert.equal(status.status, 0);
+    }
+
+    const content = capture.read();
+    const records = content
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.equal(records.length, 1);
+    assert.equal(records[0].conversation_id, "conversation-3");
+    assert.equal(Buffer.byteLength(content, "utf8") < 64 * 1024, true);
+    capture.cleanup();
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Antigravity usage capture removes temporary files after replacement failures", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-capture-failure-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(join(appDir, "settings.json"), "{}\n");
+    const capture = prepareAntigravityUsageCapture({ HOME: home });
+    assert.ok(capture);
+    const overlaySettings = JSON.parse(
+      readFileSync(join(capture.commandEnv.HOME ?? "", ".gemini", "antigravity-cli", "settings.json"), "utf8"),
+    );
+    const capturePath = capture.commandEnv.HEADLESS_ANTIGRAVITY_USAGE_FILE ?? "";
+    rmSync(capturePath);
+    mkdirSync(capturePath);
+
+    const status = spawnSync("/bin/sh", ["-c", overlaySettings.statusLine.command], {
+      encoding: "utf8",
+      env: { ...process.env, ...capture.commandEnv },
+      input: "{}",
+    });
+
+    assert.equal(status.status, 0);
+    assert.equal(existsSync(`${capturePath}.${status.pid}.tmp`), false);
+    capture.cleanup();
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/antigravity-usage.test.ts
+++ b/tests/antigravity-usage.test.ts
@@ -189,6 +189,26 @@ test("Antigravity usage capture ignores empty preferred profile roots", () => {
   }
 });
 
+test("Antigravity usage capture preserves whitespace in non-empty profile roots", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-spaced-profile-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(dir, "profile ");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(join(appDir, "settings.json"), "{}\n");
+
+    const capture = prepareAntigravityUsageCapture({ HOME: home, ANTIGRAVITY_HOME: appDir });
+    assert.ok(capture);
+    assert.equal(
+      realpathSync(join(capture.commandEnv.ANTIGRAVITY_HOME ?? "", "brain")),
+      realpathSync(join(appDir, "brain")),
+    );
+    capture.cleanup();
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("Antigravity usage capture preserves the original status command environment and exit code", () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-status-command-test-"));
   try {

--- a/tests/antigravity-usage.test.ts
+++ b/tests/antigravity-usage.test.ts
@@ -188,3 +188,76 @@ test("Antigravity usage capture ignores empty preferred profile roots", () => {
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("Antigravity usage capture preserves the original status command environment and exit code", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-status-command-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(dir, "profile");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({
+        statusLine: {
+          type: "command",
+          command: "printf '%s|%s|%s' \"$HOME\" \"$ANTIGRAVITY_HOME\" \"$AGY_HOME\"; exit 23",
+          enabled: true,
+        },
+      })}\n`,
+    );
+    const originalEnv = {
+      HOME: home,
+      ANTIGRAVITY_HOME: appDir,
+      AGY_HOME: appDir,
+    };
+    const capture = prepareAntigravityUsageCapture(originalEnv);
+    assert.ok(capture);
+    const overlaySettings = JSON.parse(
+      readFileSync(join(capture.commandEnv.ANTIGRAVITY_HOME ?? "", "settings.json"), "utf8"),
+    );
+    const status = spawnSync("/bin/sh", ["-c", overlaySettings.statusLine.command], {
+      encoding: "utf8",
+      env: { ...process.env, ...originalEnv, ...capture.commandEnv },
+      input: "{}",
+    });
+
+    assert.equal(status.status, 23);
+    assert.equal(status.stdout, `${home}|${appDir}|${appDir}`);
+    assert.equal(capture.read().trim().length > 0, true);
+    capture.cleanup();
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Antigravity usage capture preserves original status command signals", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-status-signal-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({
+        statusLine: { type: "command", command: "kill -TERM $$", enabled: true },
+      })}\n`,
+    );
+    const capture = prepareAntigravityUsageCapture({ HOME: home });
+    assert.ok(capture);
+    const overlaySettings = JSON.parse(
+      readFileSync(join(capture.commandEnv.HOME ?? "", ".gemini", "antigravity-cli", "settings.json"), "utf8"),
+    );
+    const status = spawnSync("/bin/sh", ["-c", overlaySettings.statusLine.command], {
+      encoding: "utf8",
+      env: { ...process.env, ...capture.commandEnv },
+      input: "{}",
+    });
+
+    assert.equal(status.status, null);
+    assert.equal(status.signal, "SIGTERM");
+    assert.equal(capture.read().trim().length > 0, true);
+    capture.cleanup();
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/antigravity-usage.test.ts
+++ b/tests/antigravity-usage.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { prepareAntigravityUsageCapture } from "../src/antigravity-usage.ts";
+
+test("Antigravity usage capture overlays settings and preserves the real home", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-antigravity-capture-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    mkdirSync(join(home, ".gemini", "config"), { recursive: true });
+    mkdirSync(join(appDir, "brain"), { recursive: true });
+    writeFileSync(join(home, ".gitconfig"), "[user]\n\tname = Test\n");
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({
+        enableTelemetry: false,
+        statusLine: { type: "command", command: "printf original", enabled: true },
+      })}\n`,
+    );
+
+    const capture = prepareAntigravityUsageCapture({ HOME: home });
+    assert.ok(capture);
+    const overlayHome = capture.commandEnv.HOME ?? "";
+    assert.notEqual(overlayHome, home);
+    assert.equal(realpathSync(join(overlayHome, ".gitconfig")), realpathSync(join(home, ".gitconfig")));
+    assert.equal(
+      realpathSync(join(overlayHome, ".gemini", "antigravity-cli", "brain")),
+      realpathSync(join(appDir, "brain")),
+    );
+
+    const overlaySettings = JSON.parse(
+      readFileSync(join(overlayHome, ".gemini", "antigravity-cli", "settings.json"), "utf8"),
+    );
+    const payload = {
+      email: "private@example.com",
+      plan_tier: "Pro",
+      conversation_id: "conversation-1",
+      model: { id: "Gemini 3.5 Flash (Low)", display_name: "Gemini 3.5 Flash (Low)" },
+      context_window: {
+        current_usage: {
+          input_tokens: 100,
+          output_tokens: 5,
+          cache_creation_input_tokens: 10,
+          cache_read_input_tokens: 20,
+        },
+      },
+    };
+    const status = spawnSync("/bin/sh", ["-c", overlaySettings.statusLine.command], {
+      encoding: "utf8",
+      env: { ...process.env, ...capture.commandEnv },
+      input: JSON.stringify(payload),
+    });
+
+    assert.equal(status.status, 0);
+    assert.equal(status.stdout, "original");
+    const records = capture
+      .read()
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(records, [
+      {
+        type: "headless.antigravity.usage",
+        conversation_id: "conversation-1",
+        model: { id: "Gemini 3.5 Flash (Low)", display_name: "Gemini 3.5 Flash (Low)" },
+        context_window: {
+          current_usage: {
+            input_tokens: 100,
+            output_tokens: 5,
+            cache_creation_input_tokens: 10,
+            cache_read_input_tokens: 20,
+          },
+        },
+      },
+    ]);
+    assert.doesNotMatch(capture.read(), /private@example\.com|plan_tier/);
+    assert.deepEqual(JSON.parse(readFileSync(join(appDir, "settings.json"), "utf8")), {
+      enableTelemetry: false,
+      statusLine: { type: "command", command: "printf original", enabled: true },
+    });
+
+    capture.cleanup();
+    assert.equal(existsSync(overlayHome), false);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -125,6 +125,7 @@ test("cron add persists safe detached command options and rejects unsafe tmux/se
         "read-only",
         "--work-dir",
         dir,
+        "--json",
         "--usage",
       ],
       {
@@ -152,6 +153,7 @@ test("cron add persists safe detached command options and rejects unsafe tmux/se
       "read-only",
       "--work-dir",
       dir,
+      "--json",
       "--usage",
     ]);
 
@@ -173,15 +175,6 @@ test("cron add persists safe detached command options and rejects unsafe tmux/se
     );
     assert.match(stderr, /require --docker/);
 
-    stderr = "";
-    assert.equal(
-      await runCli(
-        ["cron", "add", "codex", "--every", "1h", "--prompt", "x", "--json", "--usage"],
-        { env, stderr: (text) => { stderr += text; } },
-      ),
-      2,
-    );
-    assert.match(stderr, /--usage cannot be used with --json/);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2438,6 +2438,7 @@ test("CLI --usage prints final message and normalized usage JSON", async () => {
         outputTokens: 100,
         reasoningOutputTokens: 0,
         totalTokens: 1100,
+        usageStatus: "reported",
         cost: {
           input: 0.00075,
           cacheRead: 0.00005,
@@ -2445,10 +2446,116 @@ test("CLI --usage prints final message and normalized usage JSON", async () => {
           output: 0.001,
           total: 0.0018,
         },
+        costBasis: "api-list-price-estimate",
         pricingSource: "models.dev",
         pricingStatus: "priced",
       },
     });
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --json --usage streams raw trace and appends usage without requiring a final message", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    const firstRecord = { type: "thread.started", thread_id: "thread-1" };
+    const usageRecord = {
+      type: "turn.completed",
+      usage: { input_tokens: 1000, cached_input_tokens: 400, output_tokens: 100 },
+    };
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          `console.log(${JSON.stringify(JSON.stringify(firstRecord))});`,
+          `setTimeout(() => console.log(${JSON.stringify(JSON.stringify(usageRecord))}), 150);`,
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          openai: {
+            models: {
+              "gpt-5": { cost: { input: 1.25, cache_read: 0.125, output: 10 } },
+            },
+          },
+        }),
+      );
+
+    const stdout: string[] = [];
+    let completed = false;
+    const result = runCli(["codex", "--model", "gpt-5", "--prompt", "hello", "--json", "--usage"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    }).finally(() => {
+      completed = true;
+    });
+
+    await waitFor(() => stdout.join("").startsWith(`${JSON.stringify(firstRecord)}\n`) && !completed);
+    assert.equal(completed, false);
+    assert.equal(await result, 0);
+
+    const lines = stdout.join("").trim().split("\n");
+    assert.deepEqual(JSON.parse(lines[0] ?? ""), firstRecord);
+    assert.deepEqual(JSON.parse(lines[1] ?? ""), usageRecord);
+    const usage = JSON.parse(lines[2] ?? "").usage;
+    assert.equal(usage.inputTokens, 600);
+    assert.equal(usage.cacheReadTokens, 400);
+    assert.equal(usage.outputTokens, 100);
+    assert.equal(usage.usageStatus, "reported");
+    assert.equal(usage.cost.total, 0.0018);
+    assert.equal(usage.costBasis, "api-list-price-estimate");
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --json --usage appends partial usage and preserves a nonzero agent status", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } }));",
+          "process.exitCode = 7;",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 7);
+    const lines = stdout.join("").trim().split("\n");
+    assert.equal(JSON.parse(lines[0] ?? "").type, "turn.completed");
+    const usage = JSON.parse(lines[1] ?? "").usage;
+    assert.equal(usage.totalTokens, 12);
+    assert.equal(usage.usageStatus, "reported");
+    assert.equal(usage.cost, null);
+    assert.equal(usage.costBasis, null);
   } finally {
     globalThis.fetch = originalFetch;
     rmSync(dir, { force: true, recursive: true });
@@ -2503,6 +2610,7 @@ test("CLI --usage prices Codex hard default model", async () => {
     const usage = JSON.parse(stdout.join("").trim().split("\n")[1]).usage;
     assert.equal(usage.model, "gpt-5.5");
     assert.equal(usage.pricingStatus, "priced");
+    assert.equal(usage.costBasis, "api-list-price-estimate");
     assert.deepEqual(usage.cost, {
       input: 0.002,
       cacheRead: 0,
@@ -2564,6 +2672,7 @@ test("CLI --usage reports Cursor reasoning model variant", async () => {
     const usage = JSON.parse(stdout.join("").trim().split("\n")[1]).usage;
     assert.equal(usage.model, "gpt-5.5-extra-high");
     assert.equal(usage.pricingStatus, "priced");
+    assert.equal(usage.costBasis, "api-list-price-estimate");
     assert.deepEqual(usage.cost, {
       input: 0.0002,
       cacheRead: 0,
@@ -2644,22 +2753,14 @@ test("CLI --usage reports OpenCode hard default model", async () => {
     assert.equal(usage.provider, "openai");
     assert.equal(usage.model, "gpt-5.4");
     assert.equal(usage.pricingStatus, "native");
+    assert.equal(usage.costBasis, "native-reported");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
 });
 
-test("CLI rejects --usage in raw json and tmux modes", async () => {
+test("CLI rejects --usage in tmux mode", async () => {
   const stderr: string[] = [];
-  assert.equal(
-    await runCli(["codex", "--prompt", "hello", "--usage", "--json"], {
-      stderr: (text) => stderr.push(text),
-    }),
-    2,
-  );
-  assert.match(stderr.join(""), /--usage cannot be used with --json/);
-
-  stderr.length = 0;
   assert.equal(
     await runCli(["codex", "--prompt", "hello", "--usage", "--tmux"], {
       stderr: (text) => stderr.push(text),

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -518,6 +518,7 @@ test("interactive pi command isolates a new session with --session-dir", () => {
 test("CLI print-command normalizes Claude model shorthand", async () => {
   const stdout: string[] = [];
   const code = await runCli(["claude", "--prompt", "hello", "--model", "sonnet-4.5", "--print-command"], {
+    env: { ...process.env, CLAUDE_CODE_BIN: undefined, CLAUDE_BIN: "claude" },
     stdout: (text) => stdout.push(text),
   });
 

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -3152,7 +3152,8 @@ test("CLI cleans the Antigravity usage overlay when the parent receives SIGTERM"
       encoding: "utf8",
       env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
     });
-    assert.equal(child.status, 143, child.stderr);
+    assert.equal(child.signal, "SIGTERM", child.stderr);
+    assert.equal(child.status, null, child.stderr);
     assert.equal(existsSync(readFileSync(overlayPath, "utf8")), false);
   } finally {
     rmSync(dir, { force: true, recursive: true });

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -3018,6 +3018,103 @@ test("CLI --json --usage appends partial usage and preserves a nonzero agent sta
   }
 });
 
+test("CLI --json --usage captures Antigravity status usage without changing real settings", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "agy-capture.json");
+    mkdirSync(join(appDir, "brain"), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true }, useG1Credits: true })}\n`,
+    );
+    const binary = join(binDir, "agy");
+    writeFileSync(
+      binary,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const { spawnSync } = require('node:child_process');",
+        "const settings = JSON.parse(fs.readFileSync(path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'settings.json'), 'utf8'));",
+        "fs.writeFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify({ home: process.env.HOME, settings }));",
+        "const payload = { conversation_id: 'agy-1', model: { id: 'Gemini 3.5 Flash (Low)', display_name: 'Gemini 3.5 Flash (Low)' }, context_window: { current_usage: { input_tokens: 1000, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 200 } } };",
+        "const status = spawnSync('/bin/sh', ['-c', settings.statusLine.command], { input: JSON.stringify(payload), env: process.env, encoding: 'utf8' });",
+        "if (status.status !== 0) { process.stderr.write(status.stderr); process.exit(status.status ?? 1); }",
+        "process.stdout.write('final answer\\n');",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(binary, 0o755);
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          google: {
+            models: {
+              "gemini-3.5-flash": { cost: { input: 1.5, cache_read: 0.15, output: 9 } },
+            },
+          },
+        }),
+      );
+
+    const stdout: string[] = [];
+    const code = await runCli(
+      ["antigravity", "--model", "Gemini 3.5 Flash (Low)", "--prompt", "hello", "--json", "--usage"],
+      {
+        env: {
+          ...process.env,
+          ANTIGRAVITY_CLI_BIN: binary,
+          HEADLESS_CAPTURE: captureFile,
+          HOME: home,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdout: (text) => stdout.push(text),
+      },
+    );
+
+    assert.equal(code, 0);
+    const lines = stdout.join("").trim().split("\n");
+    assert.equal(lines[0], "final answer");
+    assert.deepEqual(JSON.parse(lines[1]).usage, {
+      agent: "antigravity",
+      provider: "google",
+      model: "Gemini 3.5 Flash (Low)",
+      inputTokens: 1000,
+      cacheReadTokens: 200,
+      cacheWriteTokens: 0,
+      outputTokens: 50,
+      reasoningOutputTokens: 0,
+      totalTokens: 1250,
+      usageStatus: "reported",
+      cost: {
+        input: 0.0015,
+        cacheRead: 0.00003,
+        cacheWrite: 0,
+        output: 0.00045,
+        total: 0.00198,
+      },
+      costBasis: "api-list-price-estimate",
+      pricingSource: "models.dev",
+      pricingStatus: "priced",
+    });
+    const invocation = JSON.parse(readFileSync(captureFile, "utf8"));
+    assert.notEqual(invocation.home, home);
+    assert.equal(invocation.settings.statusLine.type, "command");
+    assert.deepEqual(JSON.parse(readFileSync(join(appDir, "settings.json"), "utf8")), {
+      statusLine: { type: "", command: "", enabled: true },
+      useG1Credits: true,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+
 test("CLI --usage prices Codex hard default model", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const originalFetch = globalThis.fetch;

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -3293,7 +3293,7 @@ test("CLI bounds Antigravity stdout drain after the direct child exits", async (
     );
     chmodSync(binary, 0o755);
 
-    const code = await runCli(["antigravity", "--prompt", "hello", "--json", "--usage"], {
+    const code = await runCli(["antigravity", "--prompt", "hello", "--json", "--usage", "--timeout", "60"], {
       env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
       stdout: () => {},
     });
@@ -3351,6 +3351,54 @@ test(
 
       assert.equal(code, 0);
       assert.equal(existsSync(readFileSync(overlayPath, "utf8")), false);
+      grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
+      await waitFor(() => !processIsAlive(grandchildPid as number));
+    } finally {
+      if (grandchildPid && processIsAlive(grandchildPid)) process.kill(grandchildPid, "SIGKILL");
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "CLI preserves timeout status when Antigravity exits during drain",
+  { skip: process.platform === "win32" },
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+    const grandchildPidPath = join(dir, "grandchild.pid");
+    let grandchildPid: number | undefined;
+    try {
+      const home = join(dir, "home");
+      const appDir = join(home, ".gemini", "antigravity-cli");
+      const binDir = join(dir, "bin");
+      mkdirSync(appDir, { recursive: true });
+      mkdirSync(binDir);
+      writeFileSync(
+        join(appDir, "settings.json"),
+        `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true } })}\n`,
+      );
+      const binary = join(binDir, "agy");
+      writeFileSync(
+        binary,
+        [
+          "#!/bin/sh",
+          "/bin/sh -c 'trap \"\" TERM; while :; do sleep 1; done' &",
+          `printf '%s' "$!" > ${JSON.stringify(grandchildPidPath)}`,
+          "sleep 4.2",
+          "printf 'antigravity final\\n'",
+          "",
+        ].join("\n"),
+      );
+      chmodSync(binary, 0o755);
+
+      const stdout: string[] = [];
+      const code = await runCli(["antigravity", "--prompt", "hello", "--json", "--usage", "--timeout", "5"], {
+        env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+        stdout: (text) => stdout.push(text),
+      });
+
+      assert.equal(code, 124);
+      assert.match(stdout.join(""), /antigravity final/);
       grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
       await waitFor(() => !processIsAlive(grandchildPid as number));
     } finally {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1278,6 +1278,8 @@ test("CLI waits for timed-out child stdout to drain before appending usage", asy
 test("CLI bounds timeout drain when a descendant retains stdout", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const pidFile = join(dir, "grandchild.pid");
+  const naturalExitFile = join(dir, "grandchild-natural-exit");
+  const grandchildSource = `setTimeout(() => require("node:fs").writeFileSync(${JSON.stringify(naturalExitFile)}, "done"), 4_000)`;
   let grandchildPid: number | undefined;
   try {
     const binDir = join(dir, "bin");
@@ -1291,7 +1293,7 @@ test("CLI bounds timeout drain when a descendant retains stdout", async () => {
           "const { spawn } = require('node:child_process');",
           "const { writeFileSync } = require('node:fs');",
           "process.on('SIGTERM', () => {",
-          "  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'], { stdio: ['ignore', 'inherit', 'inherit'] });",
+          `  const child = spawn(process.execPath, ['-e', ${JSON.stringify(grandchildSource)}], { stdio: ['ignore', 'inherit', 'inherit'] });`,
           "  writeFileSync(process.env.HEADLESS_TEST_GRANDCHILD_PID, String(child.pid));",
           "  child.unref();",
           "  process.exit(0);",
@@ -1303,7 +1305,6 @@ test("CLI bounds timeout drain when a descendant retains stdout", async () => {
       await chmod(binary, 0o755);
     });
 
-    const startedAt = Date.now();
     const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "1"], {
       env: {
         ...process.env,
@@ -1314,11 +1315,12 @@ test("CLI bounds timeout drain when a descendant retains stdout", async () => {
     });
 
     assert.equal(code, 124);
-    assert.ok(Date.now() - startedAt < 4_000, "timeout drain should finish before the descendant exits");
+    assert.equal(existsSync(naturalExitFile), false);
     grandchildPid = Number(readFileSync(pidFile, "utf8"));
     assert.ok(Number.isInteger(grandchildPid) && grandchildPid > 0);
     if (process.platform !== "win32") {
       await waitFor(() => !processIsAlive(grandchildPid as number));
+      assert.equal(existsSync(naturalExitFile), false);
     }
   } finally {
     try {
@@ -3262,6 +3264,8 @@ test("CLI does not redeliver parent signals to embedded host listeners", async (
 test("CLI bounds Antigravity stdout drain after the direct child exits", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const grandchildPidPath = join(dir, "grandchild.pid");
+  const naturalExitPath = join(dir, "grandchild-natural-exit");
+  const grandchildSource = `setTimeout(() => require("node:fs").writeFileSync(${JSON.stringify(naturalExitPath)}, "done"), 4_000)`;
   let grandchildPid: number | undefined;
   try {
     const home = join(dir, "home");
@@ -3279,7 +3283,7 @@ test("CLI bounds Antigravity stdout drain after the direct child exits", async (
         "const { spawn } = require('node:child_process');",
         "const { writeFileSync } = require('node:fs');",
         `writeFileSync(${JSON.stringify(overlayPath)}, process.env.HOME);`,
-        "const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 4_000)'], { stdio: ['ignore', 'inherit', 'inherit'] });",
+        `const child = spawn(process.execPath, ['-e', ${JSON.stringify(grandchildSource)}], { stdio: ['ignore', 'inherit', 'inherit'] });`,
         `writeFileSync(${JSON.stringify(grandchildPidPath)}, String(child.pid));`,
         "child.unref();",
         "process.stdout.write('antigravity final\\n');",
@@ -3288,17 +3292,16 @@ test("CLI bounds Antigravity stdout drain after the direct child exits", async (
     );
     chmodSync(binary, 0o755);
 
-    const startedAt = Date.now();
     const code = await runCli(["antigravity", "--prompt", "hello", "--json", "--usage"], {
       env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
       stdout: () => {},
     });
 
     assert.equal(code, 0);
-    assert.ok(Date.now() - startedAt < 3_000);
     assert.equal(existsSync(readFileSync(overlayPath, "utf8")), false);
     grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
     await waitFor(() => !processIsAlive(grandchildPid as number));
+    assert.equal(existsSync(naturalExitPath), false);
   } finally {
     if (grandchildPid && processIsAlive(grandchildPid)) process.kill(grandchildPid, "SIGKILL");
     rmSync(dir, { force: true, recursive: true });

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   buildAgentCommand,
@@ -1225,6 +1225,81 @@ test("CLI exits 124 when a one-shot command exceeds --timeout", async () => {
     assert.equal(code, 124);
     assert.match(stderr.join(""), /timed out after 1s/);
   } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI waits for timed-out child stdout to drain before appending usage", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "process.on('SIGTERM', () => { process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } }) + '\\n'); setTimeout(() => process.exit(0), 200); });",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "1"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 124);
+    const lines = stdout.join("").trim().split("\n");
+    assert.equal(JSON.parse(lines[0] ?? "").type, "turn.completed");
+    assert.equal(JSON.parse(lines[1] ?? "").usage.usageStatus, "reported");
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --json --usage keeps usage accounting bounded around a large native trace", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const binDir = join(dir, "bin");
+    await import("node:fs/promises").then(async ({ chmod, mkdir, writeFile }) => {
+      await mkdir(binDir);
+      const binary = join(binDir, "codex");
+      await writeFile(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          `process.stdout.write(JSON.stringify({ type: 'tool', text: '${"x".repeat(300_000)}' }) + '\\n');`,
+          "process.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } }) + '\\n');",
+          "",
+        ].join("\n"),
+      );
+      await chmod(binary, 0o755);
+    });
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const stdout: string[] = [];
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage"], {
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: (text) => stdout.push(text),
+    });
+
+    assert.equal(code, 0);
+    assert.ok(stdout.join("").length > 300_000);
+    const usage = JSON.parse(stdout.join("").trim().split("\n").at(-1) ?? "").usage;
+    assert.equal(usage.totalTokens, 12);
+    assert.equal(usage.usageStatus, "reported");
+  } finally {
+    globalThis.fetch = originalFetch;
     rmSync(dir, { force: true, recursive: true });
   }
 });
@@ -2658,6 +2733,52 @@ test("CLI --json --usage captures Antigravity status usage without changing real
   }
 });
 
+test("CLI cleans the Antigravity usage overlay when the parent receives SIGTERM", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    const binDir = join(dir, "bin");
+    const overlayPath = join(dir, "overlay-home.txt");
+    mkdirSync(appDir, { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(join(appDir, "settings.json"), `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true } })}\n`);
+    const binary = join(binDir, "agy");
+    writeFileSync(
+      binary,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        `fs.writeFileSync(${JSON.stringify(overlayPath)}, process.env.HOME);`,
+        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 50));",
+        "setTimeout(() => process.kill(process.ppid, 'SIGTERM'), 100);",
+        "setInterval(() => {}, 1000);",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(binary, 0o755);
+    const runner = join(dir, "runner.mjs");
+    writeFileSync(
+      runner,
+      [
+        `import { runCli } from ${JSON.stringify(pathToFileURL(join(repoRoot, "src", "cli.ts")).href)};`,
+        "const code = await runCli(['antigravity', '--prompt', 'hello', '--json', '--usage']);",
+        "process.exitCode = code;",
+        "",
+      ].join("\n"),
+    );
+
+    const child = spawnSync(process.execPath, ["--import", "tsx", runner], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+    });
+    assert.equal(child.status, 143, child.stderr);
+    assert.equal(existsSync(readFileSync(overlayPath, "utf8")), false);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
 
 test("CLI --usage prices Codex hard default model", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2562,6 +2562,103 @@ test("CLI --json --usage appends partial usage and preserves a nonzero agent sta
   }
 });
 
+test("CLI --json --usage captures Antigravity status usage without changing real settings", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    const binDir = join(dir, "bin");
+    const captureFile = join(dir, "agy-capture.json");
+    mkdirSync(join(appDir, "brain"), { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true }, useG1Credits: true })}\n`,
+    );
+    const binary = join(binDir, "agy");
+    writeFileSync(
+      binary,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const { spawnSync } = require('node:child_process');",
+        "const settings = JSON.parse(fs.readFileSync(path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'settings.json'), 'utf8'));",
+        "fs.writeFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify({ home: process.env.HOME, settings }));",
+        "const payload = { conversation_id: 'agy-1', model: { id: 'Gemini 3.5 Flash (Low)', display_name: 'Gemini 3.5 Flash (Low)' }, context_window: { current_usage: { input_tokens: 1000, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 200 } } };",
+        "const status = spawnSync('/bin/sh', ['-c', settings.statusLine.command], { input: JSON.stringify(payload), env: process.env, encoding: 'utf8' });",
+        "if (status.status !== 0) { process.stderr.write(status.stderr); process.exit(status.status ?? 1); }",
+        "process.stdout.write('final answer\\n');",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(binary, 0o755);
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          google: {
+            models: {
+              "gemini-3.5-flash": { cost: { input: 1.5, cache_read: 0.15, output: 9 } },
+            },
+          },
+        }),
+      );
+
+    const stdout: string[] = [];
+    const code = await runCli(
+      ["antigravity", "--model", "Gemini 3.5 Flash (Low)", "--prompt", "hello", "--json", "--usage"],
+      {
+        env: {
+          ...process.env,
+          ANTIGRAVITY_CLI_BIN: binary,
+          HEADLESS_CAPTURE: captureFile,
+          HOME: home,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdout: (text) => stdout.push(text),
+      },
+    );
+
+    assert.equal(code, 0);
+    const lines = stdout.join("").trim().split("\n");
+    assert.equal(lines[0], "final answer");
+    assert.deepEqual(JSON.parse(lines[1]).usage, {
+      agent: "antigravity",
+      provider: "google",
+      model: "Gemini 3.5 Flash (Low)",
+      inputTokens: 1000,
+      cacheReadTokens: 200,
+      cacheWriteTokens: 0,
+      outputTokens: 50,
+      reasoningOutputTokens: 0,
+      totalTokens: 1250,
+      usageStatus: "reported",
+      cost: {
+        input: 0.0015,
+        cacheRead: 0.00003,
+        cacheWrite: 0,
+        output: 0.00045,
+        total: 0.00198,
+      },
+      costBasis: "api-list-price-estimate",
+      pricingSource: "models.dev",
+      pricingStatus: "priced",
+    });
+    const invocation = JSON.parse(readFileSync(captureFile, "utf8"));
+    assert.notEqual(invocation.home, home);
+    assert.equal(invocation.settings.statusLine.type, "command");
+    assert.deepEqual(JSON.parse(readFileSync(join(appDir, "settings.json"), "utf8")), {
+      statusLine: { type: "", command: "", enabled: true },
+      useG1Credits: true,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+
 test("CLI --usage prices Codex hard default model", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const originalFetch = globalThis.fetch;

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1261,7 +1261,7 @@ test("CLI waits for timed-out child stdout to drain before appending usage", asy
     globalThis.fetch = async () => new Response(JSON.stringify({}));
 
     const stdout: string[] = [];
-    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "1"], {
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "3"], {
       env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
       stdout: (text) => stdout.push(text),
     });
@@ -1306,7 +1306,7 @@ test("CLI bounds timeout drain when a descendant retains stdout", async () => {
       await chmod(binary, 0o755);
     });
 
-    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "1"], {
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--usage", "--timeout", "3"], {
       env: {
         ...process.env,
         HEADLESS_TEST_GRANDCHILD_PID: pidFile,
@@ -1362,7 +1362,7 @@ test("CLI kills timeout descendants after the direct child closes", async () => 
       await chmod(binary, 0o755);
     });
 
-    const code = await runCli(["codex", "--prompt", "hello", "--json", "--timeout", "1"], {
+    const code = await runCli(["codex", "--prompt", "hello", "--json", "--timeout", "3"], {
       env: {
         ...process.env,
         HEADLESS_TEST_GRANDCHILD_PID: pidFile,

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -3309,6 +3309,57 @@ test("CLI bounds Antigravity stdout drain after the direct child exits", async (
   }
 });
 
+test(
+  "CLI kills Antigravity descendants that close inherited stdio",
+  { skip: process.platform === "win32" },
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+    const grandchildPidPath = join(dir, "grandchild.pid");
+    let grandchildPid: number | undefined;
+    try {
+      const home = join(dir, "home");
+      const appDir = join(home, ".gemini", "antigravity-cli");
+      const binDir = join(dir, "bin");
+      const overlayPath = join(dir, "overlay-home.txt");
+      mkdirSync(appDir, { recursive: true });
+      mkdirSync(binDir);
+      writeFileSync(
+        join(appDir, "settings.json"),
+        `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true } })}\n`,
+      );
+      const binary = join(binDir, "agy");
+      writeFileSync(
+        binary,
+        [
+          "#!/usr/bin/env node",
+          "const { spawn } = require('node:child_process');",
+          "const { writeFileSync } = require('node:fs');",
+          `writeFileSync(${JSON.stringify(overlayPath)}, process.env.HOME);`,
+          "const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'], { stdio: 'ignore' });",
+          `writeFileSync(${JSON.stringify(grandchildPidPath)}, String(child.pid));`,
+          "child.unref();",
+          "process.stdout.write('antigravity final\\n');",
+          "",
+        ].join("\n"),
+      );
+      chmodSync(binary, 0o755);
+
+      const code = await runCli(["antigravity", "--prompt", "hello", "--json", "--usage", "--timeout", "60"], {
+        env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+        stdout: () => {},
+      });
+
+      assert.equal(code, 0);
+      assert.equal(existsSync(readFileSync(overlayPath, "utf8")), false);
+      grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
+      await waitFor(() => !processIsAlive(grandchildPid as number));
+    } finally {
+      if (grandchildPid && processIsAlive(grandchildPid)) process.kill(grandchildPid, "SIGKILL");
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);
+
 test("CLI --usage prices Codex hard default model", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const originalFetch = globalThis.fetch;

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -4,7 +4,7 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSy
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   buildAgentCommand,
@@ -1506,7 +1506,6 @@ test("CLI forwards suspend and continue signals to timeout-enabled agents", { sk
     rmSync(dir, { force: true, recursive: true });
   }
 });
-
 test("CLI --json --usage keeps usage accounting bounded around a large native trace", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const originalFetch = globalThis.fetch;
@@ -1684,7 +1683,6 @@ test("CLI --json --usage preserves Codex session identity across a large relevan
     rmSync(dir, { force: true, recursive: true });
   }
 });
-
 test("CLI flags override configured role allow and reasoning effort", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
@@ -3114,6 +3112,52 @@ test("CLI --json --usage captures Antigravity status usage without changing real
   }
 });
 
+test("CLI cleans the Antigravity usage overlay when the parent receives SIGTERM", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    const binDir = join(dir, "bin");
+    const overlayPath = join(dir, "overlay-home.txt");
+    mkdirSync(appDir, { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(join(appDir, "settings.json"), `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true } })}\n`);
+    const binary = join(binDir, "agy");
+    writeFileSync(
+      binary,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        `fs.writeFileSync(${JSON.stringify(overlayPath)}, process.env.HOME);`,
+        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 50));",
+        "setTimeout(() => process.kill(process.ppid, 'SIGTERM'), 100);",
+        "setInterval(() => {}, 1000);",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(binary, 0o755);
+    const runner = join(dir, "runner.mjs");
+    writeFileSync(
+      runner,
+      [
+        `import { runCli } from ${JSON.stringify(pathToFileURL(join(repoRoot, "src", "cli.ts")).href)};`,
+        "const code = await runCli(['antigravity', '--prompt', 'hello', '--json', '--usage']);",
+        "process.exitCode = code;",
+        "",
+      ].join("\n"),
+    );
+
+    const child = spawnSync(process.execPath, ["--import", "tsx", runner], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+    });
+    assert.equal(child.status, 143, child.stderr);
+    assert.equal(existsSync(readFileSync(overlayPath, "utf8")), false);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
 
 test("CLI --usage prices Codex hard default model", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -3165,7 +3165,7 @@ test("CLI cleans the Antigravity usage overlay when the parent receives SIGTERM"
   }
 });
 
-test("CLI cleans the Antigravity usage overlay for simulated Windows signals", async () => {
+test("CLI skips the Antigravity usage overlay on Windows", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {
     const home = join(dir, "home");
@@ -3182,9 +3182,7 @@ test("CLI cleans the Antigravity usage overlay for simulated Windows signals", a
         "#!/usr/bin/env node",
         "const fs = require('node:fs');",
         `fs.writeFileSync(${JSON.stringify(overlayPath)}, process.env.HOME);`,
-        "process.on('SIGTERM', () => process.exit(0));",
-        "setTimeout(() => { process.kill(process.ppid, 'SIGTERM'); setTimeout(() => process.exit(0), 500); }, 100);",
-        "setInterval(() => {}, 1000);",
+        "process.stdout.write('antigravity final\\n');",
         "",
       ].join("\n"),
     );
@@ -3206,9 +3204,11 @@ test("CLI cleans the Antigravity usage overlay for simulated Windows signals", a
       encoding: "utf8",
       env: { ...process.env, ANTIGRAVITY_CLI_BIN: binary, HOME: home, PATH: `${binDir}:${process.env.PATH ?? ""}` },
     });
-    assert.equal(child.status, null, child.stderr);
-    assert.equal(child.signal, "SIGTERM", child.stderr);
-    assert.equal(existsSync(readFileSync(overlayPath, "utf8")), false);
+    assert.equal(child.status, 0, child.stderr);
+    assert.equal(readFileSync(overlayPath, "utf8"), home);
+    assert.deepEqual(JSON.parse(readFileSync(join(appDir, "settings.json"), "utf8")), {
+      statusLine: { type: "", command: "", enabled: true },
+    });
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { extractAgentError, extractFinalMessage, extractUsageSummary, priceUsageSummary } from "../src/output.ts";
 import { extractRunNodeMetrics } from "../src/run-metrics.ts";
+import type { AgentName } from "../src/types.ts";
 
 test("extracts final Codex assistant message from JSONL trace", () => {
   const trace = [
@@ -485,6 +486,41 @@ test("does not price missing usage as zero", () => {
   assert.equal(summary.cost, null);
   assert.equal(summary.costBasis, null);
   assert.equal(summary.pricingStatus, "missing");
+});
+
+test("classifies malformed usage-shaped records as missing", () => {
+  const cases: Array<[AgentName, unknown]> = [
+    ["antigravity", { type: "headless.antigravity.usage", context_window: { current_usage: { unexpected: true } } }],
+    ["claude", { type: "result", usage: { unexpected: true } }],
+    ["codex", { type: "turn.completed", usage: { unexpected: true } }],
+    ["cursor", { type: "result", usage: { unexpected: true } }],
+    ["gemini", { type: "result", stats: { unexpected: true } }],
+    ["opencode", { type: "step_finish", part: { tokens: { unexpected: true } } }],
+    ["pi", { type: "message_end", message: { usage: { unexpected: true } } }],
+  ];
+
+  for (const [agent, record] of cases) {
+    const summary = extractUsageSummary(agent, JSON.stringify(record), { model: "test-model" });
+    assert.equal(summary.usageStatus, "missing", agent);
+    assert.equal(summary.cost, null, agent);
+  }
+});
+
+test("preserves valid native zero-cost reports", () => {
+  const cases: Array<[AgentName, unknown]> = [
+    ["claude", { type: "result", total_cost_usd: 0, usage: { input_tokens: 0 } }],
+    ["opencode", { type: "step_finish", part: { cost: 0, tokens: { input: 0 } } }],
+    ["pi", { type: "message_end", message: { usage: { input: 0, cost: { total: 0 } } } }],
+  ];
+
+  for (const [agent, record] of cases) {
+    const summary = extractUsageSummary(agent, JSON.stringify(record), { model: "test-model" });
+    assert.equal(summary.usageStatus, "reported", agent);
+    assert.equal(summary.cost?.total, 0, agent);
+    assert.equal(summary.costBasis, "native-reported", agent);
+    assert.equal(summary.pricingSource, "native", agent);
+    assert.equal(summary.pricingStatus, "native", agent);
+  }
 });
 
 test("prices Cursor effort model variants with base model rates", () => {

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -89,6 +89,52 @@ test("extracts Antigravity JSON-shaped plain text answers", () => {
   assert.equal(extractFinalMessage("antigravity", "[1,2,3]\n"), "[1,2,3]");
 });
 
+test("extracts the latest Antigravity response from mixed trace and plain output", () => {
+  assert.equal(
+    extractFinalMessage(
+      "antigravity",
+      [
+        "startup warning",
+        JSON.stringify({ type: "PLANNER_RESPONSE", status: "DONE", content: "native final" }),
+        "",
+      ].join("\n"),
+    ),
+    "native final",
+  );
+  assert.equal(
+    extractFinalMessage(
+      "antigravity",
+      [
+        JSON.stringify({ type: "SESSION_META", conversation_id: "agy-run" }),
+        "first line",
+        "",
+        "  indented line",
+        "",
+      ].join("\n"),
+    ),
+    "first line\n\n  indented line",
+  );
+  assert.equal(
+    extractFinalMessage(
+      "antigravity",
+      ["startup warning", JSON.stringify({ type: "SESSION_META", conversation_id: "agy-run" }), ""].join("\n"),
+    ),
+    "",
+  );
+  assert.equal(
+    extractFinalMessage(
+      "antigravity",
+      [
+        JSON.stringify({ type: "SESSION_META", conversation_id: "agy-run" }),
+        "plain final",
+        JSON.stringify({ type: "SESSION_META", conversation_id: "agy-run" }),
+        "",
+      ].join("\n"),
+    ),
+    "plain final",
+  );
+});
+
 test("extracts Antigravity final message from native transcript records", () => {
   assert.equal(
     extractFinalMessage(

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -244,6 +244,7 @@ test("extracts Codex usage from turn completed trace and prices with models.dev 
     outputTokens: 100,
     reasoningOutputTokens: 25,
     totalTokens: 1100,
+    usageStatus: "reported",
     cost: {
       input: 0.00075,
       cacheRead: 0.00005,
@@ -251,6 +252,7 @@ test("extracts Codex usage from turn completed trace and prices with models.dev 
       output: 0.001,
       total: 0.0018,
     },
+    costBasis: "api-list-price-estimate",
     pricingSource: "models.dev",
     pricingStatus: "priced",
   });
@@ -287,6 +289,7 @@ test("extracts Claude usage and preserves native cost", () => {
     outputTokens: 8,
     reasoningOutputTokens: 0,
     totalTokens: 29242,
+    usageStatus: "reported",
     cost: {
       input: null,
       cacheRead: null,
@@ -294,6 +297,7 @@ test("extracts Claude usage and preserves native cost", () => {
       output: null,
       total: 0.18331675,
     },
+    costBasis: "native-reported",
     pricingSource: "native",
     pricingStatus: "native",
   });
@@ -380,6 +384,22 @@ test("extracts Cursor usage and returns null cost when model pricing is missing"
   assert.equal(summary.outputTokens, 43);
   assert.equal(summary.model, "Composer 2 Fast");
   assert.equal(summary.cost, null);
+  assert.equal(summary.costBasis, null);
+  assert.equal(summary.pricingStatus, "missing");
+});
+
+test("does not price missing usage as zero", () => {
+  const summary = priceUsageSummary(
+    extractUsageSummary("codex", JSON.stringify({ type: "thread.started" }), {
+      provider: "openai",
+      model: "gpt-5",
+    }),
+    pricingFixture(),
+  );
+
+  assert.equal(summary.usageStatus, "missing");
+  assert.equal(summary.cost, null);
+  assert.equal(summary.costBasis, null);
   assert.equal(summary.pricingStatus, "missing");
 });
 
@@ -419,6 +439,7 @@ test("prices Cursor effort model variants with base model rates", () => {
     output: 0.0004,
     total: 0.00248,
   });
+  assert.equal(summary.costBasis, "api-list-price-estimate");
   assert.equal(summary.pricingStatus, "priced");
 });
 
@@ -455,6 +476,7 @@ test("extracts Gemini multi-model usage and sums priced costs", () => {
     output: 0.000028,
     total: 0.001113,
   });
+  assert.equal(summary.costBasis, "api-list-price-estimate");
   assert.equal(summary.pricingStatus, "priced");
 });
 
@@ -485,6 +507,7 @@ test("extracts OpenCode native usage cost", () => {
     output: null,
     total: 0.00087525,
   });
+  assert.equal(summary.costBasis, "native-reported");
   assert.equal(summary.pricingStatus, "native");
 });
 
@@ -521,6 +544,7 @@ test("extracts Pi usage and native cost", () => {
     outputTokens: 7,
     reasoningOutputTokens: 0,
     totalTokens: 2347,
+    usageStatus: "reported",
     cost: {
       input: 0.01155,
       output: 0.000175,
@@ -528,6 +552,7 @@ test("extracts Pi usage and native cost", () => {
       cacheWrite: 0.000125,
       total: 0.011855,
     },
+    costBasis: "native-reported",
     pricingSource: "native",
     pricingStatus: "native",
   });

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -259,6 +259,90 @@ test("extracts Codex usage from turn completed trace and prices with models.dev 
   });
 });
 
+test("extracts Antigravity turn usage from the latest status payload and prices its API equivalent", () => {
+  const trace = [
+    JSON.stringify({
+      type: "headless.antigravity.usage",
+      model: { id: "Gemini 3.5 Flash (Low)" },
+      context_window: { total_input_tokens: 153, current_usage: {} },
+    }),
+    JSON.stringify({
+      type: "headless.antigravity.usage",
+      model: { id: "Gemini 3.5 Flash (Low)" },
+      context_window: {
+        total_input_tokens: 153,
+        current_usage: {
+          input_tokens: 1000,
+          output_tokens: 50,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 200,
+        },
+      },
+    }),
+  ].join("\n");
+
+  const summary = priceUsageSummary(extractUsageSummary("antigravity", trace), {
+    google: {
+      models: {
+        "gemini-3.5-flash": {
+          cost: { input: 1.5, cache_read: 0.15, cache_write: 1.5, output: 9 },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(summary, {
+    agent: "antigravity",
+    provider: "google",
+    model: "Gemini 3.5 Flash (Low)",
+    inputTokens: 1000,
+    cacheReadTokens: 200,
+    cacheWriteTokens: 100,
+    outputTokens: 50,
+    reasoningOutputTokens: 0,
+    totalTokens: 1350,
+    usageStatus: "reported",
+    cost: {
+      input: 0.0015,
+      cacheRead: 0.00003,
+      cacheWrite: 0.00015,
+      output: 0.00045,
+      total: 0.00213,
+    },
+    costBasis: "api-list-price-estimate",
+    pricingSource: "models.dev",
+    pricingStatus: "priced",
+  });
+});
+
+test("does not guess an Antigravity API-equivalent price for an unmapped model", () => {
+  const trace = JSON.stringify({
+    type: "headless.antigravity.usage",
+    model: { id: "GPT-OSS 120B (Medium)" },
+    context_window: {
+      current_usage: {
+        input_tokens: 1000,
+        output_tokens: 50,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  });
+  const summary = priceUsageSummary(extractUsageSummary("antigravity", trace), {
+    arbitraryGateway: {
+      models: {
+        "gpt-oss-120b": { name: "GPT OSS 120B", cost: { input: 1, output: 2 } },
+      },
+    },
+  });
+
+  assert.equal(summary.model, "GPT-OSS 120B (Medium)");
+  assert.equal(summary.provider, null);
+  assert.equal(summary.totalTokens, 1050);
+  assert.equal(summary.cost, null);
+  assert.equal(summary.pricingStatus, "missing");
+});
+
 test("extracts Claude usage and preserves native cost", () => {
   const trace = JSON.stringify({
     type: "result",

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -490,6 +490,7 @@ test("does not price missing usage as zero", () => {
 
 test("classifies malformed usage-shaped records as missing", () => {
   const cases: Array<[AgentName, unknown]> = [
+    ["antigravity", { type: "headless.antigravity.usage", context_window: { current_usage: { unexpected: true } } }],
     ["claude", { type: "result", usage: { unexpected: true } }],
     ["codex", { type: "turn.completed", usage: { unexpected: true } }],
     ["cursor", { type: "result", usage: { unexpected: true } }],

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -258,6 +258,90 @@ test("extracts Codex usage from turn completed trace and prices with models.dev 
   });
 });
 
+test("extracts Antigravity turn usage from the latest status payload and prices its API equivalent", () => {
+  const trace = [
+    JSON.stringify({
+      type: "headless.antigravity.usage",
+      model: { id: "Gemini 3.5 Flash (Low)" },
+      context_window: { total_input_tokens: 153, current_usage: {} },
+    }),
+    JSON.stringify({
+      type: "headless.antigravity.usage",
+      model: { id: "Gemini 3.5 Flash (Low)" },
+      context_window: {
+        total_input_tokens: 153,
+        current_usage: {
+          input_tokens: 1000,
+          output_tokens: 50,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 200,
+        },
+      },
+    }),
+  ].join("\n");
+
+  const summary = priceUsageSummary(extractUsageSummary("antigravity", trace), {
+    google: {
+      models: {
+        "gemini-3.5-flash": {
+          cost: { input: 1.5, cache_read: 0.15, cache_write: 1.5, output: 9 },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(summary, {
+    agent: "antigravity",
+    provider: "google",
+    model: "Gemini 3.5 Flash (Low)",
+    inputTokens: 1000,
+    cacheReadTokens: 200,
+    cacheWriteTokens: 100,
+    outputTokens: 50,
+    reasoningOutputTokens: 0,
+    totalTokens: 1350,
+    usageStatus: "reported",
+    cost: {
+      input: 0.0015,
+      cacheRead: 0.00003,
+      cacheWrite: 0.00015,
+      output: 0.00045,
+      total: 0.00213,
+    },
+    costBasis: "api-list-price-estimate",
+    pricingSource: "models.dev",
+    pricingStatus: "priced",
+  });
+});
+
+test("does not guess an Antigravity API-equivalent price for an unmapped model", () => {
+  const trace = JSON.stringify({
+    type: "headless.antigravity.usage",
+    model: { id: "GPT-OSS 120B (Medium)" },
+    context_window: {
+      current_usage: {
+        input_tokens: 1000,
+        output_tokens: 50,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  });
+  const summary = priceUsageSummary(extractUsageSummary("antigravity", trace), {
+    arbitraryGateway: {
+      models: {
+        "gpt-oss-120b": { name: "GPT OSS 120B", cost: { input: 1, output: 2 } },
+      },
+    },
+  });
+
+  assert.equal(summary.model, "GPT-OSS 120B (Medium)");
+  assert.equal(summary.provider, null);
+  assert.equal(summary.totalTokens, 1050);
+  assert.equal(summary.cost, null);
+  assert.equal(summary.pricingStatus, "missing");
+});
+
 test("extracts Claude usage and preserves native cost", () => {
   const trace = JSON.stringify({
     type: "result",

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -442,6 +442,75 @@ test("Antigravity json orchestrators preserve terminal responses for run complet
   }
 });
 
+test("json Antigravity usage is included in persisted run-node metrics", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    const binDir = join(dir, "bin");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true } })}\n`,
+    );
+    const agy = join(binDir, "agy");
+    await writeExecutable(
+      agy,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const { spawnSync } = require('node:child_process');",
+        "const settings = JSON.parse(fs.readFileSync(path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'settings.json'), 'utf8'));",
+        "const payload = { conversation_id: 'agy-run', model: { id: 'Gemini 3.5 Flash (Low)', display_name: 'Gemini 3.5 Flash (Low)' }, context_window: { current_usage: { input_tokens: 11, output_tokens: 3, cache_creation_input_tokens: 0, cache_read_input_tokens: 2 } } };",
+        "const status = spawnSync('/bin/sh', ['-c', settings.statusLine.command], { input: JSON.stringify(payload), env: process.env, encoding: 'utf8' });",
+        "if (status.status !== 0) { process.stderr.write(status.stderr); process.exit(status.status ?? 1); }",
+        "process.stdout.write(JSON.stringify({ type: 'assistant', content: 'antigravity done' }) + '\\n');",
+        "",
+      ].join("\n"),
+    );
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const env = {
+      ...process.env,
+      ANTIGRAVITY_CLI_BIN: agy,
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await runCli(
+      [
+        "antigravity",
+        "--role",
+        "worker",
+        "--run",
+        "agy-run",
+        "--node",
+        "worker",
+        "--coordination",
+        "oneshot",
+        "--prompt",
+        "hello",
+        "--json",
+        "--usage",
+      ],
+      { env, stdout: (text) => stdout.push(text), stderr: (text) => stderr.push(text) },
+    );
+
+    assert.equal(code, 0, stderr.join(""));
+    const node = readRun(env, "agy-run")?.nodes.worker;
+    assert.equal(node?.metrics?.inputTokens, 11);
+    assert.equal(node?.metrics?.cacheReadTokens, 2);
+    assert.equal(node?.metrics?.outputTokens, 3);
+    assert.equal(node?.metrics?.totalTokens, 16);
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("orchestrator run rejects read-only mode because it must update run state", async () => {
   const stderr: string[] = [];
   const code = await runCli(

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -379,6 +379,75 @@ test("orchestrator run status reporter stays off for json runs", async () => {
   }
 });
 
+test("json Antigravity usage is included in persisted run-node metrics", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const home = join(dir, "home");
+    const appDir = join(home, ".gemini", "antigravity-cli");
+    const binDir = join(dir, "bin");
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, "settings.json"),
+      `${JSON.stringify({ statusLine: { type: "", command: "", enabled: true } })}\n`,
+    );
+    const agy = join(binDir, "agy");
+    await writeExecutable(
+      agy,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const { spawnSync } = require('node:child_process');",
+        "const settings = JSON.parse(fs.readFileSync(path.join(process.env.HOME, '.gemini', 'antigravity-cli', 'settings.json'), 'utf8'));",
+        "const payload = { conversation_id: 'agy-run', model: { id: 'Gemini 3.5 Flash (Low)', display_name: 'Gemini 3.5 Flash (Low)' }, context_window: { current_usage: { input_tokens: 11, output_tokens: 3, cache_creation_input_tokens: 0, cache_read_input_tokens: 2 } } };",
+        "const status = spawnSync('/bin/sh', ['-c', settings.statusLine.command], { input: JSON.stringify(payload), env: process.env, encoding: 'utf8' });",
+        "if (status.status !== 0) { process.stderr.write(status.stderr); process.exit(status.status ?? 1); }",
+        "process.stdout.write(JSON.stringify({ type: 'assistant', content: 'antigravity done' }) + '\\n');",
+        "",
+      ].join("\n"),
+    );
+    globalThis.fetch = async () => new Response(JSON.stringify({}));
+
+    const env = {
+      ...process.env,
+      ANTIGRAVITY_CLI_BIN: agy,
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await runCli(
+      [
+        "antigravity",
+        "--role",
+        "worker",
+        "--run",
+        "agy-run",
+        "--node",
+        "worker",
+        "--coordination",
+        "oneshot",
+        "--prompt",
+        "hello",
+        "--json",
+        "--usage",
+      ],
+      { env, stdout: (text) => stdout.push(text), stderr: (text) => stderr.push(text) },
+    );
+
+    assert.equal(code, 0, stderr.join(""));
+    const node = readRun(env, "agy-run")?.nodes.worker;
+    assert.equal(node?.metrics?.inputTokens, 11);
+    assert.equal(node?.metrics?.cacheReadTokens, 2);
+    assert.equal(node?.metrics?.outputTokens, 3);
+    assert.equal(node?.metrics?.totalTokens, 16);
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("orchestrator run rejects read-only mode because it must update run state", async () => {
   const stderr: string[] = [];
   const code = await runCli(

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -403,7 +403,8 @@ test("json Antigravity usage is included in persisted run-node metrics", async (
         "const payload = { conversation_id: 'agy-run', model: { id: 'Gemini 3.5 Flash (Low)', display_name: 'Gemini 3.5 Flash (Low)' }, context_window: { current_usage: { input_tokens: 11, output_tokens: 3, cache_creation_input_tokens: 0, cache_read_input_tokens: 2 } } };",
         "const status = spawnSync('/bin/sh', ['-c', settings.statusLine.command], { input: JSON.stringify(payload), env: process.env, encoding: 'utf8' });",
         "if (status.status !== 0) { process.stderr.write(status.stderr); process.exit(status.status ?? 1); }",
-        "process.stdout.write(JSON.stringify({ type: 'assistant', content: 'antigravity done' }) + '\\n');",
+        "process.stdout.write(JSON.stringify({ type: 'PLANNER_RESPONSE', status: 'DONE', content: 'antigravity done ' + 'x'.repeat(70 * 1024) }) + '\\n');",
+        "process.stdout.write(JSON.stringify({ type: 'SESSION_META', conversation_id: 'agy-run' }) + '\\n');",
         "",
       ].join("\n"),
     );
@@ -442,8 +443,58 @@ test("json Antigravity usage is included in persisted run-node metrics", async (
     assert.equal(node?.metrics?.cacheReadTokens, 2);
     assert.equal(node?.metrics?.outputTokens, 3);
     assert.equal(node?.metrics?.totalTokens, 16);
+    assert.equal(node?.lastMessage?.startsWith("antigravity done "), true);
+    assert.equal(node?.lastMessage?.length, "antigravity done ".length + 70 * 1024);
   } finally {
     globalThis.fetch = originalFetch;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("Antigravity json run nodes preserve multiline plain responses after native trace rows", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const home = join(dir, "home");
+    const binDir = join(dir, "bin");
+    mkdirSync(home);
+    await writeExecutable(
+      join(binDir, "agy"),
+      [
+        "#!/usr/bin/env node",
+        "console.log(JSON.stringify({ type: 'session_meta', conversation_id: 'agy-run' }));",
+        "process.stdout.write('first line\\n\\n  indented line\\n');",
+        "",
+      ].join("\n"),
+    );
+
+    const env = {
+      ...process.env,
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await runCli(
+      [
+        "antigravity",
+        "--role",
+        "worker",
+        "--run",
+        "agy-run",
+        "--node",
+        "worker",
+        "--coordination",
+        "oneshot",
+        "--prompt",
+        "hello",
+        "--json",
+      ],
+      { env, stdout: (text) => stdout.push(text), stderr: (text) => stderr.push(text) },
+    );
+
+    assert.equal(code, 0, stderr.join(""));
+    assert.equal(readRun(env, "agy-run")?.nodes.worker.lastMessage, "first line\n\n  indented line");
+  } finally {
     rmSync(dir, { force: true, recursive: true });
   }
 });


### PR DESCRIPTION
## What changed

Add local Antigravity usage capture for `--usage` and `--json --usage`.

Antigravity's print output and saved transcript do not expose token accounting, so Headless uses the documented status-line JSON payload. Each invocation creates a temporary HOME overlay, preserves the real Antigravity settings and session data, injects a generated status-line command, captures the latest completed usage payload, and removes the overlay in `finally`.

Captured fields include input, cached input, cache-write, output, model, and conversation ID. Known models receive API-equivalent list-price estimates from models.dev; unknown models return token counts with `cost: null`. These estimates are not actual Antigravity subscription spend.

This branch is logically stacked on draft PR #18 and includes combined `--json --usage` regression coverage. Because the shared upstream repository cannot use a fork-only branch as a PR base, this PR targets `main` and currently includes PR #18's parent commit; after #18 merges, the remaining diff will be this Antigravity change.

## Validation

- TypeScript build passed.
- 310 non-Modal tests passed on the combined branch.
- Package dry-run passed.
- Live Gemini Flash multi-turn and positive-cache probes passed.
- Four pre-existing Modal tests still fail with `invalid pax header`; Modal/Docker runtime capture is outside this PR.
