### PR TITLE
ci(docker): publish a multi-architecture Headless image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,11 @@ on:
       - published
   workflow_dispatch:
 
+concurrency:
+  group: docker-image-publish
+  cancel-in-progress: false
+  queue: max
+
 jobs:
   publish:
     name: Publish multi-architecture image
@@ -19,6 +24,18 @@ jobs:
       packages: write
 
     steps:
+      - name: Validate manual source
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          default_branch_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$DEFAULT_BRANCH" --jq .sha)
+          if [[ "$GITHUB_SHA" != "$default_branch_sha" ]]; then
+            echo "::error::Default branch advanced while this workflow was queued; rerun the publish workflow."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -45,9 +62,10 @@ jobs:
           flavor: latest=false
           tags: |
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.event_name != 'release' || !github.event.release.prerelease }}
+            type=sha,format=long,prefix=sha-
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -56,7 +74,33 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=docker-${{ github.event_name == 'workflow_dispatch' && 'main' || github.sha }}
+            type=gha,scope=docker-main
+          cache-to: type=gha,mode=max,scope=docker-${{ github.event_name == 'workflow_dispatch' && 'main' || github.sha }}
           provenance: mode=max
           sbom: true
+
+      - name: Promote current image to latest
+        if: github.event_name != 'release' || !github.event.release.prerelease
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE_NAME: ghcr.io/roberttlange/headless
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            latest_release_tag=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)
+            if [[ "$RELEASE_TAG" != "$latest_release_tag" ]]; then
+              echo "::notice::A newer stable release exists; keeping its latest tag."
+              exit 0
+            fi
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            default_branch_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$DEFAULT_BRANCH" --jq .sha)
+            if [[ "$GITHUB_SHA" != "$default_branch_sha" ]]; then
+              echo "::error::Default branch advanced while this image was built; rerun the publish workflow."
+              exit 1
+            fi
+          fi
+          docker buildx imagetools create --tag "$IMAGE_NAME:latest" "$IMAGE_NAME@$IMAGE_DIGEST"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,11 @@ on:
 jobs:
   publish:
     name: Publish multi-architecture image
+    if: >-
+      github.event_name == 'release' ||
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
+    environment: docker-publish
     permissions:
       contents: read
       packages: write
@@ -36,9 +40,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/roberttlange/headless
+          flavor: latest=false
           tags: |
-            type=raw,value=latest
             type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.event_name != 'release' || !github.event.release.prerelease }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,55 @@
+name: Docker image
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish multi-architecture image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/roberttlange/headless
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,16 +20,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -37,7 +39,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/roberttlange/headless
           flavor: latest=false
@@ -46,7 +48,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name != 'release' || !github.event.release.prerelease }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
+LABEL org.opencontainers.image.source=https://github.com/RobertTLange/headless-cli
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash ca-certificates curl git ripgrep \
   && rm -rf /var/lib/apt/lists/*

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
 
+const dockerWorkflow = readFileSync(".github/workflows/docker-image.yml", "utf8");
+
 test("Dockerfile exposes Cursor agent from a non-root path", () => {
   const dockerfile = readFileSync("Dockerfile", "utf8");
 
@@ -42,14 +44,29 @@ test("Dockerfile exposes Cursor agent from a non-root path", () => {
 });
 
 test("Docker image workflow publishes the pinned image for both host architectures", () => {
-  const workflow = readFileSync(".github/workflows/docker-image.yml", "utf8");
+  assert.match(dockerWorkflow, /packages:\s+write/);
+  assert.match(dockerWorkflow, /ghcr\.io\/roberttlange\/headless/);
+  assert.match(dockerWorkflow, /platforms:\s+linux\/amd64,linux\/arm64/);
+  assert.match(dockerWorkflow, /docker\/build-push-action@v6/);
+  assert.match(dockerWorkflow, /provenance: mode=max/);
+  assert.match(dockerWorkflow, /sbom: true/);
+});
 
-  assert.match(workflow, /packages:\s+write/);
-  assert.match(workflow, /ghcr\.io\/roberttlange\/headless/);
-  assert.match(workflow, /platforms:\s+linux\/amd64,linux\/arm64/);
-  assert.match(workflow, /docker\/build-push-action@v6/);
-  assert.match(workflow, /provenance: mode=max/);
-  assert.match(workflow, /sbom: true/);
+test("Docker image workflow only manually publishes the default branch", () => {
+  assert.match(dockerWorkflow, /if: >-\s+github\.event_name == 'release' \|\|/);
+  assert.match(
+    dockerWorkflow,
+    /github\.ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\)/,
+  );
+  assert.match(dockerWorkflow, /environment: docker-publish/);
+});
+
+test("Docker image workflow keeps prereleases off latest", () => {
+  assert.match(dockerWorkflow, /flavor: latest=false/);
+  assert.match(
+    dockerWorkflow,
+    /type=raw,value=latest,enable=\$\{\{ github\.event_name != 'release' \|\| !github\.event\.release\.prerelease \}\}/,
+  );
 });
 
 test("wraps stdin-based agent command in docker with workdir, user, env, and config mounts", () => {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -41,6 +41,17 @@ test("Dockerfile exposes Cursor agent from a non-root path", () => {
   assert.match(dockerfile, /ENV AGY_CLI_DISABLE_AUTO_UPDATE=true/);
 });
 
+test("Docker image workflow publishes the pinned image for both host architectures", () => {
+  const workflow = readFileSync(".github/workflows/docker-image.yml", "utf8");
+
+  assert.match(workflow, /packages:\s+write/);
+  assert.match(workflow, /ghcr\.io\/roberttlange\/headless/);
+  assert.match(workflow, /platforms:\s+linux\/amd64,linux\/arm64/);
+  assert.match(workflow, /docker\/build-push-action@v6/);
+  assert.match(workflow, /provenance: mode=max/);
+  assert.match(workflow, /sbom: true/);
+});
+
 test("wraps stdin-based agent command in docker with workdir, user, env, and config mounts", () => {
   const dir = mkdtempSync(join(tmpdir(), "headless-docker-test-"));
   try {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -17,11 +17,10 @@ import {
 } from "../src/docker.ts";
 import { quoteCommand } from "../src/shell.ts";
 
+const dockerfile = readFileSync("Dockerfile", "utf8");
 const dockerWorkflow = readFileSync(".github/workflows/docker-image.yml", "utf8");
 
 test("Dockerfile exposes Cursor agent from a non-root path", () => {
-  const dockerfile = readFileSync("Dockerfile", "utf8");
-
   assert.match(dockerfile, /^FROM node:22-bookworm-slim@sha256:[a-f0-9]{64}$/m);
   assert.match(dockerfile, /@anthropic-ai\/claude-code@\d+\.\d+\.\d+/);
   assert.match(dockerfile, /@google\/gemini-cli@\d+\.\d+\.\d+/);
@@ -41,6 +40,13 @@ test("Dockerfile exposes Cursor agent from a non-root path", () => {
   assert.match(dockerfile, /sha512sum -c -/);
   assert.match(dockerfile, /install -m 0755 \/tmp\/antigravity \/usr\/local\/bin\/agy/);
   assert.match(dockerfile, /ENV AGY_CLI_DISABLE_AUTO_UPDATE=true/);
+});
+
+test("Dockerfile links published images to the source repository", () => {
+  assert.match(
+    dockerfile,
+    /^LABEL org\.opencontainers\.image\.source=https:\/\/github\.com\/RobertTLange\/headless-cli$/m,
+  );
 });
 
 test("Docker image workflow publishes the pinned image for both host architectures", () => {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -53,7 +53,8 @@ test("Docker image workflow publishes the pinned image for both host architectur
   assert.match(dockerWorkflow, /packages:\s+write/);
   assert.match(dockerWorkflow, /ghcr\.io\/roberttlange\/headless/);
   assert.match(dockerWorkflow, /platforms:\s+linux\/amd64,linux\/arm64/);
-  assert.match(dockerWorkflow, /docker\/build-push-action@v6/);
+  assert.match(dockerWorkflow, /docker\/build-push-action@[a-f0-9]{40} # v6/);
+  assert.match(dockerWorkflow, /persist-credentials: false/);
   assert.match(dockerWorkflow, /provenance: mode=max/);
   assert.match(dockerWorkflow, /sbom: true/);
 });
@@ -73,6 +74,15 @@ test("Docker image workflow keeps prereleases off latest", () => {
     dockerWorkflow,
     /type=raw,value=latest,enable=\$\{\{ github\.event_name != 'release' \|\| !github\.event\.release\.prerelease \}\}/,
   );
+});
+
+test("Docker image workflow pins every action to a commit", () => {
+  const actionReferences = [...dockerWorkflow.matchAll(/^\s+uses:\s+([^@\s]+)@(\S+)(?:\s+#.*)?$/gm)];
+
+  assert.equal(actionReferences.length, 6);
+  for (const [, action, revision] of actionReferences) {
+    assert.match(revision ?? "", /^[a-f0-9]{40}$/, `${action} must use a full commit SHA`);
+  }
 });
 
 test("wraps stdin-based agent command in docker with workdir, user, env, and config mounts", () => {

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -59,6 +59,13 @@ test("Docker image workflow publishes the pinned image for both host architectur
   assert.match(dockerWorkflow, /sbom: true/);
 });
 
+test("Docker image workflow runs for published releases and manual recovery", () => {
+  assert.match(
+    dockerWorkflow,
+    /on:\s+release:\s+types:\s+- published\s+workflow_dispatch:/,
+  );
+});
+
 test("Docker image workflow only manually publishes the default branch", () => {
   assert.match(dockerWorkflow, /if: >-\s+github\.event_name == 'release' \|\|/);
   assert.match(

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -72,8 +72,67 @@ test("Docker image workflow keeps prereleases off latest", () => {
   assert.match(dockerWorkflow, /flavor: latest=false/);
   assert.match(
     dockerWorkflow,
-    /type=raw,value=latest,enable=\$\{\{ github\.event_name != 'release' \|\| !github\.event\.release\.prerelease \}\}/,
+    /if: github\.event_name != 'release' \|\| !github\.event\.release\.prerelease/,
   );
+});
+
+test("Docker image workflow serializes every publish", () => {
+  assert.match(
+    dockerWorkflow,
+    /concurrency:\s+group: docker-image-publish\s+cancel-in-progress: false\s+queue: max/,
+  );
+});
+
+test("Docker image workflow only promotes the freshest stable release", () => {
+  const buildIndex = dockerWorkflow.indexOf("- name: Build and push");
+  const promotionIndex = dockerWorkflow.indexOf("- name: Promote current image to latest");
+  const buildBlock = dockerWorkflow.slice(buildIndex, promotionIndex);
+
+  assert.notEqual(buildIndex, -1);
+  assert.ok(promotionIndex > buildIndex);
+  assert.match(buildBlock, /push: true/);
+  assert.match(buildBlock, /tags: \$\{\{ steps\.meta\.outputs\.tags \}\}/);
+  assert.match(dockerWorkflow, /id: build/);
+  assert.match(dockerWorkflow, /type=ref,event=tag/);
+  assert.match(dockerWorkflow, /type=sha,format=long,prefix=sha-/);
+  assert.match(dockerWorkflow, /gh api "repos\/\$GITHUB_REPOSITORY\/releases\/latest" --jq \.tag_name/);
+  assert.match(dockerWorkflow, /"\$RELEASE_TAG" != "\$latest_release_tag"/);
+  assert.doesNotMatch(dockerWorkflow, /releases\/latest.*\|\| true/);
+  assert.match(dockerWorkflow, /IMAGE_DIGEST: \$\{\{ steps\.build\.outputs\.digest \}\}/);
+  assert.match(
+    dockerWorkflow,
+    /docker buildx imagetools create --tag "\$IMAGE_NAME:latest" "\$IMAGE_NAME@\$IMAGE_DIGEST"/,
+  );
+});
+
+test("Docker image workflow rejects a stale manual dispatch", () => {
+  const validationIndex = dockerWorkflow.indexOf("- name: Validate manual source");
+  const buildIndex = dockerWorkflow.indexOf("- name: Build and push");
+  const promotionIndex = dockerWorkflow.indexOf("- name: Promote current image to latest");
+  const defaultHeadCheckIndices = [
+    ...dockerWorkflow.matchAll(
+      /gh api "repos\/\$GITHUB_REPOSITORY\/commits\/\$DEFAULT_BRANCH" --jq \.sha/g,
+    ),
+  ].map((match) => match.index);
+
+  assert.notEqual(validationIndex, -1);
+  assert.ok(validationIndex < buildIndex);
+  assert.ok(buildIndex < promotionIndex);
+  assert.equal(defaultHeadCheckIndices.length, 2);
+  assert.ok((defaultHeadCheckIndices[0] ?? -1) > validationIndex);
+  assert.ok((defaultHeadCheckIndices[0] ?? -1) < buildIndex);
+  assert.ok((defaultHeadCheckIndices[1] ?? -1) > promotionIndex);
+  assert.match(dockerWorkflow, /DEFAULT_BRANCH: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(dockerWorkflow, /"\$GITHUB_SHA" != "\$default_branch_sha"/);
+  assert.match(dockerWorkflow, /exit 1/);
+});
+
+test("Docker image workflow isolates release caches while reusing the default-branch cache", () => {
+  const cacheScope = /\$\{\{ github\.event_name == 'workflow_dispatch' && 'main' \|\| github\.sha \}\}/;
+
+  assert.match(dockerWorkflow, new RegExp(`cache-from:[\\s\\S]*scope=docker-${cacheScope.source}`));
+  assert.match(dockerWorkflow, /cache-from:[\s\S]*type=gha,scope=docker-main/);
+  assert.match(dockerWorkflow, new RegExp(`cache-to: type=gha,mode=max,scope=docker-${cacheScope.source}`));
 });
 
 test("Docker image workflow pins every action to a commit", () => {


### PR DESCRIPTION
## Summary

- Add a release/manual workflow for ghcr.io/roberttlange/headless.
- Build and publish linux/amd64 and linux/arm64 manifests.
- Enable BuildKit provenance, SBOMs, and GitHub Actions layer caching.
- Add a static regression test for the Docker workflow contract.

## Why

PR #21's Docker validation could not run on this ARM64 host because the published image had no ARM64 manifest. The existing Dockerfile already selects architecture-specific Cursor and Antigravity artifacts with pinned checksums; this workflow makes that support reachable and keeps the default image usable on both common host architectures.

## Validation

- node --import tsx --test tests/docker.test.ts — 24 passed, 1 Windows skip
- npm run check — build passed; 427 passed, 5 unrelated pre-existing Modal archive tests failed because their fixtures were rejected as invalid PAX headers