### PR TITLE
feat: add durable Docker sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 
 - Added durable Docker sessions with `--docker --session <name>`, persisting each native agent home under `~/.headless/docker-sessions` for multi-turn conversations while keeping the default Docker mode ephemeral.
+- Thanks to Anant Garg (@anantgar) for contributing durable Docker sessions.
 - Changed Docker auth seeding for Antigravity to mount only credential and settings files instead of copying its conversation and brain history into each container.
 - Thanks to Anant Garg (@anantgar) for contributing safer Antigravity Docker credential seeding.
 - Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TBD
 
+- Added durable Docker sessions with `--docker --session <name>`, persisting each native agent home under `~/.headless/docker-sessions` for multi-turn conversations while keeping the default Docker mode ephemeral.
 - Changed Docker auth seeding for Antigravity to mount only credential and settings files instead of copying its conversation and brain history into each container.
 - Thanks to Anant Garg (@anantgar) for contributing safer Antigravity Docker credential seeding.
 - Added combined `--json --usage` output for one-shot runs: Headless streams the native trace unchanged, appends normalized usage after the native process exits, and does not require an extractable final assistant message.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ headless codex --allow read-only --prompt "Review this repo"
 
 # Start or resume native sessions.
 headless codex --prompt "Continue the fix" --session bughunt
+headless codex --docker --session bughunt --prompt "Continue the fix in a durable Docker home"
 
 # Launch an interactive tmux session.
 headless codex --prompt "Fix the failing tests" --tmux

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -93,6 +93,7 @@ Tune polling with `HEADLESS_RUN_STATUS_INTERVAL_MS`. Modal orchestrator runs rel
 ## Docker Run Coordination
 
 Docker run coordination mounts the host run directory into containers with `HEADLESS_RUN_DIR`, so containerized nodes can read and update the same local run state.
+Containerized run nodes currently support `oneshot` coordination only; explicit `--docker --coordination session` and `--docker --session` run-node combinations are rejected because follow-up `run message` invocations do not persist Docker launch options.
 
 ```bash
 headless codex --role worker --run auth --node worker-1 --docker --prompt "Implement the next task"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -193,7 +193,8 @@ headless codex --docker --session bughunt --prompt "Continue the investigation a
 
 The workdir is always persisted through its normal host bind mount. A durable Docker session additionally persists the agent home; seed files are copied only when they do not already exist, so later turns cannot overwrite native conversation state. Delete the corresponding directory to reset the Docker session. Set `HEADLESS_DOCKER_SESSION_ROOT` to use a different absolute root directory.
 
-Durable Docker sessions currently require POSIX filesystem permissions and are rejected on Windows hosts. An existing custom root must be owned by the current user, must not be group- or world-writable, and must not grant access through a permissive macOS ACL; Headless preserves its existing mode. Its parent chain must also be owned by the current user or root and must not be writable by other users unless the directory has the sticky bit, as with `/tmp`.
+Durable Docker sessions currently require POSIX filesystem permissions and are rejected on Windows hosts. An existing custom root must be owned by the current user, must not be group- or world-writable, must not overlap the workdir, and must not grant access through a permissive macOS ACL; Headless preserves its existing mode. Its parent chain must also be owned by the current user or root and must not be writable by other users unless the directory has the sticky bit, as with `/tmp`.
+In all Docker modes, the workdir must remain separate from the reserved `/headless-home` container path.
 
 Docker mode cannot be combined with `--tmux`, `send`, `rename`, or `--list`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -169,7 +169,7 @@ Use `headless attach` without a session name to attach to the most recently acti
 
 ## Docker
 
-Docker mode wraps one-shot headless execution in `docker run --rm`. It mounts the target workdir at the same absolute path inside the container, mounts existing agent config/auth seed paths read-only, passes curated credential environment variables, and runs the selected agent from `ghcr.io/roberttlange/headless:latest` by default. For Antigravity, Docker mounts only the credential files needed for authentication and settings; it does not copy the conversation and brain history stored alongside them into the container home.
+Docker mode wraps headless execution in `docker run --rm`. By default it is one-shot: the target workdir is mounted at the same absolute path inside the container, existing agent config/auth seed paths are mounted read-only, curated credential environment variables are passed through, and the container home is a temporary filesystem. It runs the selected agent from `ghcr.io/roberttlange/headless:latest` by default. For Antigravity, Docker mounts only the credential files needed for authentication and settings; it does not copy the conversation and brain history stored alongside them into the container home.
 
 ```bash
 headless codex --prompt "Fix the failing tests" --docker
@@ -184,7 +184,16 @@ headless codex --prompt "Use the private provider" --docker --docker-env OPENROU
 headless gemini --prompt "Inspect this repo" --docker --docker-arg --network=host
 ```
 
-Docker mode is only for one-shot headless execution. It cannot be combined with `--tmux`, `send`, `rename`, or `--list`.
+Add `--session <name>` to make Docker execution durable across turns. Headless stores the container home under `~/.headless/docker-sessions/<agent>/<name>` and keeps the native agent's session files there while continuing to remove each container after the turn.
+
+```bash
+headless codex --docker --session bughunt --prompt "Start investigating the failing tests"
+headless codex --docker --session bughunt --prompt "Continue the investigation and fix the root cause"
+```
+
+The workdir is always persisted through its normal host bind mount. A durable Docker session additionally persists the agent home; seed files are copied only when they do not already exist, so later turns cannot overwrite native conversation state. Delete the corresponding directory to reset the Docker session. Set `HEADLESS_DOCKER_SESSION_ROOT` to use a different absolute root directory.
+
+Docker mode cannot be combined with `--tmux`, `send`, `rename`, or `--list`.
 
 For local development or when the default image has not been published yet, build the packaged Dockerfile explicitly.
 
@@ -278,7 +287,7 @@ Options:
 - `--acp-registry`: with `--acp-agent`, use a custom ACP registry URL.
 - `--acp-registry-file`: with `--acp-agent`, read registry JSON from a local file.
 - `--work-dir`, `-C`: run the agent from a specific working directory.
-- `--docker`: run the agent inside Docker for one-shot headless execution.
+- `--docker`: run the agent inside Docker; add `--session` for a durable multi-turn container home.
 - `--modal`: run the agent in a Modal CPU sandbox for one-shot headless execution.
 - `--timeout <s>`: stop one-shot local, Docker, Modal, or `--tmux --wait` execution after the given number of seconds.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.
@@ -317,6 +326,7 @@ See [orchestration.md](orchestration.md) for `--role`, `--run`, `--node`, `--tea
 - `HEADLESS_ACP_REGISTRY_FILE`: local ACP registry JSON file.
 - `HEADLESS_ACP_REGISTRY_JSON`: inline ACP registry JSON, mainly useful for tests or wrappers.
 - `HEADLESS_CRON_DIR`: cron state root. Defaults to `~/.headless/cron`.
+- `HEADLESS_DOCKER_SESSION_ROOT`: root for durable Docker session homes. Defaults to `~/.headless/docker-sessions`.
 - `HEADLESS_CLI_BIN`: binary path the cron daemon uses to start scheduled Headless invocations.
 - `HEADLESS_BIN`: fallback binary path for detached Headless child invocations.
 - `HEADLESS_RUN_DIR`: concrete directory for the active run store, mainly used by Docker run coordination.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -193,6 +193,8 @@ headless codex --docker --session bughunt --prompt "Continue the investigation a
 
 The workdir is always persisted through its normal host bind mount. A durable Docker session additionally persists the agent home; seed files are copied only when they do not already exist, so later turns cannot overwrite native conversation state. Delete the corresponding directory to reset the Docker session. Set `HEADLESS_DOCKER_SESSION_ROOT` to use a different absolute root directory.
 
+Durable Docker sessions currently require POSIX filesystem permissions and are rejected on Windows hosts. An existing custom root must be owned by the current user, must not be group- or world-writable, and must not grant access through a permissive macOS ACL; Headless preserves its existing mode. Its parent chain must also be owned by the current user or root and must not be writable by other users unless the directory has the sticky bit, as with `/tmp`.
+
 Docker mode cannot be combined with `--tmux`, `send`, `rename`, or `--list`.
 
 For local development or when the default image has not been published yet, build the packaged Dockerfile explicitly.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -184,7 +184,7 @@ headless codex --prompt "Use the private provider" --docker --docker-env OPENROU
 headless gemini --prompt "Inspect this repo" --docker --docker-arg --network=host
 ```
 
-Add `--session <name>` to make Docker execution durable across turns. Headless stores the container home under `~/.headless/docker-sessions/<agent>/<name>` and keeps the native agent's session files there while continuing to remove each container after the turn.
+Add `--session <name>` to make Docker execution durable across turns. Headless stores the container home under `~/.headless/docker-sessions/<agent>/<name-prefix>-<hash>` and keeps the native agent's session files there while continuing to remove each container after the turn. The readable prefix may be truncated; the exact-name hash keeps aliases distinct on case-insensitive filesystems.
 
 ```bash
 headless codex --docker --session bughunt --prompt "Start investigating the failing tests"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.21.0",
         "modal": "^0.7.4",
+        "proper-lockfile": "^4.1.2",
         "zod": "^4.2.0"
       },
       "bin": {
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@bufbuild/protobuf": "^2.12.0",
         "@types/node": "^22.10.2",
+        "@types/proper-lockfile": "^4.1.4",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2"
       },
@@ -669,6 +671,23 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
@@ -853,6 +872,12 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -923,6 +948,17 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
@@ -954,6 +990,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/smol-toml": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@bufbuild/protobuf": "^2.12.0",
     "@types/node": "^22.10.2",
+    "@types/proper-lockfile": "^4.1.4",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"
   },
@@ -46,6 +47,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.21.0",
     "modal": "^0.7.4",
+    "proper-lockfile": "^4.1.2",
     "zod": "^4.2.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3732,7 +3732,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.runId && parsed.role && coordination === "oneshot") {
       sessionAlias = undefined;
     }
-    const dockerSessionHome = parsed.docker && sessionAlias
+    let dockerSessionHome = parsed.docker && sessionAlias
       ? dockerSessionHomePath(parsed.agent, sessionAlias, env)
       : undefined;
     if (parsed.docker && sessionAlias && !dockerSessionHome) {
@@ -3740,7 +3740,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     if (dockerSessionHome) {
       validateDockerSessionEnv(parsed.agent, parsed.dockerEnv);
-      ensureDockerSessionHome(dockerSessionHome);
+      dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
     }
     dockerSessionLock = dockerSessionHome ? await acquireDockerSessionLock(dockerSessionHome) : undefined;
     const sessionEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1319,23 +1319,44 @@ async function discoverNativeSessionId(
   }
   if (agent === "gemini") {
     if (dockerSession) {
-      return resolveLatestNativeTranscript("gemini", cwd, env, startedAt ? { startedAt } : {})?.sessionId ?? "";
+      return resolveLatestNativeTranscript(
+        "gemini",
+        cwd,
+        env,
+        startedAt ? { startedAt } : {},
+        { dockerSessionRoot: env.HOME },
+      )?.sessionId ?? "";
     }
     return await newestGeminiSessionId(cwd, env);
   }
   if (agent === "antigravity") {
-    return newestAntigravitySessionId(cwd, env, startedAt);
+    return newestAntigravitySessionId(cwd, env, startedAt, dockerSession);
   }
   if (agent === "cursor" && dockerSession) {
     return env.HOME ? readDockerCursorSessionId(env.HOME) : "";
   }
   if (agent === "opencode") {
     if (dockerSession) {
-      return resolveLatestNativeTranscript("opencode", cwd, env, startedAt ? { startedAt } : {})?.sessionId ?? "";
+      return resolveLatestNativeTranscript(
+        "opencode",
+        cwd,
+        env,
+        startedAt ? { startedAt } : {},
+        { dockerSessionRoot: env.HOME },
+      )?.sessionId ?? "";
     }
     return await newestOpenCodeSessionId(cwd, env);
   }
   if (agent === "pi") {
+    if (dockerSession) {
+      return resolveLatestNativeTranscript(
+        "pi",
+        cwd,
+        env,
+        startedAt ? { startedAt } : {},
+        { dockerSessionRoot: env.HOME },
+      )?.path ?? "";
+    }
     return newestPiSessionFile(cwd, env);
   }
   return "";
@@ -1354,8 +1375,19 @@ async function newestGeminiSessionId(cwd: string | undefined, env: Env): Promise
   return matches.at(-1)?.[1] ?? "";
 }
 
-function newestAntigravitySessionId(cwd: string | undefined, env: Env, startedAt: string | undefined): string {
-  return resolveLatestNativeTranscript("antigravity", cwd ?? process.cwd(), env, startedAt ? { startedAt } : {})?.sessionId ?? "";
+function newestAntigravitySessionId(
+  cwd: string | undefined,
+  env: Env,
+  startedAt: string | undefined,
+  dockerSession: boolean,
+): string {
+  return resolveLatestNativeTranscript(
+    "antigravity",
+    cwd ?? process.cwd(),
+    env,
+    startedAt ? { startedAt } : {},
+    dockerSession ? { dockerSessionRoot: env.HOME } : {},
+  )?.sessionId ?? "";
 }
 
 async function newestOpenCodeSessionId(cwd: string | undefined, env: Env): Promise<string> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3691,21 +3691,23 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return code;
     }
 
-    let sessionPlan = buildSessionPlan(parsed.agent, parsed.sessionAlias, env);
+    let sessionAlias = parsed.sessionAlias;
     if (parsed.runId && parsed.role && coordination === "session" && !parsed.sessionAlias) {
-      sessionPlan = buildSessionPlan(parsed.agent, nodeId, env);
+      sessionAlias = nodeId;
     }
     if (parsed.runId && parsed.role && coordination === "oneshot") {
-      sessionPlan = undefined;
+      sessionAlias = undefined;
     }
+    const dockerSessionHome = parsed.docker && sessionAlias
+      ? dockerSessionHomePath(parsed.agent, sessionAlias, env)
+      : undefined;
+    if (parsed.docker && sessionAlias && !dockerSessionHome) {
+      throw new CliError("HOME is required for --session");
+    }
+    const sessionEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;
+    let sessionPlan = buildSessionPlan(parsed.agent, sessionAlias, sessionEnv);
     if (!parsed.printCommand) {
       sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env);
-    }
-    const dockerSessionHome = parsed.docker && sessionPlan
-      ? dockerSessionHomePath(parsed.agent, sessionPlan.alias, env)
-      : undefined;
-    if (parsed.docker && sessionPlan && !dockerSessionHome) {
-      throw new CliError("HOME is required for --session");
     }
     if (dockerSessionHome && !parsed.printCommand) {
       ensureDockerSessionHome(dockerSessionHome);
@@ -3876,7 +3878,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         ? `${usageCommandTrace}\n${antigravityUsageTrace}`
         : usageCommandTrace;
       if (result.code === 0 && sessionPlan) {
-        await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env, dockerSessionHome);
+        await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, sessionEnv, dockerSessionHome);
       }
       if (parsed.runId && parsed.role && nodeId) {
         const finalMessage =

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,7 +86,11 @@ import {
   resolveOpencodeTranscriptByTitle,
   resolvePiTranscriptInDir,
 } from "./native-transcripts.js";
-import { acquireDockerSessionLock, acquireLaunchLock } from "./launch-lock.js";
+import {
+  acquireDockerSessionLock,
+  acquireLaunchLock,
+  isDockerSessionLockSignalListener,
+} from "./launch-lock.js";
 import { forceKillWindowsProcessTree } from "./process-tree.js";
 import { compactOversizedTraceLine } from "./relevant-trace.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
@@ -1048,6 +1052,7 @@ interface ExecuteCommandOptions {
   captureFinalMessageTrace?: boolean;
   captureRelevantTrace?: boolean;
   cleanupBeforeParentSignalExit?: () => void;
+  inheritedSignalListeners?: ReadonlyMap<NodeJS.Signals, ReadonlySet<NodeJS.SignalsListener>>;
 }
 
 interface WaitingSpinner {
@@ -1085,6 +1090,12 @@ const waitingSpinnerVerbs = [
   "path tracing",
   "output polishing",
 ];
+
+function parentExitSignals(): NodeJS.Signals[] {
+  return process.platform === "win32"
+    ? ["SIGINT", "SIGTERM", "SIGBREAK"]
+    : ["SIGHUP", "SIGINT", "SIGTERM", "SIGQUIT"];
+}
 
 function randomWaitingSpinnerVerb(): string {
   return waitingSpinnerVerbs[Math.floor(Math.random() * waitingSpinnerVerbs.length)] ?? waitingSpinnerVerbs[0];
@@ -1669,13 +1680,12 @@ async function executeCommand(
             process.off(signal, handler);
           }
         };
-        const exitSignals: NodeJS.Signals[] =
-          process.platform === "win32"
-            ? ["SIGINT", "SIGTERM", "SIGBREAK"]
-            : ["SIGHUP", "SIGINT", "SIGTERM", "SIGQUIT"];
-        for (const signal of exitSignals) {
+        for (const signal of parentExitSignals()) {
           const handler = () => {
-            const hasExternalListener = process.listeners(signal).some((listener) => listener !== handler);
+            const inheritedListeners = options.inheritedSignalListeners?.get(signal);
+            const hasExternalListener = inheritedListeners
+              ? process.listeners(signal).some((listener) => inheritedListeners.has(listener))
+              : process.listeners(signal).some((listener) => listener !== handler);
             signalChildTree(signal);
             try {
               options.cleanupBeforeParentSignalExit?.();
@@ -2959,6 +2969,12 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
   const stderr = deps.stderr ?? ((text: string) => process.stderr.write(text));
   const stderrIsTTY = deps.stderrIsTTY ?? Boolean(process.stderr.isTTY);
   const env: Env = { ...(deps.env ?? process.env) };
+  const inheritedSignalListeners = new Map(
+    parentExitSignals().map((signal) => [
+      signal,
+      new Set(process.listeners(signal).filter((listener) => !isDockerSessionLockSignalListener(listener))),
+    ] as const),
+  );
   let registeredRunNode: { runId: string; nodeId: string } | undefined;
   let dockerSessionLock: { release: () => Promise<Error | undefined> } | undefined;
 
@@ -3964,6 +3980,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
               captureFinalMessageTrace: parsed.agent === "antigravity" && parsed.json && Boolean(parsed.runId),
               captureRelevantTrace: parsed.json && (parsed.usage || Boolean(parsed.runId) || Boolean(parsed.sessionAlias)),
               cleanupBeforeParentSignalExit: antigravityUsageCapture?.cleanup,
+              inheritedSignalListeners,
             });
         if (result && parsed.modal && parsed.runId && nodeId && stdoutHandling === "capture") {
           appendNodeLog(env, parsed.runId, nodeId, "stdout", result.stdout);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ import {
   LOCAL_DOCKER_IMAGE,
   detectDockerHostUser,
   ensureDockerSessionHome,
+  ensureDockerSessionStoreDirectory,
   readDockerCursorSessionId,
 } from "./docker.js";
 import {
@@ -101,7 +102,14 @@ import {
   validateRunId,
   type RunNode,
 } from "./runs.js";
-import { readStoredSession, sessionStorePath, writeStoredSession, writeStoredTmuxSession, type StoredTmuxWaitStrategy } from "./sessions.js";
+import {
+  readStoredSession,
+  SECURE_SESSION_STORE_ENV,
+  sessionStorePath,
+  writeStoredSession,
+  writeStoredTmuxSession,
+  type StoredTmuxWaitStrategy,
+} from "./sessions.js";
 import { quoteCommand } from "./shell.js";
 import { cell, renderTable as renderBoxTable, type TableCell } from "./table.js";
 import {
@@ -1279,6 +1287,9 @@ async function persistSessionPlan(
     (await discoverNativeSessionId(agent, stdout, cwd, discoveryEnv, plan.startedAt, Boolean(dockerSessionHome)));
   if (!nativeId) {
     throw new CliError(`could not determine ${agent} session id for --session ${plan.alias}`);
+  }
+  if (dockerSessionHome) {
+    ensureDockerSessionStoreDirectory(dockerSessionHome);
   }
   writeStoredSession(env, {
     agent,
@@ -3775,7 +3786,13 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
     }
     dockerSessionLock = dockerSessionHome ? await acquireDockerSessionLock(dockerSessionHome) : undefined;
-    const sessionEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;
+    if (dockerSessionHome) {
+      dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
+      ensureDockerSessionStoreDirectory(dockerSessionHome);
+    }
+    const sessionEnv = dockerSessionHome
+      ? { ...env, HOME: dockerSessionHome, [SECURE_SESSION_STORE_ENV]: "1" }
+      : env;
     let sessionPlan = buildSessionPlan(parsed.agent, sessionAlias, sessionEnv);
     if (!parsed.printCommand) {
       sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env, parsed.docker ? "docker" : "local");
@@ -4003,6 +4020,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return result.code;
     } finally {
       statusReporter?.stop();
+      if (dockerSessionHome) {
+        dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
+        ensureDockerSessionStoreDirectory(dockerSessionHome);
+      }
     }
   } catch (error) {
     if (registeredRunNode) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ import {
 import {
   buildDockerAgentCommand,
   DEFAULT_DOCKER_IMAGE,
+  dockerSessionAgentHomeEnvNames,
   dockerSessionNativeId,
   dockerSessionHomePath,
   LOCAL_DOCKER_IMAGE,
@@ -1272,7 +1273,7 @@ async function persistSessionPlan(
   if (!plan) {
     return;
   }
-  const discoveryEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;
+  const discoveryEnv = dockerSessionHome ? dockerSessionDiscoveryEnv(agent, env, dockerSessionHome) : env;
   const nativeId =
     plan.nativeId ||
     (await discoverNativeSessionId(agent, stdout, cwd, discoveryEnv, plan.startedAt, Boolean(dockerSessionHome)));
@@ -1285,6 +1286,23 @@ async function persistSessionPlan(
     nativeId,
     workDir: cwd ?? process.cwd(),
   });
+}
+
+function dockerSessionDiscoveryEnv(agent: AgentName, env: Env, dockerSessionHome: string): Env {
+  const discoveryEnv: Env = { ...env, HOME: dockerSessionHome };
+  for (const name of dockerSessionAgentHomeEnvNames(agent)) {
+    delete discoveryEnv[name];
+  }
+  return discoveryEnv;
+}
+
+function validateDockerSessionEnv(agent: AgentName, dockerEnv: string[]): void {
+  const agentHomeVariables = new Set<string>(dockerSessionAgentHomeEnvNames(agent));
+  const override = dockerEnv.find((item) => agentHomeVariables.has(item.split("=", 1)[0] ?? ""));
+  if (override) {
+    const name = override.split("=", 1)[0];
+    throw new CliError(`${name} cannot be overridden with --docker-env when using --docker --session`);
+  }
 }
 
 async function discoverNativeSessionId(
@@ -3718,6 +3736,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       : undefined;
     if (parsed.docker && sessionAlias && !dockerSessionHome) {
       throw new CliError("HOME is required for --session");
+    }
+    if (dockerSessionHome) {
+      validateDockerSessionEnv(parsed.agent, parsed.dockerEnv);
     }
     const sessionEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;
     let sessionPlan = buildSessionPlan(parsed.agent, sessionAlias, sessionEnv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1191,7 +1191,7 @@ function validateSessionAlias(alias: string | undefined): string | undefined {
   if (alias === undefined) {
     return undefined;
   }
-  if (!/^[A-Za-z0-9_.-]+$/.test(alias)) {
+  if (alias === "." || alias === ".." || !/^[A-Za-z0-9_.-]+$/.test(alias)) {
     throw new CliError("invalid session name; use letters, numbers, dots, dashes, or underscores");
   }
   return alias;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,7 @@ import {
   LOCAL_DOCKER_IMAGE,
   detectDockerHostUser,
   ensureDockerSessionHome,
+  readDockerCursorSessionId,
 } from "./docker.js";
 import {
   buildModalRunSummary,
@@ -1187,6 +1188,8 @@ interface SessionPlan {
   startedAt?: string;
 }
 
+type SessionExecution = "docker" | "local";
+
 function validateSessionAlias(alias: string | undefined): string | undefined {
   if (alias === undefined) {
     return undefined;
@@ -1221,11 +1224,12 @@ async function prepareSessionPlan(
   plan: SessionPlan | undefined,
   cwd: string | undefined,
   env: Env,
+  execution: SessionExecution,
 ): Promise<SessionPlan | undefined> {
   if (!plan || plan.mode !== "new") {
     return plan;
   }
-  if (agent === "cursor" && !plan.nativeId) {
+  if (agent === "cursor" && !plan.nativeId && execution === "local") {
     return { ...plan, nativeId: await mintCursorSessionId(cwd, env) };
   }
   if (agent === "antigravity" && !plan.nativeId) {
@@ -1303,6 +1307,9 @@ async function discoverNativeSessionId(
   }
   if (agent === "antigravity") {
     return newestAntigravitySessionId(cwd, env, startedAt);
+  }
+  if (agent === "cursor" && dockerSession) {
+    return env.HOME ? readDockerCursorSessionId(env.HOME) : "";
   }
   if (agent === "opencode") {
     if (dockerSession) {
@@ -2843,7 +2850,15 @@ async function executeStoredNode(
     { baseInstructionPrompt: defaults.baseInstructionPrompt },
   );
   const sessionPlan =
-    node.coordination === "session" ? await prepareSessionPlan(node.agent, buildSessionPlan(node.agent, node.sessionAlias ?? node.nodeId, env), node.workDir, env) : undefined;
+    node.coordination === "session"
+      ? await prepareSessionPlan(
+          node.agent,
+          buildSessionPlan(node.agent, node.sessionAlias ?? node.nodeId, env),
+          node.workDir,
+          env,
+          "local",
+        )
+      : undefined;
   const command = withRunEnvironment(
     buildAgentCommand(
       node.agent,
@@ -3707,7 +3722,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     const sessionEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;
     let sessionPlan = buildSessionPlan(parsed.agent, sessionAlias, sessionEnv);
     if (!parsed.printCommand) {
-      sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env);
+      sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env, parsed.docker ? "docker" : "local");
     }
     if (dockerSessionHome && !parsed.printCommand) {
       ensureDockerSessionHome(dockerSessionHome);
@@ -3743,6 +3758,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         persistentHome: dockerSessionHome,
         runDirHost: parsed.runId ? runDirectory(env, parsed.runId) : undefined,
         runId: parsed.runId,
+        sessionBootstrap:
+          parsed.agent === "cursor" && sessionPlan?.mode === "new" && dockerSessionHome
+            ? "initialize-cursor"
+            : undefined,
         workDir: cwd ?? process.cwd(),
       });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,7 +83,7 @@ import {
   resolveOpencodeTranscriptByTitle,
   resolvePiTranscriptInDir,
 } from "./native-transcripts.js";
-import { acquireLaunchLock } from "./launch-lock.js";
+import { acquireDockerSessionLock, acquireLaunchLock } from "./launch-lock.js";
 import { forceKillWindowsProcessTree } from "./process-tree.js";
 import { compactOversizedTraceLine } from "./relevant-trace.js";
 import { handleRunCommand as handleRunCommandImpl } from "./run-commands.js";
@@ -2915,6 +2915,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
   const stderrIsTTY = deps.stderrIsTTY ?? Boolean(process.stderr.isTTY);
   const env: Env = { ...(deps.env ?? process.env) };
   let registeredRunNode: { runId: string; nodeId: string } | undefined;
+  let dockerSessionLock: { release: () => Promise<Error | undefined> } | undefined;
 
   if (argv[0] === "acp-stdio") {
     await runAcpStdioAgent();
@@ -3739,14 +3740,13 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     if (dockerSessionHome) {
       validateDockerSessionEnv(parsed.agent, parsed.dockerEnv);
+      ensureDockerSessionHome(dockerSessionHome);
     }
+    dockerSessionLock = dockerSessionHome ? await acquireDockerSessionLock(dockerSessionHome) : undefined;
     const sessionEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;
     let sessionPlan = buildSessionPlan(parsed.agent, sessionAlias, sessionEnv);
     if (!parsed.printCommand) {
       sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env, parsed.docker ? "docker" : "local");
-    }
-    if (dockerSessionHome) {
-      ensureDockerSessionHome(dockerSessionHome);
     }
     const commandSessionPlan = dockerSessionHome && sessionPlan
       ? { ...sessionPlan, nativeId: dockerSessionNativeId(parsed.agent, sessionPlan.nativeId, dockerSessionHome) }
@@ -3991,6 +3991,11 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return 2;
     }
     throw error;
+  } finally {
+    const releaseError = await dockerSessionLock?.release();
+    if (releaseError) {
+      stderr(`headless: Docker session lock release failed: ${releaseError.message}\n`);
+    }
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3461,6 +3461,14 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     validateSessionAlias(parsed.sessionAlias);
     const coordination = effectiveCoordination(parsed, config.general.coordination);
+    if (
+      parsed.docker &&
+      parsed.runId &&
+      parsed.role &&
+      (coordination === "session" || parsed.sessionAlias !== undefined)
+    ) {
+      throw new CliError("Docker run nodes do not support durable sessions; use oneshot coordination without --session");
+    }
     const nodeId = nodeIdForRole(parsed.role, parsed.nodeId);
     if (parsed.runId !== undefined && parsed.role === undefined) {
       throw new CliError("--run requires --role");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3974,6 +3974,10 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         antigravityUsageCapture?.cleanup();
       }
 
+      if (dockerSessionHome) {
+        dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
+        ensureDockerSessionStoreDirectory(dockerSessionHome);
+      }
       if (!result) {
         throw new CliError("agent execution did not produce a result");
       }
@@ -4036,10 +4040,6 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
       return result.code;
     } finally {
       statusReporter?.stop();
-      if (dockerSessionHome) {
-        dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
-        ensureDockerSessionStoreDirectory(dockerSessionHome);
-      }
     }
   } catch (error) {
     if (registeredRunNode) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,8 +46,11 @@ import {
 import {
   buildDockerAgentCommand,
   DEFAULT_DOCKER_IMAGE,
+  dockerSessionNativeId,
+  dockerSessionHomePath,
   LOCAL_DOCKER_IMAGE,
   detectDockerHostUser,
+  ensureDockerSessionHome,
 } from "./docker.js";
 import {
   buildModalRunSummary,
@@ -231,7 +234,7 @@ function usage(): string {
     "  --prompt, -p <text>   Prompt text.",
     "  --prompt-file <path>  Read prompt from a file.",
     "  --work-dir, -C <path> Run from this directory.",
-    "  --docker             Run the agent inside Docker.",
+    "  --docker             Run the agent inside Docker; use --session for durable turns.",
     "  --docker-image <img> Docker image. Defaults to ghcr.io/roberttlange/headless:latest.",
     "  --docker-arg <arg>   Extra docker run argument. Repeat for multiple args.",
     "  --docker-env <env>   Pass env into Docker as NAME or NAME=value. Repeatable.",
@@ -1260,11 +1263,15 @@ async function persistSessionPlan(
   stdout: string,
   cwd: string | undefined,
   env: Env,
+  dockerSessionHome?: string,
 ): Promise<void> {
   if (!plan) {
     return;
   }
-  const nativeId = plan.nativeId || (await discoverNativeSessionId(agent, stdout, cwd, env, plan.startedAt));
+  const discoveryEnv = dockerSessionHome ? { ...env, HOME: dockerSessionHome } : env;
+  const nativeId =
+    plan.nativeId ||
+    (await discoverNativeSessionId(agent, stdout, cwd, discoveryEnv, plan.startedAt, Boolean(dockerSessionHome)));
   if (!nativeId) {
     throw new CliError(`could not determine ${agent} session id for --session ${plan.alias}`);
   }
@@ -1282,18 +1289,25 @@ async function discoverNativeSessionId(
   cwd: string | undefined,
   env: Env,
   startedAt?: string,
+  dockerSession: boolean = false,
 ): Promise<string> {
   const fromTrace = extractNativeSessionId(agent, stdout);
   if (fromTrace) {
     return fromTrace;
   }
   if (agent === "gemini") {
+    if (dockerSession) {
+      return resolveLatestNativeTranscript("gemini", cwd, env, startedAt ? { startedAt } : {})?.sessionId ?? "";
+    }
     return await newestGeminiSessionId(cwd, env);
   }
   if (agent === "antigravity") {
     return newestAntigravitySessionId(cwd, env, startedAt);
   }
   if (agent === "opencode") {
+    if (dockerSession) {
+      return resolveLatestNativeTranscript("opencode", cwd, env, startedAt ? { startedAt } : {})?.sessionId ?? "";
+    }
     return await newestOpenCodeSessionId(cwd, env);
   }
   if (agent === "pi") {
@@ -3365,9 +3379,6 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (parsed.sessionAlias !== undefined && parsed.tmuxName !== undefined) {
       throw new CliError("--session cannot be used with --name");
     }
-    if (parsed.sessionAlias !== undefined && parsed.docker) {
-      throw new CliError("--session cannot be used with --docker");
-    }
     if (parsed.sessionAlias !== undefined && parsed.modal) {
       throw new CliError("--session cannot be used with --modal");
     }
@@ -3690,6 +3701,18 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (!parsed.printCommand) {
       sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env);
     }
+    const dockerSessionHome = parsed.docker && sessionPlan
+      ? dockerSessionHomePath(parsed.agent, sessionPlan.alias, env)
+      : undefined;
+    if (parsed.docker && sessionPlan && !dockerSessionHome) {
+      throw new CliError("HOME is required for --session");
+    }
+    if (dockerSessionHome && !parsed.printCommand) {
+      ensureDockerSessionHome(dockerSessionHome);
+    }
+    const commandSessionPlan = dockerSessionHome && sessionPlan
+      ? { ...sessionPlan, nativeId: dockerSessionNativeId(parsed.agent, sessionPlan.nativeId, dockerSessionHome) }
+      : sessionPlan;
     let command = withRunEnvironment(buildAgentCommand(
       parsed.agent,
       applySessionPlan({
@@ -3699,7 +3722,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         model: configuredDefaults.model,
         allow,
         reasoningEffort: configuredDefaults.reasoningEffort,
-      }, sessionPlan),
+      }, commandSessionPlan),
       env,
     ), parsed.runId, nodeId);
     const reasoningWarning = unsupportedReasoningEffortWarning(parsed.agent, configuredDefaults.reasoningEffort, "headless");
@@ -3715,6 +3738,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         env,
         hostUser: detectDockerHostUser(),
         image: parsed.dockerImage ?? DEFAULT_DOCKER_IMAGE,
+        persistentHome: dockerSessionHome,
         runDirHost: parsed.runId ? runDirectory(env, parsed.runId) : undefined,
         runId: parsed.runId,
         workDir: cwd ?? process.cwd(),
@@ -3852,7 +3876,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         ? `${usageCommandTrace}\n${antigravityUsageTrace}`
         : usageCommandTrace;
       if (result.code === 0 && sessionPlan) {
-        await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env);
+        await persistSessionPlan(parsed.agent, sessionPlan, commandTrace, cwd, env, dockerSessionHome);
       }
       if (parsed.runId && parsed.role && nodeId) {
         const finalMessage =

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,8 @@ import {
   ensureDockerSessionHome,
   ensureDockerSessionStoreDirectory,
   readDockerCursorSessionId,
+  validateDockerSessionRootWorkDir,
+  validateDockerWorkDir,
 } from "./docker.js";
 import {
   buildModalRunSummary,
@@ -3516,6 +3518,9 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     const commandTimeoutSeconds = parsed.timeoutSeconds ?? config.general.timeoutSeconds;
     const modalTimeoutSeconds = parsed.modalTimeoutSeconds ?? commandTimeoutSeconds ?? DEFAULT_MODAL_TIMEOUT_SECONDS;
     const cwd = validateWorkDir(parsed.workDir);
+    if (parsed.docker) {
+      validateDockerWorkDir(cwd ?? process.cwd());
+    }
     const prompt = await resolvePrompt(parsed, deps, { forceText: parsed.tmux || parsed.role !== undefined || parsed.runId !== undefined });
     const allow = configuredDefaults.allow ?? roleDefaultAllow(parsed.role);
     if (parsed.runId && parsed.role === "orchestrator" && allow === "read-only") {
@@ -3791,11 +3796,14 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     }
     if (dockerSessionHome) {
       validateDockerSessionEnv(parsed.agent, parsed.dockerEnv);
+      validateDockerSessionRootWorkDir(dockerSessionHome, cwd ?? process.cwd());
       dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
+      validateDockerSessionRootWorkDir(dockerSessionHome, cwd ?? process.cwd());
     }
     dockerSessionLock = dockerSessionHome ? await acquireDockerSessionLock(dockerSessionHome) : undefined;
     if (dockerSessionHome) {
       dockerSessionHome = ensureDockerSessionHome(dockerSessionHome);
+      validateDockerSessionRootWorkDir(dockerSessionHome, cwd ?? process.cwd());
       ensureDockerSessionStoreDirectory(dockerSessionHome);
     }
     const sessionEnv = dockerSessionHome

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3745,7 +3745,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
     if (!parsed.printCommand) {
       sessionPlan = await prepareSessionPlan(parsed.agent, sessionPlan, cwd, env, parsed.docker ? "docker" : "local");
     }
-    if (dockerSessionHome && !parsed.printCommand) {
+    if (dockerSessionHome) {
       ensureDockerSessionHome(dockerSessionHome);
     }
     const commandSessionPlan = dockerSessionHome && sessionPlan

--- a/src/docker-transcript-safety.ts
+++ b/src/docker-transcript-safety.ts
@@ -1,0 +1,113 @@
+import { existsSync, lstatSync, opendirSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+const maxTranscriptBytes = 64 * 1024 * 1024;
+
+export function assertSafeDockerAntigravityState(sessionRoot: string, root: string, brainRoot: string): void {
+  assertSafeDockerFile(sessionRoot, join(root, "cache", "last_conversations.json"), 1024 * 1024);
+  assertSafeDockerDirectory(sessionRoot, brainRoot);
+  const directory = opendirSync(brainRoot);
+  let entries = 0;
+  try {
+    let entry;
+    while ((entry = directory.readSync()) !== null) {
+      if (++entries > 100) throw new Error("unsafe Docker transcript state: too many Antigravity conversations");
+      const conversationRoot = join(brainRoot, entry.name);
+      const stats = lstatSync(conversationRoot);
+      if (stats.isFile() && !stats.isSymbolicLink() && stats.size <= 1024 * 1024) continue;
+      if (!stats.isDirectory() || stats.isSymbolicLink()) {
+        throw new Error(`unsafe Docker transcript state path: ${conversationRoot}`);
+      }
+      assertSafeDockerFile(
+        sessionRoot,
+        join(conversationRoot, ".system_generated", "logs", "transcript.jsonl"),
+        maxTranscriptBytes,
+      );
+      assertSafeDockerFile(sessionRoot, join(conversationRoot, "transcript.jsonl"), maxTranscriptBytes);
+    }
+  } finally {
+    directory.closeSync();
+  }
+}
+
+export function assertSafeDockerTree(sessionRoot: string, treeRoot: string): void {
+  if (!existsSync(treeRoot)) return;
+  assertSafeDockerDirectory(sessionRoot, treeRoot);
+  const stack = [treeRoot];
+  let entries = 0;
+  while (stack.length > 0) {
+    const directoryPath = stack.pop() as string;
+    const directory = opendirSync(directoryPath);
+    try {
+      let entry;
+      while ((entry = directory.readSync()) !== null) {
+        if (++entries > 10_000) throw new Error("unsafe Docker transcript state: too many entries");
+        const path = join(directoryPath, entry.name);
+        const stats = lstatSync(path);
+        if (stats.isSymbolicLink()) throw new Error(`unsafe Docker transcript state path: ${path}`);
+        if (stats.isDirectory()) {
+          stack.push(path);
+        } else if (!stats.isFile() || stats.size > maxTranscriptBytes) {
+          throw new Error(`unsafe Docker transcript state path: ${path}`);
+        }
+      }
+    } finally {
+      directory.closeSync();
+    }
+  }
+}
+
+export function assertSafeDockerOpenCodeDatabase(sessionRoot: string, path: string): void {
+  let databaseBytes = assertSafeDockerFile(sessionRoot, path, 256 * 1024 * 1024);
+  const sidecars = [
+    ["-wal", 256 * 1024 * 1024],
+    ["-shm", 64 * 1024 * 1024],
+    ["-journal", 256 * 1024 * 1024],
+  ] as const;
+  for (const [suffix, maxBytes] of sidecars) {
+    databaseBytes += assertSafeDockerFile(sessionRoot, `${path}${suffix}`, maxBytes);
+  }
+  if (databaseBytes > 384 * 1024 * 1024) {
+    throw new Error("unsafe Docker transcript state: OpenCode database files are too large");
+  }
+}
+
+export function assertSafeDockerFile(sessionRoot: string, path: string, maxBytes: number): number {
+  if (!existsSync(path)) return 0;
+  assertSafeDockerPath(sessionRoot, path);
+  const stats = lstatSync(path);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.size > maxBytes) {
+    throw new Error(`unsafe Docker transcript state path: ${path}`);
+  }
+  return stats.size;
+}
+
+function assertSafeDockerDirectory(sessionRoot: string, path: string): void {
+  assertSafeDockerPath(sessionRoot, path);
+  const stats = lstatSync(path);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`unsafe Docker transcript state path: ${path}`);
+  }
+}
+
+function assertSafeDockerPath(sessionRoot: string, path: string): void {
+  const root = resolve(sessionRoot);
+  const target = resolve(path);
+  const relativePath = relative(root, target);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    relativePath.startsWith("..\\") ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(`Docker transcript state escapes the durable home: ${path}`);
+  }
+  let current = root;
+  for (const segment of relativePath.split(/[\\/]/).filter(Boolean)) {
+    current = join(current, segment);
+    if (!existsSync(current)) return;
+    if (lstatSync(current).isSymbolicLink()) {
+      throw new Error(`unsafe Docker transcript state path: ${current}`);
+    }
+  }
+}

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -234,7 +234,7 @@ export function readDockerCursorSessionId(persistentHome: string): string {
   const path = join(persistentHome, ".headless-cursor-session-id");
   let descriptor: number | undefined;
   try {
-    descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
     const stats = fstatSync(descriptor);
     if (!stats.isFile() || stats.size > 256) {
       return "";

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,5 +1,5 @@
-import { existsSync, lstatSync, realpathSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, lstatSync, mkdirSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { getAgentConfig } from "./agents.js";
 import { collectForwardedEnvEntries, type ForwardedEnvEntry } from "./env.js";
@@ -7,14 +7,9 @@ import type { AgentName, BuiltCommand, Env } from "./types.js";
 
 export const DEFAULT_DOCKER_IMAGE = "ghcr.io/roberttlange/headless:latest";
 export const LOCAL_DOCKER_IMAGE = "headless-local:dev";
+export const DOCKER_SESSION_ROOT_ENV = "HEADLESS_DOCKER_SESSION_ROOT";
 const containerHome = "/headless-home";
 const hostHomeMountRoot = "/tmp/headless-host-home";
-const bootstrapScript = [
-  "set -eu",
-  `mkdir -p "${containerHome}"`,
-  `if [ -d "${hostHomeMountRoot}" ]; then cp -R "${hostHomeMountRoot}/." "$HOME"/; fi`,
-  'exec "$@"',
-].join("; ");
 
 type DockerEnvEntry = ForwardedEnvEntry;
 
@@ -26,6 +21,7 @@ export interface DockerAgentCommandOptions {
   env: Env;
   hostUser?: string;
   image: string;
+  persistentHome?: string;
   runDirHost?: string;
   runId?: string;
   workDir: string;
@@ -38,12 +34,43 @@ export function detectDockerHostUser(): string | undefined {
   return `${process.getuid()}:${process.getgid()}`;
 }
 
+export function dockerSessionHomePath(agent: AgentName, alias: string, env: Env): string | undefined {
+  const root =
+    env[DOCKER_SESSION_ROOT_ENV]?.trim() || (env.HOME ? join(env.HOME, ".headless", "docker-sessions") : undefined);
+  return root ? resolve(root, agent, alias) : undefined;
+}
+
+export function ensureDockerSessionHome(path: string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+}
+
+export function dockerSessionNativeId(agent: AgentName, nativeId: string | undefined, persistentHome: string): string | undefined {
+  if (!nativeId || agent !== "pi") {
+    return nativeId;
+  }
+  const relativePath = relative(resolve(persistentHome), resolve(nativeId));
+  if (
+    relativePath === "" ||
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    relativePath.startsWith("..\\") ||
+    isAbsolute(relativePath)
+  ) {
+    return nativeId;
+  }
+  return join(containerHome, relativePath);
+}
+
 export function buildDockerAgentCommand(options: DockerAgentCommandOptions): BuiltCommand {
   const args = ["run", "--rm"];
   if (options.command.stdinText !== undefined || options.command.stdinFile !== undefined) {
     args.push("--interactive");
   }
-  args.push("--tmpfs", `${containerHome}:rw,mode=1777`);
+  if (options.persistentHome) {
+    args.push("--volume", `${options.persistentHome}:${containerHome}:rw`);
+  } else {
+    args.push("--tmpfs", `${containerHome}:rw,mode=1777`);
+  }
   if (options.hostUser) {
     args.push("--user", options.hostUser);
   }
@@ -59,7 +86,15 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
   args.push(...credentialMountArgs(options.env, dockerEnvEntries, workDir));
   args.push(...dockerEnvArgs(dockerEnvEntries));
   args.push(...options.dockerArgs);
-  args.push(options.image, "sh", "-lc", bootstrapScript, "headless-agent", options.command.command, ...options.command.args);
+  args.push(
+    options.image,
+    "sh",
+    "-lc",
+    bootstrapScript(Boolean(options.persistentHome)),
+    "headless-agent",
+    options.command.command,
+    ...options.command.args,
+  );
 
   const dockerCommand: BuiltCommand = { command: "docker", args };
   if (options.command.env) {
@@ -72,6 +107,16 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
     dockerCommand.stdinText = options.command.stdinText;
   }
   return dockerCommand;
+}
+
+function bootstrapScript(persistentHome: boolean): string {
+  const copyFlags = persistentHome ? "-R -n" : "-R";
+  return [
+    "set -eu",
+    `mkdir -p "${containerHome}"`,
+    `if [ -d "${hostHomeMountRoot}" ]; then cp ${copyFlags} "${hostHomeMountRoot}/." "$HOME"/; fi`,
+    'exec "$@"',
+  ].join("; ");
 }
 
 function agentConfigMountArgs(agent: AgentName, env: Env): string[] {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -2,6 +2,7 @@ import {
   closeSync,
   constants,
   existsSync,
+  fchmodSync,
   fstatSync,
   lstatSync,
   mkdirSync,
@@ -10,7 +11,8 @@ import {
   realpathSync,
   statSync,
 } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { getAgentConfig } from "./agents.js";
 import { collectForwardedEnvEntries, type ForwardedEnvEntry } from "./env.js";
@@ -68,8 +70,150 @@ export function dockerSessionHomePath(agent: AgentName, alias: string, env: Env)
   return root ? resolve(root, agent, alias) : undefined;
 }
 
-export function ensureDockerSessionHome(path: string): void {
-  mkdirSync(path, { recursive: true, mode: 0o700 });
+export function ensureDockerSessionHome(path: string): string {
+  if (process.platform === "win32") {
+    throw new Error(
+      "durable Docker sessions are not supported on Windows because private directory ACLs cannot be validated",
+    );
+  }
+  const sessionHome = resolve(path);
+  const agentRoot = dirname(sessionHome);
+  const sessionRoot = dirname(agentRoot);
+  if (dirname(sessionRoot) === sessionRoot) {
+    throw new Error("Docker session root cannot be the filesystem root");
+  }
+  let realSessionRoot = ensureDockerSessionRoot(sessionRoot);
+  assertTrustedDirectoryAncestors(dirname(realSessionRoot));
+  realSessionRoot = validateOwnedDirectory(realSessionRoot, false, true);
+  const realAgentRoot = ensurePrivateOwnedDirectory(join(realSessionRoot, basename(agentRoot)));
+  const realSessionHome = ensurePrivateOwnedDirectory(join(realAgentRoot, basename(sessionHome)));
+  const relativeHome = relative(realSessionRoot, realSessionHome);
+  if (!isContainedRelativePath(relativeHome)) {
+    throw new Error("Docker session home escapes its configured root");
+  }
+  return realSessionHome;
+}
+
+function ensureDockerSessionRoot(path: string): string {
+  const created = mkdirSync(path, { recursive: true, mode: 0o700 }) !== undefined;
+  return validateOwnedDirectory(path, created, false);
+}
+
+function ensurePrivateOwnedDirectory(path: string): string {
+  try {
+    mkdirSync(path, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+  return validateOwnedDirectory(path, true, true);
+}
+
+function validateOwnedDirectory(path: string, hardenPermissions: boolean, validateAcl: boolean): string {
+  const pathStats = lstatSync(path);
+  if (pathStats.isSymbolicLink()) {
+    throw new Error(`Docker session path contains a symbolic link: ${path}`);
+  }
+  if (!pathStats.isDirectory()) {
+    throw new Error(`Docker session path is not a directory: ${path}`);
+  }
+  assertCurrentUserOwnsDirectory(path, pathStats.uid);
+
+  const descriptor = openSync(path, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+  try {
+    const descriptorStats = fstatSync(descriptor);
+    assertCurrentUserOwnsDirectory(path, descriptorStats.uid);
+    if (descriptorStats.dev !== pathStats.dev || descriptorStats.ino !== pathStats.ino) {
+      throw new Error(`Docker session path changed while validating: ${path}`);
+    }
+    if (!hardenPermissions && (descriptorStats.mode & 0o022) !== 0) {
+      throw new Error(`Docker session root must not be group- or world-writable: ${path}`);
+    }
+    if (hardenPermissions) {
+      fchmodSync(descriptor, 0o700);
+    }
+    assertDirectoryIdentity(path, descriptorStats);
+    const realPath = realpathSync(path);
+    assertDirectoryIdentity(realPath, descriptorStats);
+    if (validateAcl) {
+      assertNoUnsafeMacAcl(realPath);
+      assertDirectoryIdentity(realPath, descriptorStats);
+    }
+    return realPath;
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function assertTrustedDirectoryAncestors(path: string): void {
+  const currentUserId = process.getuid?.();
+  let currentPath = realpathSync(path);
+  const ancestors: string[] = [];
+  while (true) {
+    ancestors.push(currentPath);
+    const parentPath = dirname(currentPath);
+    if (parentPath === currentPath) break;
+    currentPath = parentPath;
+  }
+  for (const ancestor of ancestors.reverse()) {
+    const pathStats = lstatSync(ancestor);
+    const descriptor = openSync(ancestor, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+    try {
+      const stats = fstatSync(descriptor);
+      if (
+        !pathStats.isDirectory() ||
+        stats.dev !== pathStats.dev ||
+        stats.ino !== pathStats.ino
+      ) {
+        throw new Error(`Docker session root ancestor changed while validating: ${ancestor}`);
+      }
+      if (currentUserId !== undefined && stats.uid !== currentUserId && stats.uid !== 0) {
+        throw new Error(`Docker session root ancestor is owned by an untrusted user: ${ancestor}`);
+      }
+      const writableByOthers = (stats.mode & 0o022) !== 0;
+      const sticky = (stats.mode & 0o1000) !== 0;
+      if (writableByOthers && !sticky) {
+        throw new Error(`Docker session root ancestor is writable by other users: ${ancestor}`);
+      }
+      assertNoUnsafeMacAcl(ancestor);
+      assertDirectoryIdentity(ancestor, stats);
+    } finally {
+      closeSync(descriptor);
+    }
+  }
+}
+
+function assertDirectoryIdentity(path: string, expected: ReturnType<typeof fstatSync>): void {
+  const stats = lstatSync(path);
+  if (
+    !stats.isDirectory() ||
+    stats.isSymbolicLink() ||
+    stats.dev !== expected.dev ||
+    stats.ino !== expected.ino
+  ) {
+    throw new Error(`Docker session path changed while validating: ${path}`);
+  }
+}
+
+function assertNoUnsafeMacAcl(path: string): void {
+  if (process.platform !== "darwin") return;
+  const result = spawnSync("/bin/ls", ["-lde", "--", path], {
+    encoding: "utf8",
+    env: { LC_ALL: "C" },
+    maxBuffer: 64 * 1024,
+    timeout: 2_000,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(`could not validate Docker session path ACL: ${path}`);
+  }
+  if (/^\s*\d+:.*\ballow\b/im.test(result.stdout)) {
+    throw new Error(`Docker session path has a permissive access ACL: ${path}`);
+  }
+}
+
+function assertCurrentUserOwnsDirectory(path: string, ownerId: number): void {
+  if (typeof process.getuid === "function" && ownerId !== process.getuid()) {
+    throw new Error(`Docker session path is not owned by the current user: ${path}`);
+  }
 }
 
 export function dockerSessionAgentHomeEnvNames(agent: AgentName): readonly string[] {
@@ -100,7 +244,13 @@ export function dockerSessionNativeId(agent: AgentName, nativeId: string | undef
   if (!nativeId || agent !== "pi") {
     return nativeId;
   }
-  const relativePath = relative(resolve(persistentHome), resolve(nativeId));
+  let resolvedNativeId = resolve(nativeId);
+  try {
+    resolvedNativeId = realpathSync(resolvedNativeId);
+  } catch {
+    // Retain the original value when a previously stored transcript no longer exists.
+  }
+  const relativePath = relative(resolve(persistentHome), resolvedNativeId);
   if (!isContainedRelativePath(relativePath)) {
     return nativeId;
   }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -48,8 +48,12 @@ export function detectDockerHostUser(): string | undefined {
 }
 
 export function dockerSessionHomePath(agent: AgentName, alias: string, env: Env): string | undefined {
+  const configuredRoot = env[DOCKER_SESSION_ROOT_ENV]?.trim();
+  if (configuredRoot && !isAbsolute(configuredRoot)) {
+    throw new Error(`${DOCKER_SESSION_ROOT_ENV} must be an absolute path`);
+  }
   const root =
-    env[DOCKER_SESSION_ROOT_ENV]?.trim() || (env.HOME ? join(env.HOME, ".headless", "docker-sessions") : undefined);
+    configuredRoot || (env.HOME ? join(env.HOME, ".headless", "docker-sessions") : undefined);
   return root ? resolve(root, agent, alias) : undefined;
 }
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -12,6 +12,7 @@ import {
   statSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { getAgentConfig } from "./agents.js";
@@ -67,7 +68,12 @@ export function dockerSessionHomePath(agent: AgentName, alias: string, env: Env)
   }
   const root =
     configuredRoot || (env.HOME ? join(env.HOME, ".headless", "docker-sessions") : undefined);
-  return root ? resolve(root, agent, alias) : undefined;
+  return root ? resolve(root, agent, dockerSessionDirectoryName(alias)) : undefined;
+}
+
+function dockerSessionDirectoryName(alias: string): string {
+  const digest = createHash("sha256").update(alias).digest("hex");
+  return `${alias.slice(0, 100)}-${digest}`;
 }
 
 export function ensureDockerSessionHome(path: string): string {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -94,6 +94,10 @@ export function ensureDockerSessionHome(path: string): string {
   return realSessionHome;
 }
 
+export function ensureDockerSessionStoreDirectory(sessionHome: string): void {
+  ensurePrivateOwnedDirectory(join(sessionHome, ".headless"));
+}
+
 function ensureDockerSessionRoot(path: string): string {
   const created = mkdirSync(path, { recursive: true, mode: 0o700 }) !== undefined;
   return validateOwnedDirectory(path, created, false);

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,4 +1,15 @@
-import { existsSync, lstatSync, mkdirSync, realpathSync, statSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { getAgentConfig } from "./agents.js";
@@ -12,6 +23,7 @@ const containerHome = "/headless-home";
 const hostHomeMountRoot = "/tmp/headless-host-home";
 
 type DockerEnvEntry = ForwardedEnvEntry;
+type DockerSessionBootstrap = "initialize-cursor";
 
 export interface DockerAgentCommandOptions {
   agent: AgentName;
@@ -24,6 +36,7 @@ export interface DockerAgentCommandOptions {
   persistentHome?: string;
   runDirHost?: string;
   runId?: string;
+  sessionBootstrap?: DockerSessionBootstrap;
   workDir: string;
 }
 
@@ -44,21 +57,39 @@ export function ensureDockerSessionHome(path: string): void {
   mkdirSync(path, { recursive: true, mode: 0o700 });
 }
 
+export function readDockerCursorSessionId(persistentHome: string): string {
+  const path = join(persistentHome, ".headless-cursor-session-id");
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stats = fstatSync(descriptor);
+    if (!stats.isFile() || stats.size > 256) {
+      return "";
+    }
+    const nativeId = readFileSync(descriptor, "utf8").trim();
+    return /^[A-Za-z0-9_.:-]{1,256}$/.test(nativeId) ? nativeId : "";
+  } catch {
+    return "";
+  } finally {
+    if (descriptor !== undefined) {
+      closeSync(descriptor);
+    }
+  }
+}
+
 export function dockerSessionNativeId(agent: AgentName, nativeId: string | undefined, persistentHome: string): string | undefined {
   if (!nativeId || agent !== "pi") {
     return nativeId;
   }
   const relativePath = relative(resolve(persistentHome), resolve(nativeId));
-  if (
-    relativePath === "" ||
-    relativePath === ".." ||
-    relativePath.startsWith("../") ||
-    relativePath.startsWith("..\\") ||
-    isAbsolute(relativePath)
-  ) {
+  if (!isContainedRelativePath(relativePath)) {
     return nativeId;
   }
   return join(containerHome, relativePath);
+}
+
+function isContainedRelativePath(path: string): boolean {
+  return path !== "" && path !== ".." && !path.startsWith("../") && !path.startsWith("..\\") && !isAbsolute(path);
 }
 
 export function buildDockerAgentCommand(options: DockerAgentCommandOptions): BuiltCommand {
@@ -90,7 +121,7 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
     options.image,
     "sh",
     "-lc",
-    bootstrapScript(Boolean(options.persistentHome)),
+    bootstrapScript(Boolean(options.persistentHome), options.sessionBootstrap),
     "headless-agent",
     options.command.command,
     ...options.command.args,
@@ -109,14 +140,28 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
   return dockerCommand;
 }
 
-function bootstrapScript(persistentHome: boolean): string {
+function bootstrapScript(persistentHome: boolean, sessionBootstrap?: DockerSessionBootstrap): string {
   const copyFlags = persistentHome ? "-R -n" : "-R";
-  return [
+  const commands = [
     "set -eu",
     `mkdir -p "${containerHome}"`,
     `if [ -d "${hostHomeMountRoot}" ]; then cp ${copyFlags} "${hostHomeMountRoot}/." "$HOME"/; fi`,
-    'exec "$@"',
-  ].join("; ");
+  ];
+  if (sessionBootstrap === "initialize-cursor") {
+    commands.push(
+      'cursor_session_id="$("$1" create-chat)"',
+      'if [ -z "$cursor_session_id" ]; then echo "Cursor did not return a session id" >&2; exit 1; fi',
+      'cursor_session_id_tmp="$(mktemp "$HOME/.headless-cursor-session-id.XXXXXX")"',
+      `printf '%s\\n' "$cursor_session_id" > "$cursor_session_id_tmp"`,
+      'mv -f "$cursor_session_id_tmp" "$HOME/.headless-cursor-session-id"',
+      'cursor_command="$1"',
+      "shift",
+      'exec "$cursor_command" --resume "$cursor_session_id" "$@"',
+    );
+  } else {
+    commands.push('exec "$@"');
+  }
+  return commands.join("; ");
 }
 
 function agentConfigMountArgs(agent: AgentName, env: Env): string[] {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -25,6 +25,17 @@ const hostHomeMountRoot = "/tmp/headless-host-home";
 type DockerEnvEntry = ForwardedEnvEntry;
 type DockerSessionBootstrap = "initialize-cursor";
 
+const dockerSessionAgentHomeVariables = {
+  acp: [],
+  antigravity: ["AGY_HOME", "ANTIGRAVITY_HOME"],
+  claude: ["CLAUDE_CONFIG_DIR"],
+  codex: ["CODEX_HOME"],
+  cursor: ["CURSOR_HOME"],
+  gemini: ["GEMINI_HOME"],
+  opencode: ["OPENCODE_DATA_HOME"],
+  pi: ["PI_CODING_AGENT_HOME"],
+} satisfies Record<AgentName, readonly string[]>;
+
 export interface DockerAgentCommandOptions {
   agent: AgentName;
   command: BuiltCommand;
@@ -59,6 +70,10 @@ export function dockerSessionHomePath(agent: AgentName, alias: string, env: Env)
 
 export function ensureDockerSessionHome(path: string): void {
   mkdirSync(path, { recursive: true, mode: 0o700 });
+}
+
+export function dockerSessionAgentHomeEnvNames(agent: AgentName): readonly string[] {
+  return dockerSessionAgentHomeVariables[agent];
 }
 
 export function readDockerCursorSessionId(persistentHome: string): string {
@@ -125,7 +140,7 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
     options.image,
     "sh",
     "-lc",
-    bootstrapScript(Boolean(options.persistentHome), options.sessionBootstrap),
+    bootstrapScript(options.agent, Boolean(options.persistentHome), options.sessionBootstrap),
     "headless-agent",
     options.command.command,
     ...options.command.args,
@@ -144,13 +159,20 @@ export function buildDockerAgentCommand(options: DockerAgentCommandOptions): Bui
   return dockerCommand;
 }
 
-function bootstrapScript(persistentHome: boolean, sessionBootstrap?: DockerSessionBootstrap): string {
+function bootstrapScript(agent: AgentName, persistentHome: boolean, sessionBootstrap?: DockerSessionBootstrap): string {
   const copyFlags = persistentHome ? "-R -n" : "-R";
   const commands = [
     "set -eu",
+    `export HOME="${containerHome}"`,
     `mkdir -p "${containerHome}"`,
     `if [ -d "${hostHomeMountRoot}" ]; then cp ${copyFlags} "${hostHomeMountRoot}/." "$HOME"/; fi`,
   ];
+  if (persistentHome) {
+    const agentHomeVariables = dockerSessionAgentHomeEnvNames(agent);
+    if (agentHomeVariables.length > 0) {
+      commands.push(`unset ${agentHomeVariables.join(" ")}`);
+    }
+  }
   if (sessionBootstrap === "initialize-cursor") {
     commands.push(
       'cursor_session_id="$("$1" create-chat)"',

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -104,6 +104,47 @@ export function ensureDockerSessionStoreDirectory(sessionHome: string): void {
   ensurePrivateOwnedDirectory(join(sessionHome, ".headless"));
 }
 
+export function validateDockerSessionRootWorkDir(sessionHome: string, workDir: string): void {
+  validateDockerWorkDir(workDir);
+  const sessionRoot = canonicalProspectivePath(dirname(dirname(resolve(sessionHome))));
+  const canonicalWorkDir = realpathSync(workDir);
+  if (pathsOverlap(sessionRoot, canonicalWorkDir)) {
+    throw new Error("Docker session root must not overlap the work dir");
+  }
+}
+
+export function validateDockerWorkDir(workDir: string): void {
+  const requestedWorkDir = resolve(workDir);
+  if (pathsOverlap(containerHome, requestedWorkDir)) {
+    throw new Error(`Docker work dir must not overlap the container home ${containerHome}`);
+  }
+  const canonicalWorkDir = realpathSync(workDir);
+  if (pathsOverlap(containerHome, canonicalWorkDir)) {
+    throw new Error(`Docker work dir must not overlap the container home ${containerHome}`);
+  }
+}
+
+function canonicalProspectivePath(path: string): string {
+  let existingPath = resolve(path);
+  const missingSegments: string[] = [];
+  while (!existsSync(existingPath)) {
+    missingSegments.unshift(basename(existingPath));
+    const parent = dirname(existingPath);
+    if (parent === existingPath) break;
+    existingPath = parent;
+  }
+  return resolve(realpathSync(existingPath), ...missingSegments);
+}
+
+function pathsOverlap(first: string, second: string): boolean {
+  return isSameOrContained(first, second) || isSameOrContained(second, first);
+}
+
+function isSameOrContained(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return relativePath === "" || isContainedRelativePath(relativePath);
+}
+
 function ensureDockerSessionRoot(path: string): string {
   const created = mkdirSync(path, { recursive: true, mode: 0o700 }) !== undefined;
   return validateOwnedDirectory(path, created, false);

--- a/src/launch-lock.ts
+++ b/src/launch-lock.ts
@@ -1,5 +1,20 @@
-import { chmodSync, closeSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join, win32 } from "node:path";
+
+import { lock as lockFile } from "proper-lockfile";
 
 import type { AgentName, Env } from "./types.js";
 
@@ -8,6 +23,10 @@ const privateFileMode = 0o600;
 
 export interface LaunchLock {
   release: () => void;
+}
+
+export interface DockerSessionLock {
+  release: () => Promise<Error | undefined>;
 }
 
 interface LaunchLockOptions {
@@ -27,7 +46,7 @@ export function acquireLaunchLock(
   const lockPath = launchLockPath(env, agent, workspace);
   if (!lockPath) return { release: () => {} };
 
-  ensurePrivateDir(lockPath.slice(0, lockPath.lastIndexOf("/")));
+  ensurePrivateDir(dirname(lockPath));
   const deadline = options.timeoutMs === undefined ? undefined : Date.now() + options.timeoutMs;
   while (true) {
     try {
@@ -50,6 +69,164 @@ export function launchLockPath(env: Env, agent: AgentName, workspace: string): s
   if (!env.HOME) return undefined;
   const key = `${agent}-${workspace.replace(/\//g, "-")}`.replace(/[^A-Za-z0-9._-]/g, "_");
   return join(env.HOME, ".headless", "launch-locks", `${key}.lock`);
+}
+
+export async function acquireDockerSessionLock(persistentHome: string): Promise<DockerSessionLock> {
+  const lockPath = dockerSessionLockPath(persistentHome);
+  const ownerPath = `${lockPath}.owner`;
+  ensurePrivateDir(dirname(lockPath));
+  let compromisedError: Error | undefined;
+  let verifiedOwner: { checkedAt: number; token: string } | undefined;
+  let release: (() => Promise<void>) | undefined;
+  while (!release) {
+    const owner = readDockerLockOwner(ownerPath);
+    const recentlyVerified =
+      owner &&
+      verifiedOwner?.token === owner.token &&
+      Date.now() - verifiedOwner.checkedAt < 5_000;
+    if (
+      owner?.hostname === hostname() &&
+      owner.startIdentity !== undefined &&
+      (recentlyVerified || owner.startIdentity === processStartIdentity(owner.pid))
+    ) {
+      if (!recentlyVerified) {
+        verifiedOwner = { checkedAt: Date.now(), token: owner.token };
+      }
+      await sleep(250);
+      continue;
+    }
+    try {
+      release = await lockFile(persistentHome, {
+        lockfilePath: lockPath,
+        onCompromised: (error) => {
+          compromisedError = error;
+        },
+        retries: 0,
+        stale: 60_000,
+        update: 20_000,
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ELOCKED") throw error;
+      await sleep(50);
+    }
+  }
+
+  const owner = {
+    hostname: hostname(),
+    pid: process.pid,
+    startIdentity: processStartIdentity(process.pid),
+    token: randomUUID(),
+  };
+  try {
+    writeDockerLockOwner(ownerPath, owner);
+  } catch (error) {
+    await release();
+    throw error;
+  }
+  let released = false;
+  return {
+    release: async () => {
+      if (released) return compromisedError;
+      released = true;
+      let cleanupError: Error | undefined;
+      try {
+        removeDockerLockOwner(ownerPath, owner.token);
+      } catch (error) {
+        cleanupError = error instanceof Error ? error : new Error(String(error));
+      }
+      try {
+        await release();
+      } catch (error) {
+        cleanupError ??= error instanceof Error ? error : new Error(String(error));
+      }
+      return compromisedError ?? cleanupError;
+    },
+  };
+}
+
+export function dockerSessionLockPath(persistentHome: string): string {
+  const canonicalHome = realpathSync(persistentHome);
+  const sessionRoot = dirname(dirname(canonicalHome));
+  const key = createHash("sha256").update(canonicalHome).digest("hex");
+  return join(sessionRoot, ".headless-session-locks", `${key}.lock`);
+}
+
+function writeDockerLockOwner(
+  ownerPath: string,
+  owner: { hostname: string; pid: number; startIdentity: string | undefined; token: string },
+): void {
+  const temporaryPath = `${ownerPath}.${owner.token}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(owner)}\n`, { flag: "wx", mode: privateFileMode });
+  try {
+    renameSync(temporaryPath, ownerPath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
+function readDockerLockOwner(
+  ownerPath: string,
+): { hostname: string; pid: number; startIdentity: string | undefined; token: string } | undefined {
+  try {
+    const owner = JSON.parse(readFileSync(ownerPath, "utf8")) as Record<string, unknown>;
+    if (typeof owner.hostname !== "string" || !owner.hostname) return undefined;
+    if (!Number.isSafeInteger(owner.pid) || (owner.pid as number) <= 0) return undefined;
+    if (owner.startIdentity !== undefined && typeof owner.startIdentity !== "string") return undefined;
+    if (typeof owner.token !== "string" || !/^[0-9a-f-]{36}$/.test(owner.token)) return undefined;
+    return {
+      hostname: owner.hostname,
+      pid: owner.pid as number,
+      startIdentity: owner.startIdentity as string | undefined,
+      token: owner.token,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function removeDockerLockOwner(ownerPath: string, token: string): void {
+  if (readDockerLockOwner(ownerPath)?.token === token) {
+    rmSync(ownerPath, { force: true });
+  }
+}
+
+function processStartIdentity(pid: number): string | undefined {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return undefined;
+  if (process.platform === "linux") {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+      const fieldsAfterName = stat.slice(stat.lastIndexOf(")") + 1).trim().split(/\s+/);
+      const startTicks = fieldsAfterName[19];
+      return bootId && startTicks ? `linux:${bootId}:${startTicks}` : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  const result = process.platform === "win32"
+    ? spawnSync(
+        windowsPowerShellPath(),
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+        ],
+        { encoding: "utf8", timeout: 1_000, windowsHide: true },
+      )
+    : spawnSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
+        encoding: "utf8",
+        env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+        timeout: 1_000,
+      });
+  const identity = result.status === 0 ? result.stdout.trim() : "";
+  return identity ? `${process.platform}:${identity}` : undefined;
+}
+
+function windowsPowerShellPath(systemRoot = process.env.SystemRoot): string {
+  const root = systemRoot && win32.isAbsolute(systemRoot) ? systemRoot : "C:\\Windows";
+  return win32.join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
 }
 
 // A lock can be reaped only when its writer process is gone. A live holder may
@@ -85,4 +262,8 @@ function ensurePrivateDir(path: string): void {
 
 function sleepSync(milliseconds: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+async function sleep(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/src/launch-lock.ts
+++ b/src/launch-lock.ts
@@ -14,12 +14,11 @@ import {
 import { hostname } from "node:os";
 import { dirname, join, win32 } from "node:path";
 
-import { lock as lockFile } from "proper-lockfile";
-
 import type { AgentName, Env } from "./types.js";
 
 const privateDirMode = 0o700;
 const privateFileMode = 0o600;
+const dockerSessionLockSignalListeners = new Set<NodeJS.SignalsListener>();
 
 export interface LaunchLock {
   release: () => void;
@@ -72,6 +71,21 @@ export function launchLockPath(env: Env, agent: AgentName, workspace: string): s
 }
 
 export async function acquireDockerSessionLock(persistentHome: string): Promise<DockerSessionLock> {
+  const signals: NodeJS.Signals[] =
+    process.platform === "win32"
+      ? ["SIGINT", "SIGTERM", "SIGBREAK"]
+      : ["SIGHUP", "SIGINT", "SIGTERM", "SIGQUIT"];
+  const listenersBeforeImport = new Map(
+    signals.map((signal) => [signal, new Set(process.listeners(signal))] as const),
+  );
+  const { lock: lockFile } = await import("proper-lockfile");
+  for (const signal of signals) {
+    for (const listener of process.listeners(signal)) {
+      if (!listenersBeforeImport.get(signal)?.has(listener)) {
+        dockerSessionLockSignalListeners.add(listener);
+      }
+    }
+  }
   const lockPath = dockerSessionLockPath(persistentHome);
   const ownerPath = `${lockPath}.owner`;
   ensurePrivateDir(dirname(lockPath));
@@ -142,6 +156,10 @@ export async function acquireDockerSessionLock(persistentHome: string): Promise<
       return compromisedError ?? cleanupError;
     },
   };
+}
+
+export function isDockerSessionLockSignalListener(listener: NodeJS.SignalsListener): boolean {
+  return dockerSessionLockSignalListeners.has(listener);
 }
 
 export function dockerSessionLockPath(persistentHome: string): string {

--- a/src/native-transcripts.ts
+++ b/src/native-transcripts.ts
@@ -1,7 +1,13 @@
-import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { closeSync, constants, existsSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
+import {
+  assertSafeDockerAntigravityState,
+  assertSafeDockerFile,
+  assertSafeDockerOpenCodeDatabase,
+  assertSafeDockerTree,
+} from "./docker-transcript-safety.js";
 import { extractFinalMessage } from "./output.js";
 import type { NativeTranscript } from "./runs.js";
 import type { AgentName, Env } from "./types.js";
@@ -16,6 +22,7 @@ export interface NativeAssistantCompletion {
 
 interface ResolveLatestOptions {
   antigravityScope?: "workspace" | "all";
+  dockerSessionRoot?: string;
 }
 
 export function resolveNativeTranscript(
@@ -95,8 +102,9 @@ export function resolveLatestNativeTranscript(
   workDir: string | undefined,
   env: Env,
   partial: Partial<NativeTranscript> = {},
+  options: ResolveLatestOptions = {},
 ): NativeTranscript | undefined {
-  return resolveLatestNativeTranscripts(agent, workDir, env, partial, 1)[0];
+  return resolveLatestNativeTranscripts(agent, workDir, env, partial, 1, options)[0];
 }
 
 export function resolveLatestNativeTranscripts(
@@ -110,22 +118,22 @@ export function resolveLatestNativeTranscripts(
   const workspace = realWorkspace(workDir);
   if (!workspace) return [];
   if (agent === "opencode") {
-    return latestOpenCodeTranscripts(workspace, workDir, env, partial, limit);
+    return latestOpenCodeTranscripts(workspace, workDir, env, partial, limit, options.dockerSessionRoot);
   }
 
   const paths =
     agent === "claude"
       ? latestFiles(claudeProjectRoot(workspace, env), partial)
       : agent === "antigravity"
-        ? latestAntigravityTranscripts(workspace, workDir, env, partial, options.antigravityScope ?? "workspace")
+        ? latestAntigravityTranscripts(workspace, workDir, env, partial, options.antigravityScope ?? "workspace", options.dockerSessionRoot)
       : agent === "codex"
         ? latestWorkspaceFiles(codexSessionsRoot(env), workspace, workDir, partial)
         : agent === "cursor"
           ? latestFiles(cursorTranscriptsRoot(workspace, env), partial)
           : agent === "gemini"
-            ? latestGeminiTranscripts(workspace, env, partial)
+            ? latestGeminiTranscripts(workspace, env, partial, options.dockerSessionRoot)
             : agent === "pi"
-              ? latestFiles(piProjectRoot(workspace, env), partial)
+              ? latestPiTranscripts(workspace, env, partial, options.dockerSessionRoot)
               : [];
   return paths.slice(0, Math.max(0, limit)).map((path) => ({
     kind: "jsonl",
@@ -280,14 +288,15 @@ function piProjectRoot(workspace: string, env: Env): string | undefined {
   return root ? join(root, "sessions", piProjectKey(workspace)) : undefined;
 }
 
-function geminiProjectSlot(root: string, workspace: string): string {
+function geminiProjectSlot(root: string, workspace: string, dockerSession = false): string {
   const projectsPath = join(root, "projects.json");
   if (!existsSync(projectsPath)) return "";
   try {
     const config = JSON.parse(readFileSync(projectsPath, "utf8")) as Record<string, unknown>;
     const projects = isRecord(config.projects) ? config.projects : config;
     const direct = projects[workspace];
-    if (typeof direct === "string") return direct;
+    if (typeof direct === "string") return dockerSession ? safePathSegment(direct) : direct;
+    if (dockerSession) return "";
     for (const [key, value] of Object.entries(projects)) {
       if (realWorkspace(key) === workspace && typeof value === "string") return value;
     }
@@ -295,6 +304,10 @@ function geminiProjectSlot(root: string, workspace: string): string {
     return "";
   }
   return "";
+}
+
+function safePathSegment(value: string): string {
+  return value !== "." && value !== ".." && /^[A-Za-z0-9._-]+$/.test(value) ? value : "";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -326,11 +339,19 @@ function latestGeminiTranscripts(
   workspace: string,
   env: Env,
   partial: Partial<NativeTranscript>,
+  dockerSessionRoot?: string,
 ): string[] {
   const root = env.GEMINI_HOME ?? (env.HOME ? join(env.HOME, ".gemini") : undefined);
   if (!root) return [];
-  const projectSlot = geminiProjectSlot(root, workspace);
-  return projectSlot ? latestFiles(join(root, "tmp", projectSlot, "chats"), partial) : [];
+  if (dockerSessionRoot && root) {
+    assertSafeDockerFile(dockerSessionRoot, join(root, "projects.json"), 1024 * 1024);
+  }
+  const projectSlot = geminiProjectSlot(root, workspace, Boolean(dockerSessionRoot));
+  const chatsRoot = projectSlot ? join(root, "tmp", projectSlot, "chats") : undefined;
+  if (dockerSessionRoot && chatsRoot) {
+    assertSafeDockerTree(dockerSessionRoot, chatsRoot);
+  }
+  return chatsRoot ? latestFiles(chatsRoot, partial) : [];
 }
 
 function latestAntigravityTranscripts(
@@ -339,10 +360,14 @@ function latestAntigravityTranscripts(
   env: Env,
   partial: Partial<NativeTranscript>,
   scope: "workspace" | "all",
+  dockerSessionRoot?: string,
 ): string[] {
   const root = antigravityRoot(env);
   const brainRoot = root ? join(root, "brain") : undefined;
   if (!brainRoot || !existsSync(brainRoot)) return [];
+  if (dockerSessionRoot && root) {
+    assertSafeDockerAntigravityState(dockerSessionRoot, root, brainRoot);
+  }
   const startedAtMs = partial.startedAt ? Date.parse(partial.startedAt) : Number.NaN;
   const candidates = readdirSync(brainRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -359,16 +384,22 @@ function latestAntigravityTranscripts(
     .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs || right.localeCompare(left));
   if (scope === "all") return candidates;
   const needles = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
-  const mappedIds = antigravityConversationIdsForWorkspace(root, needles);
+  const dockerSession = Boolean(dockerSessionRoot);
+  const mappedIds = antigravityConversationIdsForWorkspace(root, needles, dockerSession);
+  const statuses = new Map(candidates.map((path) => [path, fileWorkspaceCwdStatus(path, needles, dockerSession)]));
   const mapped = candidates.filter((path) => {
     const nativeId = nativeIdFromPath("antigravity", path);
-    return Boolean(nativeId && mappedIds.includes(nativeId) && fileWorkspaceCwdStatus(path, needles) !== "mismatch");
+    return Boolean(nativeId && mappedIds.includes(nativeId) && statuses.get(path) !== "mismatch");
   });
-  const fromTranscript = candidates.filter((path) => fileWorkspaceCwdStatus(path, needles) === "match");
+  const fromTranscript = candidates.filter((path) => statuses.get(path) === "match");
   return uniqueStrings([...mapped, ...fromTranscript]);
 }
 
-function antigravityConversationIdsForWorkspace(root: string | undefined, needles: string[]): string[] {
+function antigravityConversationIdsForWorkspace(
+  root: string | undefined,
+  needles: string[],
+  dockerSession: boolean,
+): string[] {
   if (!root) return [];
   const cachePath = join(root, "cache", "last_conversations.json");
   try {
@@ -377,6 +408,7 @@ function antigravityConversationIdsForWorkspace(root: string | undefined, needle
       Object.entries(values)
         .filter(([key]) => {
           if (needles.includes(key)) return true;
+          if (dockerSession) return false;
           const realKey = realWorkspace(key);
           return Boolean(realKey && needles.includes(realKey));
         })
@@ -394,16 +426,23 @@ function latestOpenCodeTranscripts(
   env: Env,
   partial: Partial<NativeTranscript>,
   limit: number,
+  dockerSessionRoot?: string,
 ): NativeTranscript[] {
   const path = opencodeDatabasePath(env);
   if (!path || !existsSync(path)) return [];
+  let databasePath = path;
+  if (dockerSessionRoot) {
+    assertSafeDockerOpenCodeDatabase(dockerSessionRoot, path);
+    databasePath = realpathSync(path);
+  }
   const directories = uniqueStrings([workspace, workDir].filter((value): value is string => Boolean(value)));
   const startedAtMs = partial.startedAt ? Date.parse(partial.startedAt) : Number.NaN;
   const whereDirectory = directories.map((directory) => `'${directory.replaceAll("'", "''")}'`).join(", ");
   const sqlite = spawnSync(
     "sqlite3",
     [
-      path,
+      ...(dockerSessionRoot ? ["-batch", "-nofollow", "-readonly", "-safe"] : []),
+      databasePath,
       [
         "select id",
         "from session",
@@ -413,10 +452,34 @@ function latestOpenCodeTranscripts(
         `limit ${Math.max(0, limit)};`,
       ].join("\n"),
     ],
-    { encoding: "utf8" },
+    {
+      encoding: "utf8",
+      ...(dockerSessionRoot ? { maxBuffer: 1024 * 1024, timeout: 5_000 } : {}),
+    },
   );
-  const sessionIds = sqlite.status === 0 ? sqlite.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean) : [];
-  return sessionIds.map((sessionId) => ({ kind: "sqlite", path, sessionId, ...partial }));
+  const sessionIds = sqlite.status === 0
+    ? sqlite.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(
+        (sessionId) =>
+          Boolean(sessionId) && (!dockerSessionRoot || /^[A-Za-z0-9_.:-]{1,256}$/.test(sessionId)),
+      )
+    : [];
+  return sessionIds.map((sessionId) => ({ kind: "sqlite", path: databasePath, sessionId, ...partial }));
+}
+
+function latestPiTranscripts(
+  workspace: string,
+  env: Env,
+  partial: Partial<NativeTranscript>,
+  dockerSessionRoot?: string,
+): string[] {
+  const root = piProjectRoot(workspace, env);
+  if (dockerSessionRoot && root) {
+    assertSafeDockerTree(dockerSessionRoot, root);
+  }
+  return latestFiles(root, partial);
 }
 
 // Resolve the opencode session whose `title` equals a caller-assigned unique
@@ -503,15 +566,21 @@ function fileHasWorkspaceCwd(path: string, needles: string[]): boolean {
   return fileWorkspaceCwdStatus(path, needles) === "match";
 }
 
-function fileWorkspaceCwdStatus(path: string, needles: string[]): "match" | "mismatch" | "unknown" {
+function fileWorkspaceCwdStatus(
+  path: string,
+  needles: string[],
+  dockerSession = false,
+): "match" | "mismatch" | "unknown" {
   let sawCwd = false;
   try {
-    for (const line of readFileSync(path, "utf8").split(/\r?\n/).slice(0, 40)) {
+    const contents = dockerSession ? readFilePrefix(path, 64 * 1024) : readFileSync(path, "utf8");
+    for (const line of contents.split(/\r?\n/).slice(0, 40)) {
       if (!line.trim()) continue;
       const record = JSON.parse(line) as Record<string, unknown>;
       const cwd = cwdFromRecord(record);
       if (cwd) sawCwd = true;
       if (cwd && needles.includes(cwd)) return "match";
+      if (dockerSession) continue;
       const realCwd = realWorkspace(cwd);
       if (realCwd && needles.includes(realCwd)) return "match";
     }
@@ -519,6 +588,17 @@ function fileWorkspaceCwdStatus(path: string, needles: string[]): "match" | "mis
     return "unknown";
   }
   return sawCwd ? "mismatch" : "unknown";
+}
+
+function readFilePrefix(path: string, maxBytes: number): string {
+  const descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const buffer = Buffer.allocUnsafe(maxBytes);
+    const bytesRead = readSync(descriptor, buffer, 0, maxBytes, 0);
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    closeSync(descriptor);
+  }
 }
 
 function cwdFromRecord(record: Record<string, unknown>): string {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,4 +1,16 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 
 import type { AgentName, Env } from "./types.js";
@@ -23,6 +35,9 @@ interface SessionStoreFile {
   version: 1;
   agents: Partial<Record<AgentName, Record<string, StoredSession>>>;
 }
+
+export const SECURE_SESSION_STORE_ENV = "HEADLESS_INTERNAL_SECURE_SESSION_STORE";
+const maxSessionStoreBytes = 1024 * 1024;
 
 export function sessionStorePath(env: Env): string | undefined {
   return env.HOME ? join(env.HOME, ".headless", "sessions.json") : undefined;
@@ -55,7 +70,7 @@ export function writeStoredSession(
   };
 
   store.agents[session.agent] = { ...(store.agents[session.agent] ?? {}), [session.alias]: stored };
-  writeSessionStore(path, store);
+  writeSessionStore(path, store, env[SECURE_SESSION_STORE_ENV] === "1");
   return stored;
 }
 
@@ -82,12 +97,15 @@ export function writeStoredTmuxSession(
   };
 
   store.agents[session.agent] = { ...(store.agents[session.agent] ?? {}), [session.alias]: stored };
-  writeSessionStore(path, store);
+  writeSessionStore(path, store, env[SECURE_SESSION_STORE_ENV] === "1");
   return stored;
 }
 
 function readSessionStore(env: Env): SessionStoreFile {
   const path = sessionStorePath(env);
+  if (env[SECURE_SESSION_STORE_ENV] === "1") {
+    return path ? readSecureSessionStore(path) : emptyStore();
+  }
   if (!path || !existsSync(path)) {
     return emptyStore();
   }
@@ -103,13 +121,114 @@ function readSessionStore(env: Env): SessionStoreFile {
   }
 }
 
+function readSecureSessionStore(path: string): SessionStoreFile {
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const stats = fstatSync(descriptor);
+    if (!stats.isFile() || stats.size > maxSessionStoreBytes) {
+      throw new Error("Docker session store must be a bounded regular file");
+    }
+    return normalizeSessionStore(JSON.parse(readFileSync(descriptor, "utf8")) as unknown);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyStore();
+    if (error instanceof SyntaxError) return emptyStore();
+    throw error;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function normalizeSessionStore(value: unknown): SessionStoreFile {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.agents)) return emptyStore();
+  const store = emptyStore();
+  for (const agent of ["acp", "antigravity", "claude", "codex", "cursor", "gemini", "opencode", "pi"] as const) {
+    const sessions = value.agents[agent];
+    if (!isRecord(sessions)) continue;
+    for (const [alias, candidate] of Object.entries(sessions)) {
+      const session = normalizeStoredSession(candidate, agent, alias);
+      if (session) {
+        (store.agents[agent] ??= {})[alias] = session;
+      }
+    }
+  }
+  return store;
+}
+
+function normalizeStoredSession(value: unknown, agent: AgentName, alias: string): StoredSession | undefined {
+  if (
+    !isRecord(value) ||
+    value.agent !== agent ||
+    value.alias !== alias ||
+    !/^[A-Za-z0-9_.-]{1,256}$/.test(alias) ||
+    typeof value.createdAt !== "string" ||
+    value.createdAt.length > 64 ||
+    typeof value.updatedAt !== "string" ||
+    value.updatedAt.length > 64
+  ) {
+    return undefined;
+  }
+  const nativeId = boundedOptionalString(value.nativeId, 4096);
+  const workDir = boundedOptionalString(value.workDir, 4096);
+  if (nativeId === null || workDir === null) return undefined;
+  return {
+    agent,
+    alias,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+    ...(nativeId === undefined ? {} : { nativeId }),
+    ...(workDir === undefined ? {} : { workDir }),
+  };
+}
+
+function boundedOptionalString(value: unknown, maxLength: number): string | undefined | null {
+  if (value === undefined) return undefined;
+  return typeof value === "string" && value.length <= maxLength ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function emptyStore(): SessionStoreFile {
   return { version: 1, agents: {} };
 }
 
-function writeSessionStore(path: string, store: SessionStoreFile): void {
+function writeSessionStore(path: string, store: SessionStoreFile, secure: boolean): void {
+  if (secure) {
+    writeSecureSessionStore(path, store);
+    return;
+  }
   mkdirSync(dirname(path), { recursive: true });
   const tmpPath = `${path}.tmp-${process.pid}`;
   writeFileSync(tmpPath, `${JSON.stringify(store, null, 2)}\n`);
   renameSync(tmpPath, path);
+}
+
+function writeSecureSessionStore(path: string, store: SessionStoreFile): void {
+  const contents = `${JSON.stringify(store, null, 2)}\n`;
+  if (Buffer.byteLength(contents) > maxSessionStoreBytes) {
+    throw new Error("Docker session store exceeds its size limit");
+  }
+  const tmpPath = join(dirname(path), `.sessions.json.tmp-${process.pid}-${randomUUID()}`);
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(
+      tmpPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    writeFileSync(descriptor, contents);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(tmpPath, path);
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // The temporary file may not have been created.
+    }
+    throw error;
+  }
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -145,11 +145,15 @@ function normalizeSessionStore(value: unknown): SessionStoreFile {
   for (const agent of ["acp", "antigravity", "claude", "codex", "cursor", "gemini", "opencode", "pi"] as const) {
     const sessions = value.agents[agent];
     if (!isRecord(sessions)) continue;
+    const normalizedSessions = Object.create(null) as Record<string, StoredSession>;
     for (const [alias, candidate] of Object.entries(sessions)) {
       const session = normalizeStoredSession(candidate, agent, alias);
       if (session) {
-        (store.agents[agent] ??= {})[alias] = session;
+        normalizedSessions[alias] = session;
       }
+    }
+    if (Object.keys(normalizedSessions).length > 0) {
+      store.agents[agent] = normalizedSessions;
     }
   }
   return store;

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -160,7 +160,9 @@ function normalizeStoredSession(value: unknown, agent: AgentName, alias: string)
     !isRecord(value) ||
     value.agent !== agent ||
     value.alias !== alias ||
-    !/^[A-Za-z0-9_.-]{1,256}$/.test(alias) ||
+    alias === "." ||
+    alias === ".." ||
+    !/^[A-Za-z0-9_.-]+$/.test(alias) ||
     typeof value.createdAt !== "string" ||
     value.createdAt.length > 64 ||
     typeof value.updatedAt !== "string" ||

--- a/tests/docker-transcript-safety.test.ts
+++ b/tests/docker-transcript-safety.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, truncateSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { resolveLatestNativeTranscript } from "../src/native-transcripts.ts";
+
+test("rejects Gemini project slots that escape the transcript root", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    mkdirSync(join(home, ".gemini"), { recursive: true });
+    mkdirSync(workDir);
+    writeFileSync(
+      join(home, ".gemini", "projects.json"),
+      `${JSON.stringify({ [realpathSync(workDir)]: "../../outside" })}\n`,
+    );
+
+    assert.equal(
+      resolveLatestNativeTranscript("gemini", workDir, { HOME: home }, {}, { dockerSessionRoot: home }),
+      undefined,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("does not canonicalize Gemini project keys supplied by Docker state", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const workAlias = join(dir, "work-alias");
+    const transcript = join(home, ".gemini", "tmp", "gemini-1", "chats", "session-now-id.jsonl");
+    mkdirSync(dirname(transcript), { recursive: true });
+    mkdirSync(workDir);
+    symlinkSync(workDir, workAlias);
+    writeFileSync(join(home, ".gemini", "projects.json"), `${JSON.stringify({ [workAlias]: "gemini-1" })}\n`);
+    writeFileSync(transcript, "{}\n");
+
+    assert.equal(resolveLatestNativeTranscript("gemini", workDir, { HOME: home })?.path, transcript);
+    assert.equal(
+      resolveLatestNativeTranscript("gemini", workDir, { HOME: home }, {}, { dockerSessionRoot: home }),
+      undefined,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects symlinked Antigravity transcripts in Docker session homes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const external = join(dir, "external.jsonl");
+    const transcript = join(
+      home,
+      ".gemini",
+      "antigravity-cli",
+      "brain",
+      "conversation",
+      ".system_generated",
+      "logs",
+      "transcript.jsonl",
+    );
+    mkdirSync(dirname(transcript), { recursive: true });
+    mkdirSync(workDir);
+    writeFileSync(external, "{}\n");
+    symlinkSync(external, transcript);
+
+    assert.throws(
+      () => resolveLatestNativeTranscript(
+        "antigravity",
+        workDir,
+        { HOME: home },
+        {},
+        { dockerSessionRoot: home },
+      ),
+      /unsafe Docker transcript state path/,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects symlinked Pi transcript trees in Docker session homes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    mkdirSync(workDir);
+    const projectRoot = join(
+      home,
+      ".pi",
+      "agent",
+      "sessions",
+      `--${realpathSync(workDir).replace(/^\/+/, "").replace(/[\\/]+/g, "-")}--`,
+    );
+    mkdirSync(dirname(projectRoot), { recursive: true });
+    symlinkSync(dir, projectRoot);
+
+    assert.throws(
+      () => resolveLatestNativeTranscript("pi", workDir, { HOME: home }, {}, { dockerSessionRoot: home }),
+      /unsafe Docker transcript state path/,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects oversized OpenCode databases in Docker session homes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const database = join(home, ".local", "share", "opencode", "opencode.db");
+    mkdirSync(dirname(database), { recursive: true });
+    mkdirSync(workDir);
+    writeFileSync(database, "");
+    truncateSync(database, 256 * 1024 * 1024 + 1);
+
+    assert.throws(
+      () => resolveLatestNativeTranscript("opencode", workDir, { HOME: home }, {}, { dockerSessionRoot: home }),
+      /unsafe Docker transcript state path/,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects symlinked OpenCode database sidecars in Docker session homes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const database = join(home, ".local", "share", "opencode", "opencode.db");
+    const external = join(dir, "external-wal");
+    mkdirSync(dirname(database), { recursive: true });
+    mkdirSync(workDir);
+    writeFileSync(database, "");
+    writeFileSync(external, "");
+    symlinkSync(external, `${database}-wal`);
+
+    assert.throws(
+      () => resolveLatestNativeTranscript("opencode", workDir, { HOME: home }, {}, { dockerSessionRoot: home }),
+      /unsafe Docker transcript state path/,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test(
+  "reads valid OpenCode session IDs from Docker databases in safe read-only mode",
+  { skip: spawnSync("sqlite3", ["--version"]).status !== 0 },
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+    try {
+      const home = join(dir, "home");
+      const workDir = join(dir, "work");
+      const database = join(home, ".local", "share", "opencode", "opencode.db");
+      mkdirSync(dirname(database), { recursive: true });
+      mkdirSync(workDir);
+      const sql = [
+        "create table session (id text, directory text, time_updated integer);",
+        `insert into session values ('ses_valid-1', '${realpathSync(workDir).replaceAll("'", "''")}', 1);`,
+      ].join("\n");
+      const created = spawnSync("sqlite3", [database, sql], { encoding: "utf8" });
+      assert.equal(created.status, 0, created.stderr);
+      assert.equal(
+        resolveLatestNativeTranscript(
+          "opencode",
+          workDir,
+          { HOME: home },
+          {},
+          { dockerSessionRoot: home },
+        )?.sessionId,
+        "ses_valid-1",
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "rejects oversized OpenCode session IDs from Docker databases",
+  { skip: spawnSync("sqlite3", ["--version"]).status !== 0 },
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+    try {
+      const home = join(dir, "home");
+      const workDir = join(dir, "work");
+      const database = join(home, ".local", "share", "opencode", "opencode.db");
+      mkdirSync(dirname(database), { recursive: true });
+      mkdirSync(workDir);
+      const sql = [
+        "create table session (id text, directory text, time_updated integer);",
+        `insert into session values ('${"a".repeat(300)}', '${realpathSync(workDir).replaceAll("'", "''")}', 1);`,
+      ].join("\n");
+      const created = spawnSync("sqlite3", [database, sql], { encoding: "utf8" });
+      assert.equal(created.status, 0, created.stderr);
+      assert.equal(
+        resolveLatestNativeTranscript(
+          "opencode",
+          workDir,
+          { HOME: home },
+          {},
+          { dockerSessionRoot: home },
+        ),
+        undefined,
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  },
+);
+
+test("bounds Antigravity Docker transcript scans and ignores harmless brain metadata", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-native-transcripts-test-"));
+  try {
+    const home = join(dir, "home");
+    const workDir = join(dir, "work");
+    const workAlias = join(dir, "work-alias");
+    const root = join(home, ".gemini", "antigravity-cli");
+    const transcript = join(root, "brain", "conversation", "transcript.jsonl");
+    mkdirSync(dirname(transcript), { recursive: true });
+    mkdirSync(join(root, "cache"));
+    mkdirSync(workDir);
+    symlinkSync(workDir, workAlias);
+    writeFileSync(join(root, "brain", ".DS_Store"), "metadata");
+    writeFileSync(
+      join(root, "cache", "last_conversations.json"),
+      `${JSON.stringify({ [workAlias]: "conversation" })}\n`,
+      { flag: "w" },
+    );
+    writeFileSync(transcript, `${JSON.stringify({ cwd: workAlias })}\n${"\n".repeat(1024 * 1024)}`);
+
+    assert.equal(resolveLatestNativeTranscript("antigravity", workDir, { HOME: home })?.path, transcript);
+    assert.equal(
+      resolveLatestNativeTranscript("antigravity", workDir, { HOME: home }, {}, { dockerSessionRoot: home }),
+      undefined,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -13,6 +13,7 @@ import {
   ensureDockerSessionStoreDirectory,
   DEFAULT_DOCKER_IMAGE,
   readDockerCursorSessionId,
+  validateDockerSessionRootWorkDir,
 } from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
 
@@ -387,6 +388,15 @@ test("bounds long Docker session directory names without alias collisions", () =
 
   assert.ok(first.length < root.length + 180);
   assert.notEqual(first, second);
+});
+
+test("rejects workdirs that overlap the Docker container home target", () => {
+  for (const workDir of ["/headless-home", "/headless-home/project"]) {
+    assert.throws(
+      () => validateDockerSessionRootWorkDir("/var/lib/headless-sessions/codex/work", workDir),
+      /work dir must not overlap the container home/,
+    );
+  }
 });
 
 test("maps Pi transcripts stored through a former symlinked Docker root", { skip: process.platform === "win32" }, () => {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -8,6 +9,7 @@ import {
   buildDockerAgentCommand,
   dockerSessionHomePath,
   dockerSessionNativeId,
+  ensureDockerSessionHome,
   DEFAULT_DOCKER_IMAGE,
   readDockerCursorSessionId,
 } from "../src/docker.ts";
@@ -358,6 +360,148 @@ test("requires an absolute configured Docker session root", () => {
       HOME: "/home/test",
     }),
     "/var/lib/headless-sessions/codex/work",
+  );
+});
+
+test("maps Pi transcripts stored through a former symlinked Docker root", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const targetHome = join(dir, "target", "sessions", "pi", "work");
+    const linkedRoot = join(dir, "current");
+    const transcriptSuffix = join(".pi", "agent", "sessions", "turn.jsonl");
+    mkdirSync(join(targetHome, ".pi", "agent", "sessions"), { recursive: true });
+    writeFileSync(join(targetHome, transcriptSuffix), "{}\n");
+    symlinkSync(join(dir, "target"), linkedRoot);
+
+    assert.equal(
+      dockerSessionNativeId("pi", join(linkedRoot, "sessions", "pi", "work", transcriptSuffix), realpathSync(targetHome)),
+      `/headless-home/${transcriptSuffix}`,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects symlinked Docker session path components", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const root = join(dir, "sessions");
+    const external = join(dir, "external");
+    mkdirSync(join(root, "codex"), { recursive: true });
+    mkdirSync(external);
+    symlinkSync(external, join(root, "codex", "work"));
+
+    assert.throws(
+      () => ensureDockerSessionHome(join(root, "codex", "work")),
+      /symbolic link/,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("enforces private permissions on existing Docker session directories", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const root = join(dir, "sessions");
+    const agentDir = join(root, "codex");
+    const sessionHome = join(agentDir, "work");
+    mkdirSync(sessionHome, { recursive: true });
+    chmodSync(root, 0o755);
+    chmodSync(agentDir, 0o755);
+    chmodSync(sessionHome, 0o755);
+
+    ensureDockerSessionHome(sessionHome);
+
+    assert.equal(statSync(root).mode & 0o777, 0o755);
+    for (const path of [agentDir, sessionHome]) {
+      assert.equal(statSync(path).mode & 0o777, 0o700);
+    }
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects an unsafe existing Docker session root without mutating it", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const root = join(dir, "sessions");
+    mkdirSync(root);
+    chmodSync(root, 0o777);
+
+    assert.throws(
+      () => ensureDockerSessionHome(join(root, "codex", "work")),
+      /root must not be group- or world-writable/,
+    );
+    assert.equal(statSync(root).mode & 0o777, 0o777);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects Docker session roots below writable non-sticky parents", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const unsafeParent = join(dir, "shared");
+    const root = join(unsafeParent, "sessions");
+    mkdirSync(root, { recursive: true });
+    chmodSync(unsafeParent, 0o777);
+
+    assert.throws(
+      () => ensureDockerSessionHome(join(root, "codex", "work")),
+      /root ancestor is writable by other users/,
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("returns a canonical Docker session home despite ancestor symlink changes", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const firstTarget = join(dir, "first");
+    const secondTarget = join(dir, "second");
+    const linkedRoot = join(dir, "current");
+    mkdirSync(firstTarget);
+    mkdirSync(secondTarget);
+    symlinkSync(firstTarget, linkedRoot);
+
+    const sessionHome = ensureDockerSessionHome(join(linkedRoot, "sessions", "codex", "work"));
+    unlinkSync(linkedRoot);
+    symlinkSync(secondTarget, linkedRoot);
+
+    assert.equal(sessionHome, realpathSync(join(firstTarget, "sessions", "codex", "work")));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects permissive macOS ACLs on Docker session roots", { skip: process.platform !== "darwin" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const root = join(dir, "sessions");
+    mkdirSync(root);
+    const acl = spawnSync(
+      "/bin/chmod",
+      ["+a", "everyone allow list,search,add_file,add_subdirectory,delete_child", root],
+      { encoding: "utf8" },
+    );
+    assert.equal(acl.status, 0, acl.stderr);
+
+    assert.throws(
+      () => ensureDockerSessionHome(join(root, "codex", "work")),
+      /permissive access ACL/,
+    );
+    assert.equal(existsSync(join(root, "codex")), false);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects durable Docker session homes on Windows", { skip: process.platform !== "win32" }, () => {
+  assert.throws(
+    () => ensureDockerSessionHome("C:\\headless-sessions\\codex\\work"),
+    /not supported on Windows/,
   );
 });
 

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { buildDockerAgentCommand, DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
+import { buildDockerAgentCommand, dockerSessionNativeId, DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
 
 test("Dockerfile exposes Cursor agent from a non-root path", () => {
@@ -292,6 +292,43 @@ test("does not mount a symlinked Antigravity credential with a directory target"
       !command.args.some((arg) =>
         arg.endsWith(":/tmp/headless-host-home/.gemini/antigravity-cli/antigravity-oauth-token:ro"),
       ),
+    );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("uses a persistent host home for durable Docker sessions", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const home = join(dir, "home");
+    const persistentHome = join(dir, "sessions", "codex", "work");
+    const workDir = join(dir, "project");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(workDir, { recursive: true });
+
+    const command = buildDockerAgentCommand({
+      agent: "codex",
+      command: {
+        command: "codex",
+        args: ["exec", "--json", "-"],
+        stdinText: "hello",
+      },
+      dockerArgs: [],
+      dockerEnv: [],
+      env: { HOME: home },
+      hostUser: "501:20",
+      image: DEFAULT_DOCKER_IMAGE,
+      persistentHome,
+      workDir,
+    });
+
+    assert.ok(command.args.includes(`${persistentHome}:/headless-home:rw`));
+    assert.ok(!command.args.includes("/headless-home:rw,mode=1777"));
+    assert.match(command.args.find((arg) => arg.includes("cp -R -n")) ?? "", /cp -R -n/);
+    assert.equal(
+      dockerSessionNativeId("pi", join(persistentHome, ".pi", "agent", "sessions", "turn.jsonl"), persistentHome),
+      "/headless-home/.pi/agent/sessions/turn.jsonl",
     );
   } finally {
     rmSync(dir, { force: true, recursive: true });

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -10,6 +10,7 @@ import {
   dockerSessionHomePath,
   dockerSessionNativeId,
   ensureDockerSessionHome,
+  ensureDockerSessionStoreDirectory,
   DEFAULT_DOCKER_IMAGE,
   readDockerCursorSessionId,
 } from "../src/docker.ts";
@@ -493,6 +494,23 @@ test("rejects permissive macOS ACLs on Docker session roots", { skip: process.pl
       /permissive access ACL/,
     );
     assert.equal(existsSync(join(root, "codex")), false);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("rejects symlinked Docker session metadata directories", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const sessionHome = ensureDockerSessionHome(join(dir, "sessions", "codex", "work"));
+    const external = join(dir, "external");
+    mkdirSync(external);
+    symlinkSync(external, join(sessionHome, ".headless"));
+
+    assert.throws(
+      () => ensureDockerSessionStoreDirectory(sessionHome),
+      /symbolic link/,
+    );
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   buildDockerAgentCommand,
+  dockerSessionHomePath,
   dockerSessionNativeId,
   DEFAULT_DOCKER_IMAGE,
   readDockerCursorSessionId,
@@ -338,6 +339,24 @@ test("uses a persistent host home for durable Docker sessions", () => {
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }
+});
+
+test("requires an absolute configured Docker session root", () => {
+  assert.throws(
+    () =>
+      dockerSessionHomePath("codex", "work", {
+        HEADLESS_DOCKER_SESSION_ROOT: ".headless/docker-sessions",
+        HOME: "/home/test",
+      }),
+    /HEADLESS_DOCKER_SESSION_ROOT must be an absolute path/,
+  );
+  assert.equal(
+    dockerSessionHomePath("codex", "work", {
+      HEADLESS_DOCKER_SESSION_ROOT: "/var/lib/headless-sessions",
+      HOME: "/home/test",
+    }),
+    "/var/lib/headless-sessions/codex/work",
+  );
 });
 
 test("reads regular Docker Cursor session IDs and rejects symlinks", () => {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -360,8 +360,33 @@ test("requires an absolute configured Docker session root", () => {
       HEADLESS_DOCKER_SESSION_ROOT: "/var/lib/headless-sessions",
       HOME: "/home/test",
     }),
-    "/var/lib/headless-sessions/codex/work",
+    "/var/lib/headless-sessions/codex/work-00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e",
   );
+});
+
+test("uses distinct Docker homes for aliases that differ only by case", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const env = { HEADLESS_DOCKER_SESSION_ROOT: join(dir, "sessions") };
+    const lowerHome = dockerSessionHomePath("codex", "work", env) as string;
+    const upperHome = dockerSessionHomePath("codex", "WORK", env) as string;
+
+    assert.notEqual(lowerHome.toLowerCase(), upperHome.toLowerCase());
+    assert.notEqual(ensureDockerSessionHome(lowerHome), ensureDockerSessionHome(upperHome));
+    assert.notEqual(statSync(lowerHome).ino, statSync(upperHome).ino);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("bounds long Docker session directory names without alias collisions", () => {
+  const root = "/var/lib/headless-sessions";
+  const sharedPrefix = "a".repeat(200);
+  const first = dockerSessionHomePath("codex", `${sharedPrefix}x`, { HEADLESS_DOCKER_SESSION_ROOT: root }) as string;
+  const second = dockerSessionHomePath("codex", `${sharedPrefix}y`, { HEADLESS_DOCKER_SESSION_ROOT: root }) as string;
+
+  assert.ok(first.length < root.length + 180);
+  assert.notEqual(first, second);
 });
 
 test("maps Pi transcripts stored through a former symlinked Docker root", { skip: process.platform === "win32" }, () => {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -320,7 +320,7 @@ test("uses a persistent host home for durable Docker sessions", () => {
         args: ["exec", "--json", "-"],
         stdinText: "hello",
       },
-      dockerArgs: [],
+      dockerArgs: ["--env", "CODEX_HOME=/headless-home/custom"],
       dockerEnv: [],
       env: { HOME: home },
       hostUser: "501:20",
@@ -332,6 +332,8 @@ test("uses a persistent host home for durable Docker sessions", () => {
     assert.ok(command.args.includes(`${persistentHome}:/headless-home:rw`));
     assert.ok(!command.args.includes("/headless-home:rw,mode=1777"));
     assert.match(command.args.find((arg) => arg.includes("cp -R -n")) ?? "", /cp -R -n/);
+    assert.match(command.args.find((arg) => arg.includes("cp -R -n")) ?? "", /export HOME="\/headless-home"/);
+    assert.match(command.args.find((arg) => arg.includes("cp -R -n")) ?? "", /unset CODEX_HOME/);
     assert.equal(
       dockerSessionNativeId("pi", join(persistentHome, ".pi", "agent", "sessions", "turn.jsonl"), persistentHome),
       "/headless-home/.pi/agent/sessions/turn.jsonl",

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -564,6 +564,13 @@ test("reads regular Docker Cursor session IDs and rejects symlinks", () => {
     symlinkSync(externalId, marker);
 
     assert.equal(readDockerCursorSessionId(persistentHome), "");
+
+    if (process.platform !== "win32") {
+      rmSync(marker);
+      const fifo = spawnSync("mkfifo", [marker], { encoding: "utf8" });
+      assert.equal(fifo.status, 0, fifo.stderr);
+      assert.equal(readDockerCursorSessionId(persistentHome), "");
+    }
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { buildDockerAgentCommand, dockerSessionNativeId, DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
+import {
+  buildDockerAgentCommand,
+  dockerSessionNativeId,
+  DEFAULT_DOCKER_IMAGE,
+  readDockerCursorSessionId,
+} from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
 
 test("Dockerfile exposes Cursor agent from a non-root path", () => {
@@ -330,6 +335,27 @@ test("uses a persistent host home for durable Docker sessions", () => {
       dockerSessionNativeId("pi", join(persistentHome, ".pi", "agent", "sessions", "turn.jsonl"), persistentHome),
       "/headless-home/.pi/agent/sessions/turn.jsonl",
     );
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("reads regular Docker Cursor session IDs and rejects symlinks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
+  try {
+    const persistentHome = join(dir, "session");
+    const externalId = join(dir, "external-id");
+    mkdirSync(persistentHome);
+    const marker = join(persistentHome, ".headless-cursor-session-id");
+    writeFileSync(marker, "cursor-chat\n");
+
+    assert.equal(readDockerCursorSessionId(persistentHome), "cursor-chat");
+
+    rmSync(marker);
+    writeFileSync(externalId, "external-chat\n");
+    symlinkSync(externalId, marker);
+
+    assert.equal(readDockerCursorSessionId(persistentHome), "");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1,6 +1,17 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -2181,6 +2192,119 @@ test("CLI --docker --session persists a durable home across turns", async () => 
     const resetCalls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
     const resetCommand = resetCalls[2].args.slice(resetCalls[2].args.indexOf("headless-agent") + 1);
     assert.ok(!resetCommand.includes("resume"));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI --docker --session creates Cursor chats inside the container", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const hostBinDir = join(dir, "host-bin");
+    const containerBinDir = join(dir, "container-bin");
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    const captureFile = join(dir, "cursor-calls.jsonl");
+    mkdirSync(hostBinDir);
+    mkdirSync(containerBinDir);
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    const docker = join(hostBinDir, "docker");
+    writeFileSync(
+      docker,
+      [
+        "#!/usr/bin/env node",
+        "const { spawnSync } = require('node:child_process');",
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "const volume = args.find((arg) => arg.endsWith(':/headless-home:rw'));",
+        "if (!volume) process.exit(11);",
+        "const sessionHome = volume.slice(0, -':/headless-home:rw'.length);",
+        "const scriptIndex = args.indexOf('-lc') + 1;",
+        "const script = args[scriptIndex] ?? '';",
+        "const runnableScript = script.replaceAll('/headless-home', sessionHome);",
+        "const command = args.slice(scriptIndex + 2);",
+        "const result = spawnSync('sh', ['-lc', runnableScript, 'headless-agent', ...command], {",
+        "  env: {",
+        "    ...process.env,",
+        "    HOME: sessionHome,",
+        "    PATH: `${process.env.HEADLESS_CONTAINER_BIN}:${process.env.HEADLESS_NODE_BIN}:/usr/bin:/bin`,",
+        "  },",
+        "  input: fs.readFileSync(0),",
+        "});",
+        "process.stdout.write(result.stdout);",
+        "process.stderr.write(result.stderr);",
+        "process.exit(result.status ?? 1);",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(docker, 0o755);
+    const agent = join(containerBinDir, "agent");
+    writeFileSync(
+      agent,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.HEADLESS_CURSOR_CAPTURE, JSON.stringify(args) + '\\n');",
+        "if (args[0] === 'create-chat') {",
+        "  if (!process.env.HEADLESS_CURSOR_EMPTY_ID) console.log('cursor-docker-chat');",
+        "  process.exit(0);",
+        "}",
+        "if (!args.includes('--resume') || !args.includes('cursor-docker-chat')) process.exit(12);",
+        "console.log(JSON.stringify({ role: 'assistant', content: 'cursor docker done' }));",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(agent, 0o755);
+
+    const stdout: string[] = [];
+    const env = {
+      ...process.env,
+      HEADLESS_CONTAINER_BIN: containerBinDir,
+      HEADLESS_CURSOR_CAPTURE: captureFile,
+      HEADLESS_NODE_BIN: dirname(process.execPath),
+      HOME: homeDir,
+      PATH: `${hostBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`,
+    };
+    const sessionHome = join(homeDir, ".headless", "docker-sessions", "cursor", "work");
+    const externalMarkerTarget = join(dir, "external-marker-target");
+    mkdirSync(sessionHome, { recursive: true });
+    writeFileSync(externalMarkerTarget, "do not overwrite\n");
+    symlinkSync(externalMarkerTarget, join(sessionHome, ".headless-cursor-session-id"));
+
+    for (const prompt of ["first", "second"]) {
+      assert.equal(
+        await runCli(["cursor", "--docker", "--session", "work", "--prompt", prompt, "--work-dir", projectDir], {
+          env,
+          stdout: (text) => stdout.push(text),
+        }),
+        0,
+      );
+    }
+    assert.equal(stdout.join(""), "cursor docker done\ncursor docker done\n");
+    assert.equal(readFileSync(externalMarkerTarget, "utf8"), "do not overwrite\n");
+
+    const store = JSON.parse(readFileSync(join(sessionHome, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.cursor.work.nativeId, "cursor-docker-chat");
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(calls[0], ["create-chat"]);
+    assert.equal(calls.filter((args) => args[0] === "create-chat").length, 1);
+    assert.ok(calls[1].includes("--resume"));
+    assert.ok(calls[2].includes("--resume"));
+
+    rmSync(sessionHome, { force: true, recursive: true });
+    const failureStderr: string[] = [];
+    assert.equal(
+      await runCli(["cursor", "--docker", "--session", "work", "--prompt", "empty", "--work-dir", projectDir], {
+        env: { ...env, HEADLESS_CURSOR_EMPTY_ID: "1" },
+        stderr: (text) => failureStderr.push(text),
+        stdout: () => {},
+      }),
+      1,
+    );
+    assert.match(failureStderr.join(""), /Cursor did not return a session id/);
+    assert.equal(existsSync(join(sessionHome, ".headless", "sessions.json")), false);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2442,6 +2442,31 @@ test("CLI --docker print-command wraps the selected agent command", async () => 
   }
 });
 
+test("CLI --docker --session print-command prepares its bind-mount source", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    const stdout: string[] = [];
+
+    assert.equal(
+      await runCli(["codex", "--docker", "--session", "work", "--prompt", "hello", "--work-dir", projectDir, "--print-command"], {
+        env: { ...process.env, HOME: homeDir },
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+
+    const sessionHome = join(homeDir, ".headless", "docker-sessions", "codex", "work");
+    assert.equal(existsSync(sessionHome), true);
+    assert.ok(stdout.join("").includes(`${sessionHome}:/headless-home:rw`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --modal print-command wraps the selected agent command", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2531,6 +2531,57 @@ test("CLI --docker --session print-command prepares its bind-mount source", asyn
   }
 });
 
+test("CLI rejects Docker session roots that overlap the workdir", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    const projectLink = join(dir, "project-link");
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    symlinkSync(projectDir, projectLink);
+
+    for (const sessionRoot of [join(projectDir, ".sessions"), join(projectLink, ".sessions"), dir]) {
+      const stderr: string[] = [];
+      assert.equal(
+        await runCli(
+          ["codex", "--docker", "--session", "work", "--prompt", "hello", "--work-dir", projectDir, "--print-command"],
+          {
+            env: {
+              ...process.env,
+              HEADLESS_DOCKER_SESSION_ROOT: sessionRoot,
+              HOME: homeDir,
+            },
+            stderr: (text) => stderr.push(text),
+          },
+        ),
+        2,
+      );
+      assert.match(stderr.join(""), /Docker session root must not overlap the work dir/);
+      assert.equal(existsSync(join(sessionRoot, "codex")), false);
+    }
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI rejects plain Docker workdirs that overlap the container home", { skip: process.platform === "win32" }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const stderr: string[] = [];
+    assert.equal(
+      await runCli(["codex", "--docker", "--prompt", "hello", "--work-dir", "/", "--print-command"], {
+        env: { ...process.env, HOME: dir },
+        stderr: (text) => stderr.push(text),
+      }),
+      2,
+    );
+    assert.match(stderr.join(""), /Docker work dir must not overlap the container home/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --modal print-command wraps the selected agent command", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -29,7 +29,7 @@ import {
 import { acpClientCapabilities } from "../src/acp.ts";
 import { runCli } from "../src/cli.ts";
 import { parseHeadlessConfig } from "../src/config.ts";
-import { DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
+import { DEFAULT_DOCKER_IMAGE, dockerSessionHomePath } from "../src/docker.ts";
 import { launchLockPath } from "../src/launch-lock.ts";
 import { writeStoredSession } from "../src/sessions.ts";
 import { quoteCommand } from "../src/shell.ts";
@@ -2172,7 +2172,7 @@ test("CLI --docker --session persists a durable home across turns", async () => 
     const secondCommand = calls[1].args.slice(calls[1].args.indexOf("headless-agent") + 1);
     assert.ok(secondCommand.includes("resume"));
 
-    const sessionHome = join(homeDir, ".headless", "docker-sessions", "codex", "work");
+    const sessionHome = dockerSessionHomePath("codex", "work", { HOME: homeDir }) as string;
     assert.equal(readFileSync(join(sessionHome, "turns.txt"), "utf8"), "2");
     const dockerStore = JSON.parse(readFileSync(join(sessionHome, ".headless", "sessions.json"), "utf8"));
     assert.equal(dockerStore.agents.codex.work.nativeId, "docker-thread");
@@ -2314,7 +2314,7 @@ test("CLI --docker --session discovers Antigravity transcripts in the durable ho
     );
     assert.equal(stdout.join(""), "antigravity docker done\n");
 
-    const sessionHome = join(homeDir, ".headless", "docker-sessions", "antigravity", "work");
+    const sessionHome = dockerSessionHomePath("antigravity", "work", { HOME: homeDir }) as string;
     const store = JSON.parse(readFileSync(join(sessionHome, ".headless", "sessions.json"), "utf8"));
     assert.equal(store.agents.antigravity.work.nativeId, "agy-docker-session");
 
@@ -2417,7 +2417,7 @@ test("CLI --docker --session creates Cursor chats inside the container", async (
       HOME: homeDir,
       PATH: `${hostBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`,
     };
-    const sessionHome = join(homeDir, ".headless", "docker-sessions", "cursor", "work");
+    const sessionHome = dockerSessionHomePath("cursor", "work", { HOME: homeDir }) as string;
     const externalMarkerTarget = join(dir, "external-marker-target");
     mkdirSync(sessionHome, { recursive: true });
     writeFileSync(externalMarkerTarget, "do not overwrite\n");
@@ -2523,7 +2523,7 @@ test("CLI --docker --session print-command prepares its bind-mount source", asyn
       0,
     );
 
-    const sessionHome = join(homeDir, ".headless", "docker-sessions", "codex", "work");
+    const sessionHome = dockerSessionHomePath("codex", "work", { HOME: homeDir }) as string;
     assert.equal(existsSync(sessionHome), true);
     assert.ok(stdout.join("").includes(`${sessionHome}:/headless-home:rw`));
   } finally {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -20,6 +20,7 @@ import { runCli } from "../src/cli.ts";
 import { parseHeadlessConfig } from "../src/config.ts";
 import { DEFAULT_DOCKER_IMAGE } from "../src/docker.ts";
 import { launchLockPath } from "../src/launch-lock.ts";
+import { writeStoredSession } from "../src/sessions.ts";
 import { quoteCommand } from "../src/shell.ts";
 import type { AgentName } from "../src/types.ts";
 
@@ -2124,6 +2125,13 @@ test("CLI --docker --session persists a durable home across turns", async () => 
       HOME: homeDir,
       PATH: `${binDir}:${process.env.PATH ?? ""}`,
     };
+    writeStoredSession(env, {
+      agent: "codex",
+      alias: "work",
+      nativeId: "local-thread",
+      workDir: projectDir,
+    });
+
     const stdout: string[] = [];
     assert.equal(
       await runCli(["codex", "--session", "work", "--prompt", "first", "--work-dir", projectDir, "--docker"], {
@@ -2148,13 +2156,31 @@ test("CLI --docker --session persists a durable home across turns", async () => 
     assert.equal(calls.length, 2);
     assert.equal(calls[0].turn, 1);
     assert.equal(calls[1].turn, 2);
+    const firstCommand = calls[0].args.slice(calls[0].args.indexOf("headless-agent") + 1);
+    assert.ok(!firstCommand.includes("resume"));
     const secondCommand = calls[1].args.slice(calls[1].args.indexOf("headless-agent") + 1);
     assert.ok(secondCommand.includes("resume"));
 
     const sessionHome = join(homeDir, ".headless", "docker-sessions", "codex", "work");
     assert.equal(readFileSync(join(sessionHome, "turns.txt"), "utf8"), "2");
-    const store = JSON.parse(readFileSync(join(homeDir, ".headless", "sessions.json"), "utf8"));
-    assert.equal(store.agents.codex.work.nativeId, "docker-thread");
+    const dockerStore = JSON.parse(readFileSync(join(sessionHome, ".headless", "sessions.json"), "utf8"));
+    assert.equal(dockerStore.agents.codex.work.nativeId, "docker-thread");
+    const localStore = JSON.parse(readFileSync(join(homeDir, ".headless", "sessions.json"), "utf8"));
+    assert.equal(localStore.agents.codex.work.nativeId, "local-thread");
+
+    rmSync(sessionHome, { force: true, recursive: true });
+    stdout.length = 0;
+    assert.equal(
+      await runCli(["codex", "--session", "work", "--prompt", "reset", "--work-dir", projectDir, "--docker"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "turn 1\n");
+    const resetCalls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const resetCommand = resetCalls[2].args.slice(resetCalls[2].args.indexOf("headless-agent") + 1);
+    assert.ok(!resetCommand.includes("resume"));
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -1464,6 +1464,130 @@ test("CLI forwards parent signals to timeout-enabled agents", async () => {
   }
 });
 
+test("CLI forwards parent signals while holding a durable Docker session lock", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  const dockerPidFile = join(dir, "docker.pid");
+  const signalFile = join(dir, "signal.txt");
+  let dockerPid: number | undefined;
+  try {
+    const binDir = join(dir, "bin");
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    mkdirSync(binDir);
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    const docker = join(binDir, "docker");
+    writeFileSync(
+      docker,
+      [
+        "#!/usr/bin/env node",
+        "const { writeFileSync } = require('node:fs');",
+        "writeFileSync(process.env.HEADLESS_TEST_DOCKER_PID, String(process.pid));",
+        "process.on('SIGINT', () => {",
+        "  writeFileSync(process.env.HEADLESS_TEST_SIGNAL_FILE, 'SIGINT');",
+        "  process.exit(130);",
+        "});",
+        "setInterval(() => {}, 1000);",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(docker, 0o755);
+
+    const headless = spawn(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        join(repoRoot, "src", "cli.ts"),
+        "codex",
+        "--docker",
+        "--session",
+        "work",
+        "--prompt",
+        "hello",
+        "--timeout",
+        "30",
+        "--work-dir",
+        projectDir,
+      ],
+      {
+        env: {
+          ...process.env,
+          HEADLESS_TEST_DOCKER_PID: dockerPidFile,
+          HEADLESS_TEST_SIGNAL_FILE: signalFile,
+          HOME: homeDir,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdio: "ignore",
+      },
+    );
+    await waitFor(() => existsSync(dockerPidFile));
+
+    headless.kill("SIGINT");
+    const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      headless.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+
+    assert.deepEqual(exit, { code: null, signal: "SIGINT" });
+    await waitFor(() => existsSync(signalFile));
+    assert.equal(readFileSync(signalFile, "utf8"), "SIGINT");
+  } finally {
+    try {
+      dockerPid = Number(readFileSync(dockerPidFile, "utf8"));
+      if (Number.isInteger(dockerPid) && dockerPid > 0 && processIsAlive(dockerPid)) process.kill(dockerPid, "SIGKILL");
+    } catch {
+      // The wrapper may fail before launching Docker.
+    }
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("CLI ignores durable lock signal listeners left by an earlier invocation", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const homeDir = join(dir, "home");
+    const lockHome = join(dir, "docker-sessions", "codex", "work");
+    mkdirSync(binDir);
+    mkdirSync(homeDir);
+    mkdirSync(lockHome, { recursive: true });
+    const binary = join(binDir, "codex");
+    writeFileSync(
+      binary,
+      [
+        "#!/usr/bin/env node",
+        "setTimeout(() => process.kill(process.ppid, 'SIGTERM'), 100);",
+        "process.on('SIGTERM', () => process.exit(0));",
+        "setInterval(() => {}, 1000);",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(binary, 0o755);
+    const runner = join(dir, "runner.mjs");
+    writeFileSync(
+      runner,
+      [
+        `const { acquireDockerSessionLock } = await import(${JSON.stringify(pathToFileURL(join(repoRoot, "src", "launch-lock.ts")).href)});`,
+        `const lock = await acquireDockerSessionLock(${JSON.stringify(lockHome)});`,
+        "await lock.release();",
+        `const { runCli } = await import(${JSON.stringify(pathToFileURL(join(repoRoot, "src", "cli.ts")).href)});`,
+        "process.exitCode = await runCli(['codex', '--prompt', 'hello', '--json', '--timeout', '30']);",
+        "",
+      ].join("\n"),
+    );
+
+    const child = spawnSync(process.execPath, ["--import", "tsx", runner], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, HOME: homeDir, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+    });
+    assert.equal(child.status, null, child.stderr);
+    assert.equal(child.signal, "SIGTERM");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI forwards suspend and continue signals to timeout-enabled agents", { skip: process.platform === "win32" }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   const agentPidFile = join(dir, "agent.pid");

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2062,6 +2062,27 @@ test("CLI rejects invalid --session combinations", async () => {
   assert.match(stderr.join(""), /--session cannot be used with --name/);
 });
 
+test("CLI rejects dot-segment session names", async () => {
+  const home = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    for (const alias of [".", ".."]) {
+      const stderr: string[] = [];
+
+      assert.equal(
+        await runCli(["codex", "--session", alias, "--prompt", "hello", "--print-command"], {
+          env: { ...process.env, HOME: home },
+          stderr: (text) => stderr.push(text),
+          stdout: () => {},
+        }),
+        2,
+      );
+      assert.match(stderr.join(""), /invalid session name/);
+    }
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
+});
+
 test("CLI --docker --session persists a durable home across turns", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2197,6 +2197,92 @@ test("CLI --docker --session persists a durable home across turns", async () => 
   }
 });
 
+test("CLI --docker --session discovers Antigravity transcripts in the durable home", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const homeDir = join(dir, "home");
+    const hostAntigravityHome = join(dir, "host-antigravity");
+    const projectDir = join(dir, "project");
+    mkdirSync(binDir);
+    mkdirSync(homeDir);
+    mkdirSync(hostAntigravityHome);
+    mkdirSync(projectDir);
+    const docker = join(binDir, "docker");
+    writeFileSync(
+      docker,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const args = process.argv.slice(2);",
+        "const volume = args.find((arg) => arg.endsWith(':/headless-home:rw'));",
+        "if (!volume) process.exit(11);",
+        "const sessionHome = volume.slice(0, -':/headless-home:rw'.length);",
+        "const id = 'agy-docker-session';",
+        "const root = path.join(sessionHome, '.gemini', 'antigravity-cli');",
+        "const cache = path.join(root, 'cache', 'last_conversations.json');",
+        "const transcript = path.join(root, 'brain', id, '.system_generated', 'logs', 'transcript.jsonl');",
+        "fs.mkdirSync(path.dirname(cache), { recursive: true });",
+        "fs.writeFileSync(cache, JSON.stringify({ [process.env.HEADLESS_EXPECT_CWD]: id }));",
+        "fs.mkdirSync(path.dirname(transcript), { recursive: true });",
+        "fs.writeFileSync(transcript, JSON.stringify({ type: 'SESSION_META', payload: { cwd: process.env.HEADLESS_EXPECT_CWD } }) + '\\n');",
+        "console.log('antigravity docker done');",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(docker, 0o755);
+
+    const stdout: string[] = [];
+    const env = {
+      ...process.env,
+      ANTIGRAVITY_HOME: hostAntigravityHome,
+      HEADLESS_EXPECT_CWD: realpathSync(projectDir),
+      HOME: homeDir,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    assert.equal(
+      await runCli(["antigravity", "--docker", "--session", "work", "--prompt", "hello", "--work-dir", projectDir], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "antigravity docker done\n");
+
+    const sessionHome = join(homeDir, ".headless", "docker-sessions", "antigravity", "work");
+    const store = JSON.parse(readFileSync(join(sessionHome, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.antigravity.work.nativeId, "agy-docker-session");
+
+    const stderr: string[] = [];
+    assert.equal(
+      await runCli(
+        [
+          "antigravity",
+          "--docker",
+          "--session",
+          "custom-home",
+          "--docker-env",
+          "ANTIGRAVITY_HOME=/headless-home/custom",
+          "--prompt",
+          "hello",
+          "--work-dir",
+          projectDir,
+        ],
+        {
+          env,
+          stderr: (text) => stderr.push(text),
+          stdout: () => {},
+        },
+      ),
+      2,
+    );
+    assert.match(stderr.join(""), /ANTIGRAVITY_HOME cannot be overridden.*--docker --session/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --docker --session creates Cursor chats inside the container", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2197,6 +2197,59 @@ test("CLI --docker --session persists a durable home across turns", async () => 
   }
 });
 
+test("CLI revalidates Docker session storage before persisting container state", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    const externalStore = join(dir, "external-store");
+    mkdirSync(binDir);
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    mkdirSync(externalStore);
+    const docker = join(binDir, "docker");
+    writeFileSync(
+      docker,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const args = process.argv.slice(2);",
+        "const volume = args.find((arg) => arg.endsWith(':/headless-home:rw'));",
+        "if (!volume) process.exit(11);",
+        "const sessionHome = volume.slice(0, -':/headless-home:rw'.length);",
+        "const store = path.join(sessionHome, '.headless');",
+        "fs.rmSync(store, { force: true, recursive: true });",
+        "fs.symlinkSync(process.env.HEADLESS_EXTERNAL_STORE, store);",
+        "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'untrusted-thread' }));",
+        "console.log(JSON.stringify({ type: 'agent_message', text: 'done' }));",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(docker, 0o755);
+
+    const stderr: string[] = [];
+    assert.equal(
+      await runCli(["codex", "--docker", "--session", "work", "--prompt", "hello", "--work-dir", projectDir], {
+        env: {
+          ...process.env,
+          HEADLESS_EXTERNAL_STORE: externalStore,
+          HOME: homeDir,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        stderr: (text) => stderr.push(text),
+        stdout: () => {},
+      }),
+      2,
+    );
+    assert.match(stderr.join(""), /symbolic link/);
+    assert.equal(existsSync(join(externalStore, "sessions.json")), false);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI serializes concurrent turns for the same durable Docker session", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2060,13 +2060,83 @@ test("CLI rejects invalid --session combinations", async () => {
     2,
   );
   assert.match(stderr.join(""), /--session cannot be used with --name/);
+});
 
-  stderr.length = 0;
-  assert.equal(
-    await runCli(["codex", "--session", "work", "--docker", "--prompt", "hello"], { stderr: (text) => stderr.push(text) }),
-    2,
-  );
-  assert.match(stderr.join(""), /--session cannot be used with --docker/);
+test("CLI --docker --session persists a durable home across turns", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const homeDir = join(dir, "home");
+    const projectDir = join(dir, "project");
+    const captureFile = join(dir, "docker.jsonl");
+    mkdirSync(binDir);
+    mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    await import("node:fs/promises").then(async ({ chmod, writeFile }) => {
+      const docker = join(binDir, "docker");
+      await writeFile(
+        docker,
+        [
+          "#!/usr/bin/env node",
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "const args = process.argv.slice(2);",
+          "const volume = args.find((arg) => arg.endsWith(':/headless-home:rw'));",
+          "if (!volume) process.exit(11);",
+          "const sessionHome = volume.slice(0, -':/headless-home:rw'.length);",
+          "fs.mkdirSync(sessionHome, { recursive: true });",
+          "const statePath = path.join(sessionHome, 'turns.txt');",
+          "const turn = fs.existsSync(statePath) ? Number(fs.readFileSync(statePath, 'utf8')) + 1 : 1;",
+          "fs.writeFileSync(statePath, String(turn));",
+          "fs.appendFileSync(process.env.HEADLESS_DOCKER_CAPTURE, JSON.stringify({ args, turn }) + '\\n');",
+          "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'docker-thread' }));",
+          "console.log(JSON.stringify({ type: 'agent_message', text: `turn ${turn}` }));",
+          "",
+        ].join("\n"),
+      );
+      await chmod(docker, 0o755);
+    });
+
+    const env = {
+      ...process.env,
+      HEADLESS_DOCKER_CAPTURE: captureFile,
+      HOME: homeDir,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+    const stdout: string[] = [];
+    assert.equal(
+      await runCli(["codex", "--session", "work", "--prompt", "first", "--work-dir", projectDir, "--docker"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "turn 1\n");
+
+    stdout.length = 0;
+    assert.equal(
+      await runCli(["codex", "--session", "work", "--prompt", "second", "--work-dir", projectDir, "--docker"], {
+        env,
+        stdout: (text) => stdout.push(text),
+      }),
+      0,
+    );
+    assert.equal(stdout.join(""), "turn 2\n");
+
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].turn, 1);
+    assert.equal(calls[1].turn, 2);
+    const secondCommand = calls[1].args.slice(calls[1].args.indexOf("headless-agent") + 1);
+    assert.ok(secondCommand.includes("resume"));
+
+    const sessionHome = join(homeDir, ".headless", "docker-sessions", "codex", "work");
+    assert.equal(readFileSync(join(sessionHome, "turns.txt"), "utf8"), "2");
+    const store = JSON.parse(readFileSync(join(homeDir, ".headless", "sessions.json"), "utf8"));
+    assert.equal(store.agents.codex.work.nativeId, "docker-thread");
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
 });
 
 test("CLI --docker print-command wraps the selected agent command", async () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2197,6 +2197,70 @@ test("CLI --docker --session persists a durable home across turns", async () => 
   }
 });
 
+test("CLI serializes concurrent turns for the same durable Docker session", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const binDir = join(dir, "bin");
+    const homeDirs = [join(dir, "home-first"), join(dir, "home-second")];
+    const sessionRoot = join(dir, "shared-sessions");
+    const projectDir = join(dir, "project");
+    const activeFile = join(dir, "active");
+    const overlapFile = join(dir, "overlap");
+    const captureFile = join(dir, "calls.jsonl");
+    mkdirSync(binDir);
+    for (const homeDir of homeDirs) mkdirSync(homeDir);
+    mkdirSync(projectDir);
+    const docker = join(binDir, "docker");
+    writeFileSync(
+      docker,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "const prompt = fs.readFileSync(0, 'utf8');",
+        "if (fs.existsSync(process.env.HEADLESS_ACTIVE_FILE)) fs.writeFileSync(process.env.HEADLESS_OVERLAP_FILE, 'overlap');",
+        "fs.writeFileSync(process.env.HEADLESS_ACTIVE_FILE, String(process.pid));",
+        "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 150);",
+        "fs.rmSync(process.env.HEADLESS_ACTIVE_FILE, { force: true });",
+        "fs.appendFileSync(process.env.HEADLESS_CAPTURE, JSON.stringify({ args, prompt }) + '\\n');",
+        "console.log(JSON.stringify({ type: 'thread.started', thread_id: `thread-${prompt}` }));",
+        "console.log(JSON.stringify({ type: 'agent_message', text: `done ${prompt}` }));",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(docker, 0o755);
+    const sharedEnv = {
+      ...process.env,
+      HEADLESS_ACTIVE_FILE: activeFile,
+      HEADLESS_CAPTURE: captureFile,
+      HEADLESS_DOCKER_SESSION_ROOT: sessionRoot,
+      HEADLESS_OVERLAP_FILE: overlapFile,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    };
+
+    const results = await Promise.all(
+      ["first", "second"].map((prompt, index) =>
+        runCli(["codex", "--docker", "--session", "work", "--prompt", prompt, "--work-dir", projectDir], {
+          env: { ...sharedEnv, HOME: homeDirs[index] },
+          stdout: () => {},
+        }),
+      ),
+    );
+
+    assert.deepEqual(results, [0, 0]);
+    assert.equal(existsSync(overlapFile), false);
+    const calls = readFileSync(captureFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(calls.length, 2);
+    const firstCommand = calls[0].args.slice(calls[0].args.indexOf("headless-agent") + 1);
+    const secondCommand = calls[1].args.slice(calls[1].args.indexOf("headless-agent") + 1);
+    assert.equal(firstCommand.includes("resume"), false);
+    assert.ok(secondCommand.includes("resume"));
+    assert.ok(secondCommand.includes(`thread-${calls[0].prompt}`));
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI --docker --session discovers Antigravity transcripts in the durable home", async () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
   try {

--- a/tests/launch-lock.test.ts
+++ b/tests/launch-lock.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import { acquireLaunchLock, launchLockPath } from "../src/launch-lock.ts";
+import { acquireDockerSessionLock, acquireLaunchLock, dockerSessionLockPath, launchLockPath } from "../src/launch-lock.ts";
 
 function withHome<T>(callback: (home: string) => T): T {
   const home = mkdtempSync(join(tmpdir(), "headless-lock-"));
@@ -81,4 +81,141 @@ test("launch lock blocks against a live holder until released", () => {
 test("launch lock is a no-op without HOME", () => {
   const lock = acquireLaunchLock({}, "codex", "/repo/a");
   lock.release(); // must not throw
+});
+
+test("Docker session lock paths derive from the canonical durable home", () => {
+  withHome((home) => {
+    const persistentHome = join(home, "sessions", "codex", "work");
+    const dottedAliasHome = join(home, "sessions", "codex", "work.lock");
+    mkdirSync(persistentHome, { recursive: true });
+    mkdirSync(dottedAliasHome);
+    const path = dockerSessionLockPath(persistentHome);
+
+    assert.ok(path.startsWith(join(realpathSync(join(home, "sessions")), ".headless-session-locks")));
+    assert.ok(path.endsWith(".lock"));
+    assert.notEqual(path, realpathSync(dottedAliasHome));
+  });
+});
+
+test("Docker session locks recover stale crash remnants", async () => {
+  const home = mkdtempSync(join(tmpdir(), "headless-lock-"));
+  try {
+    const persistentHome = join(home, "sessions", "codex", "work");
+    mkdirSync(persistentHome, { recursive: true });
+    const lockPath = dockerSessionLockPath(persistentHome);
+    mkdirSync(lockPath, { recursive: true });
+    const stale = new Date(Date.now() - 120_000);
+    utimesSync(lockPath, stale, stale);
+
+    const lock = await acquireDockerSessionLock(persistentHome);
+    assert.equal(existsSync(lockPath), true);
+    await lock.release();
+    assert.equal(existsSync(lockPath), false);
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
+});
+
+test("Docker session locks do not steal a stale lease from a live local owner", async () => {
+  const home = mkdtempSync(join(tmpdir(), "headless-lock-"));
+  const originalTimezone = process.env.TZ;
+  try {
+    const persistentHome = join(home, "sessions", "codex", "work");
+    mkdirSync(persistentHome, { recursive: true });
+    process.env.TZ = "UTC";
+    const first = await acquireDockerSessionLock(persistentHome);
+    if (process.platform === "linux") {
+      const owner = JSON.parse(readFileSync(`${dockerSessionLockPath(persistentHome)}.owner`, "utf8"));
+      assert.match(owner.startIdentity, /^linux:[0-9a-f-]{36}:\d+$/);
+    }
+    const stale = new Date(Date.now() - 120_000);
+    utimesSync(dockerSessionLockPath(persistentHome), stale, stale);
+    process.env.TZ = "Pacific/Honolulu";
+    let secondAcquired = false;
+    const secondPromise = acquireDockerSessionLock(persistentHome).then((lock) => {
+      secondAcquired = true;
+      return lock;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(secondAcquired, false);
+    assert.equal(await first.release(), undefined);
+    const second = await secondPromise;
+    assert.equal(secondAcquired, true);
+    assert.equal(await second.release(), undefined);
+  } finally {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+    rmSync(home, { force: true, recursive: true });
+  }
+});
+
+test("Docker session locks recover when a stale owner PID has been reused", async () => {
+  const home = mkdtempSync(join(tmpdir(), "headless-lock-"));
+  try {
+    const persistentHome = join(home, "sessions", "codex", "work");
+    mkdirSync(persistentHome, { recursive: true });
+    const lockPath = dockerSessionLockPath(persistentHome);
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(
+      `${lockPath}.owner`,
+      `${JSON.stringify({
+        hostname: hostname(),
+        pid: process.pid,
+        startIdentity: "different process birth",
+        token: "00000000-0000-4000-8000-000000000000",
+      })}\n`,
+    );
+    const stale = new Date(Date.now() - 120_000);
+    utimesSync(lockPath, stale, stale);
+
+    const lock = await acquireDockerSessionLock(persistentHome);
+    assert.equal(await lock.release(), undefined);
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
+});
+
+test("Docker session lock release remains non-throwing after external removal", async () => {
+  const home = mkdtempSync(join(tmpdir(), "headless-lock-"));
+  try {
+    const persistentHome = join(home, "sessions", "codex", "work");
+    mkdirSync(persistentHome, { recursive: true });
+    const lock = await acquireDockerSessionLock(persistentHome);
+    rmSync(dockerSessionLockPath(persistentHome), { force: true, recursive: true });
+
+    await assert.doesNotReject(lock.release());
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
+});
+
+test("Docker session lock release reports permission failures without rejecting", { skip: process.platform === "win32" }, async () => {
+  const home = mkdtempSync(join(tmpdir(), "headless-lock-"));
+  const persistentHome = join(home, "sessions", "codex", "work");
+  let lockPath = "";
+  try {
+    mkdirSync(persistentHome, { recursive: true });
+    const lock = await acquireDockerSessionLock(persistentHome);
+    lockPath = dockerSessionLockPath(persistentHome);
+    chmodSync(dirname(lockPath), 0o500);
+
+    assert.match((await lock.release())?.message ?? "", /permission|EACCES/i);
+  } finally {
+    if (lockPath) chmodSync(dirname(lockPath), 0o700);
+    rmSync(home, { force: true, recursive: true });
+  }
+});
+
+test("Docker session locks do not retry permanent namespace errors", async () => {
+  const home = mkdtempSync(join(tmpdir(), "headless-lock-"));
+  try {
+    const persistentHome = join(home, "sessions", "codex", "work");
+    mkdirSync(persistentHome, { recursive: true });
+    writeFileSync(join(home, "sessions", ".headless-session-locks"), "not a directory");
+
+    await assert.rejects(acquireDockerSessionLock(persistentHome), /EEXIST|not a directory|ENOTDIR/);
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
 });

--- a/tests/run-coordination.test.ts
+++ b/tests/run-coordination.test.ts
@@ -1327,3 +1327,59 @@ test("Docker run coordination mounts the host run directory", async () => {
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("Docker run nodes reject unsupported durable sessions", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-run-test-"));
+  try {
+    const env = { ...process.env, HOME: join(dir, "home") };
+    const stderr: string[] = [];
+    assert.equal(
+      await runCli(
+        [
+          "codex",
+          "--role",
+          "worker",
+          "--run",
+          "auth",
+          "--node",
+          "worker-1",
+          "--coordination",
+          "session",
+          "--prompt",
+          "hello",
+          "--docker",
+        ],
+        { env, stderr: (text) => stderr.push(text) },
+      ),
+      2,
+    );
+    assert.match(stderr.join(""), /Docker run nodes do not support durable sessions/);
+    assert.equal(readRun(env, "auth"), undefined);
+
+    stderr.length = 0;
+    assert.equal(
+      await runCli(
+        [
+          "codex",
+          "--role",
+          "worker",
+          "--run",
+          "auth",
+          "--node",
+          "worker-1",
+          "--session",
+          "work",
+          "--prompt",
+          "hello",
+          "--docker",
+        ],
+        { env, stderr: (text) => stderr.push(text) },
+      ),
+      2,
+    );
+    assert.match(stderr.join(""), /Docker run nodes do not support durable sessions/);
+    assert.equal(readRun(env, "auth"), undefined);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -72,6 +72,15 @@ test("secure session stores validate records and write private files atomically"
     });
     assert.equal(readStoredSession(env, "codex", "work")?.nativeId, "trusted");
     assert.equal(statSync(storePath).mode & 0o777, 0o600);
+
+    const longAlias = "a".repeat(300);
+    writeStoredSession(env, {
+      agent: "codex",
+      alias: longAlias,
+      nativeId: "long-session",
+      workDir: dir,
+    });
+    assert.equal(readStoredSession(env, "codex", longAlias)?.nativeId, "long-session");
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, truncateSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  readStoredSession,
+  SECURE_SESSION_STORE_ENV,
+  writeStoredSession,
+} from "../src/sessions.ts";
+
+test("secure session stores reject symlinks and oversized files", { skip: process.platform === "win32" }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-sessions-test-"));
+  try {
+    const storeDir = join(dir, ".headless");
+    const storePath = join(storeDir, "sessions.json");
+    const external = join(dir, "external.json");
+    const env = { HOME: dir, [SECURE_SESSION_STORE_ENV]: "1" };
+    mkdirSync(storeDir);
+    writeFileSync(external, "{}\n");
+    symlinkSync(external, storePath);
+
+    assert.throws(() => readStoredSession(env, "codex", "work"), /ELOOP/);
+    assert.equal(readFileSync(external, "utf8"), "{}\n");
+
+    rmSync(storePath);
+    const fifo = spawnSync("mkfifo", [storePath], { encoding: "utf8" });
+    assert.equal(fifo.status, 0, fifo.stderr);
+    assert.throws(() => readStoredSession(env, "codex", "work"), /bounded regular file/);
+    rmSync(storePath);
+    writeFileSync(storePath, "");
+    truncateSync(storePath, 1024 * 1024 + 1);
+    assert.throws(() => readStoredSession(env, "codex", "work"), /bounded regular file/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test("secure session stores validate records and write private files atomically", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-sessions-test-"));
+  try {
+    const storeDir = join(dir, ".headless");
+    const storePath = join(storeDir, "sessions.json");
+    const env = { HOME: dir, [SECURE_SESSION_STORE_ENV]: "1" };
+    mkdirSync(storeDir);
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        version: 1,
+        agents: {
+          codex: {
+            work: {
+              agent: "codex",
+              alias: "different",
+              nativeId: "untrusted",
+              createdAt: "now",
+              updatedAt: "now",
+            },
+          },
+        },
+      }),
+    );
+    assert.equal(readStoredSession(env, "codex", "work"), undefined);
+
+    writeStoredSession(env, {
+      agent: "codex",
+      alias: "work",
+      nativeId: "trusted",
+      workDir: dir,
+    });
+    assert.equal(readStoredSession(env, "codex", "work")?.nativeId, "trusted");
+    assert.equal(statSync(storePath).mode & 0o777, 0o600);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -85,3 +85,44 @@ test("secure session stores validate records and write private files atomically"
     rmSync(dir, { force: true, recursive: true });
   }
 });
+
+test("secure session stores preserve reserved aliases as own properties", () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-sessions-test-"));
+  try {
+    const storeDir = join(dir, ".headless");
+    const storePath = join(storeDir, "sessions.json");
+    const env = { HOME: dir, [SECURE_SESSION_STORE_ENV]: "1" };
+    const aliases = ["__proto__", "constructor", "prototype"];
+    const sessions = Object.fromEntries(
+      aliases.map((alias) => [
+        alias,
+        {
+          agent: "codex",
+          alias,
+          nativeId: `${alias}-session`,
+          createdAt: "now",
+          updatedAt: "now",
+        },
+      ]),
+    );
+    mkdirSync(storeDir);
+    writeFileSync(storePath, JSON.stringify({ version: 1, agents: { codex: sessions } }));
+
+    writeStoredSession(env, {
+      agent: "codex",
+      alias: "work",
+      nativeId: "work-session",
+      workDir: dir,
+    });
+
+    const stored = JSON.parse(readFileSync(storePath, "utf8")) as {
+      agents: { codex: Record<string, unknown> };
+    };
+    for (const alias of aliases) {
+      assert.equal(Object.hasOwn(stored.agents.codex, alias), true);
+      assert.equal(readStoredSession(env, "codex", alias)?.nativeId, `${alias}-session`);
+    }
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add opt-in durable Docker sessions with `--docker --session <name>`.
- Persist each session's native agent home under `~/.headless/docker-sessions/<agent>/<name>` while keeping containers disposable with `--rm`.
- Preserve native session state across turns, including Pi's container-visible session-file path.
- Document `HEADLESS_DOCKER_SESSION_ROOT` and add command-construction plus two-turn fake-Docker coverage.
- Rebased onto `main` after #19/#20 (selective Antigravity Docker seed mounts + usage accounting).

## Behavior

Plain `--docker` remains ephemeral. Adding `--session` bind-mounts a durable home, copies seed files only when absent, and reuses Headless's existing native session alias mapping from `~/.headless/sessions.json`.

## Validation

- `npm run build`
- `node --import tsx --test tests/docker.test.ts tests/headless.test.ts` — 173 passed
- `npm run pack:check` — passed