### PR TITLE
fix: limit Docker credential seed mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TBD
 
+- Changed Docker auth seeding for Antigravity to mount only credential and settings files instead of copying its conversation and brain history into each container.
+
 ## 0.4.0 - 2026-06-18
 
 - Added Antigravity CLI (`agy`) harness support for one-shot prompts, model selection, read-only sandbox mode, native session aliases, tmux launches, `--tmux --wait`, transcript final-message extraction, setup checks, Docker packaging, and README/config documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 
 - Changed Docker auth seeding for Antigravity to mount only credential and settings files instead of copying its conversation and brain history into each container.
+- Thanks to Anant Garg (@anantgar) for contributing safer Antigravity Docker credential seeding.
 - Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.
 - Clarified accounting provenance with `usageStatus` and `costBasis`: missing usage stays unknown instead of becoming a priced zero, and native-reported costs are distinguished from API list-price estimates calculated from token counts and `models.dev` pricing.
 - Thanks to Anant Garg (@anantgar) for contributing combined JSON traces with usage accounting.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -163,7 +163,7 @@ Use `headless attach` without a session name to attach to the most recently acti
 
 ## Docker
 
-Docker mode wraps one-shot headless execution in `docker run --rm`. It mounts the target workdir at the same absolute path inside the container, mounts existing agent config/auth seed paths read-only, passes curated credential environment variables, and runs the selected agent from `ghcr.io/roberttlange/headless:latest` by default.
+Docker mode wraps one-shot headless execution in `docker run --rm`. It mounts the target workdir at the same absolute path inside the container, mounts existing agent config/auth seed paths read-only, passes curated credential environment variables, and runs the selected agent from `ghcr.io/roberttlange/headless:latest` by default. For Antigravity, Docker mounts only the credential files needed for authentication and settings; it does not copy the conversation and brain history stored alongside them into the container home.
 
 ```bash
 headless codex --prompt "Fix the failing tests" --docker

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -527,6 +527,14 @@ const harnesses: Record<AgentName, AgentHarness> = {
     configRelDir: ".gemini/antigravity-cli",
     workspaceConfigRelDir: ".agents",
     seedPaths: [".gemini/antigravity-cli", ".gemini/config"],
+    dockerSeedFiles: {
+      ".gemini/antigravity-cli": [
+        "antigravity-oauth-token",
+        "settings.json",
+        "installation_id",
+        "jetski_state.pbtxt",
+      ],
+    },
     buildCommand: buildAntigravity,
     buildInteractiveCommand: buildInteractiveAntigravity,
   },
@@ -619,7 +627,17 @@ export function getAgentConfig(name: AgentName): AgentConfig {
     buildInteractiveCommand: _buildInteractiveCommand,
     ...config
   } = harnesses[name];
-  return { ...config, seedPaths: [...config.seedPaths] };
+  return {
+    ...config,
+    seedPaths: [...config.seedPaths],
+    ...(config.dockerSeedFiles
+      ? {
+          dockerSeedFiles: Object.fromEntries(
+            Object.entries(config.dockerSeedFiles).map(([path, files]) => [path, [...files]]),
+          ),
+        }
+      : {}),
+  };
 }
 
 export function buildAgentCommand(name: AgentName, options: BuildOptions, env: Env = process.env): BuiltCommand {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { existsSync, lstatSync, realpathSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { getAgentConfig } from "./agents.js";
@@ -80,13 +80,29 @@ function agentConfigMountArgs(agent: AgentName, env: Env): string[] {
     return [];
   }
 
+  const config = getAgentConfig(agent);
+  const dockerSeedFiles = config.dockerSeedFiles ?? {};
   const mounted = new Set<string>();
   const args: string[] = [];
-  for (const relPath of getAgentConfig(agent).seedPaths) {
+  for (const relPath of config.seedPaths) {
     const hostPath = join(home, relPath);
     if (!existsSync(hostPath) || mounted.has(hostPath)) {
       continue;
     }
+
+    const selectedFiles = dockerSeedFiles[relPath];
+    if (selectedFiles && statSync(hostPath).isDirectory()) {
+      for (const fileName of selectedFiles) {
+        const hostFile = join(hostPath, fileName);
+        if (!existsSync(hostFile) || !lstatSync(hostFile).isFile()) {
+          continue;
+        }
+        args.push("--volume", `${hostFile}:${join(hostHomeMountRoot, relPath, fileName)}:ro`);
+      }
+      mounted.add(hostPath);
+      continue;
+    }
+
     mounted.add(hostPath);
     args.push("--volume", `${hostPath}:${join(hostHomeMountRoot, relPath)}:ro`);
     if (statSync(hostPath).isDirectory()) {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -94,10 +94,14 @@ function agentConfigMountArgs(agent: AgentName, env: Env): string[] {
     if (selectedFiles && statSync(hostPath).isDirectory()) {
       for (const fileName of selectedFiles) {
         const hostFile = join(hostPath, fileName);
-        if (!existsSync(hostFile) || !lstatSync(hostFile).isFile()) {
+        if (!existsSync(hostFile)) {
           continue;
         }
-        args.push("--volume", `${hostFile}:${join(hostHomeMountRoot, relPath, fileName)}:ro`);
+        const mountSource = lstatSync(hostFile).isSymbolicLink() ? realpathSync(hostFile) : hostFile;
+        if (!statSync(mountSource).isFile()) {
+          continue;
+        }
+        args.push("--volume", `${mountSource}:${join(hostHomeMountRoot, relPath, fileName)}:ro`);
       }
       mounted.add(hostPath);
       break;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -100,7 +100,7 @@ function agentConfigMountArgs(agent: AgentName, env: Env): string[] {
         args.push("--volume", `${hostFile}:${join(hostHomeMountRoot, relPath, fileName)}:ro`);
       }
       mounted.add(hostPath);
-      continue;
+      break;
     }
 
     mounted.add(hostPath);

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,9 @@ export interface AgentConfig {
   configRelDir: string;
   workspaceConfigRelDir: string;
   seedPaths: string[];
+  // Optional allowlists for directory seed paths used by Docker. These keep
+  // provider caches and conversation history out of the container seed.
+  dockerSeedFiles?: Record<string, string[]>;
 }
 
 export interface AgentHarness extends AgentConfig {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -220,6 +220,79 @@ test("mounts only selected Antigravity credential files from its state directory
     assert.ok(!command.args.some((arg) => arg.includes("conversation_summaries.db")));
     assert.ok(!command.args.some((arg) => arg.includes("/antigravity-cli:/tmp/headless-host-home")));
     assert.ok(!command.args.some((arg) => arg.includes(`${configDir}:`)));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("mounts a resolved symlinked Antigravity credential file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const antigravityDir = join(home, ".gemini", "antigravity-cli");
+    const workDir = join(dir, "project");
+    const tokenFile = join(dir, "secrets", "antigravity-oauth-token");
+    mkdirSync(antigravityDir, { recursive: true });
+    mkdirSync(join(dir, "secrets"), { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(tokenFile, "token");
+    symlinkSync(tokenFile, join(antigravityDir, "antigravity-oauth-token"));
+
+    const command = buildDockerAgentCommand({
+      agent: "antigravity",
+      command: {
+        command: "agy",
+        args: ["--prompt", "hello"],
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: { HOME: home },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      workDir,
+    });
+
+    assert.ok(
+      command.args.includes(
+        `${realpathSync(tokenFile)}:/tmp/headless-host-home/.gemini/antigravity-cli/antigravity-oauth-token:ro`,
+      ),
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("does not mount a symlinked Antigravity credential with a directory target", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const antigravityDir = join(home, ".gemini", "antigravity-cli");
+    const workDir = join(dir, "project");
+    const tokenDirectory = join(dir, "secrets");
+    mkdirSync(antigravityDir, { recursive: true });
+    mkdirSync(tokenDirectory, { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    symlinkSync(tokenDirectory, join(antigravityDir, "antigravity-oauth-token"));
+
+    const command = buildDockerAgentCommand({
+      agent: "antigravity",
+      command: {
+        command: "agy",
+        args: ["--prompt", "hello"],
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: { HOME: home },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      workDir,
+    });
+
+    assert.ok(
+      !command.args.some((arg) =>
+        arg.endsWith(":/tmp/headless-host-home/.gemini/antigravity-cli/antigravity-oauth-token:ro"),
+      ),
+    );
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -181,14 +181,17 @@ test("mounts only selected Antigravity credential files from its state directory
   try {
     const home = join(dir, "home");
     const antigravityDir = join(home, ".gemini", "antigravity-cli");
+    const configDir = join(home, ".gemini", "config");
     const workDir = join(dir, "project");
     mkdirSync(antigravityDir, { recursive: true });
     mkdirSync(join(antigravityDir, "brain"), { recursive: true });
+    mkdirSync(configDir, { recursive: true });
     mkdirSync(workDir, { recursive: true });
     writeFileSync(join(antigravityDir, "antigravity-oauth-token"), "token");
     writeFileSync(join(antigravityDir, "settings.json"), "{}");
     writeFileSync(join(antigravityDir, "conversation_summaries.db"), "large state");
     writeFileSync(join(antigravityDir, "brain", "transcript.jsonl"), "history");
+    writeFileSync(join(configDir, "mcp_config.json"), "{}");
 
     const command = buildDockerAgentCommand({
       agent: "antigravity",
@@ -216,6 +219,7 @@ test("mounts only selected Antigravity credential files from its state directory
     );
     assert.ok(!command.args.some((arg) => arg.includes("conversation_summaries.db")));
     assert.ok(!command.args.some((arg) => arg.includes("/antigravity-cli:/tmp/headless-host-home")));
+    assert.ok(!command.args.some((arg) => arg.includes(`${configDir}:`)));
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -176,6 +176,51 @@ test("uses a writable container home while keeping host agent config read-only",
   }
 });
 
+test("mounts only selected Antigravity credential files from its state directory", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const antigravityDir = join(home, ".gemini", "antigravity-cli");
+    const workDir = join(dir, "project");
+    mkdirSync(antigravityDir, { recursive: true });
+    mkdirSync(join(antigravityDir, "brain"), { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+    writeFileSync(join(antigravityDir, "antigravity-oauth-token"), "token");
+    writeFileSync(join(antigravityDir, "settings.json"), "{}");
+    writeFileSync(join(antigravityDir, "conversation_summaries.db"), "large state");
+    writeFileSync(join(antigravityDir, "brain", "transcript.jsonl"), "history");
+
+    const command = buildDockerAgentCommand({
+      agent: "antigravity",
+      command: {
+        command: "agy",
+        args: ["--prompt", "hello"],
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: { HOME: home },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      workDir,
+    });
+
+    assert.ok(
+      command.args.includes(
+        `${join(antigravityDir, "antigravity-oauth-token")}:/tmp/headless-host-home/.gemini/antigravity-cli/antigravity-oauth-token:ro`,
+      ),
+    );
+    assert.ok(
+      command.args.includes(
+        `${join(antigravityDir, "settings.json")}:/tmp/headless-host-home/.gemini/antigravity-cli/settings.json:ro`,
+      ),
+    );
+    assert.ok(!command.args.some((arg) => arg.includes("conversation_summaries.db")));
+    assert.ok(!command.args.some((arg) => arg.includes("/antigravity-cli:/tmp/headless-host-home")));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("preserves prompt-file stdin through docker for print-command output", () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -874,6 +874,14 @@ test("exposes config metadata", () => {
     configRelDir: ".gemini/antigravity-cli",
     workspaceConfigRelDir: ".agents",
     seedPaths: [".gemini/antigravity-cli", ".gemini/config"],
+    dockerSeedFiles: {
+      ".gemini/antigravity-cli": [
+        "antigravity-oauth-token",
+        "settings.json",
+        "installation_id",
+        "jetski_state.pbtxt",
+      ],
+    },
   });
 });
 


### PR DESCRIPTION
## What changed

- Add optional provider-owned Docker seed-file allowlists.
- Use the allowlist for Antigravity's `.gemini/antigravity-cli` state directory.
- Mount only authentication and settings files instead of the entire directory.
- Add regression coverage, documentation, and a changelog entry.

## Why

Antigravity stores credentials beside conversation summaries, brain transcripts, and other large runtime state. Docker currently mounts the whole directory and copies it into the container's temporary home on every invocation. That can expose unnecessary host state and copy hundreds of megabytes into container memory for each run.

The new allowlist mounts only the files needed by the container. Other agents retain the existing behavior.

## Validation

- `npm run check` builds successfully and reports 304 passing tests; four pre-existing Modal tests fail with `invalid pax header`.
- `node --import tsx --test tests/docker.test.ts tests/headless.test.ts` — 152 passing.
- `npm run pack:check` — passed.
- `git diff --check` — passed.
