### PR TITLE
fix: honor Antigravity timeouts and update Agy image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TBD
 
+- Fixed Antigravity one-shot runs to forward Headless's configured command timeout to `agy --print-timeout`, so long reasoning runs are not cut off by Agy's independent five-minute default.
+
 ## 0.5.0 - 2026-07-27
 
 - Added multi-architecture GHCR image publishing for Linux AMD64 and ARM64 releases, with guarded manual recovery, immutable release and commit tags, serialized `latest` promotion, provenance, and SBOM attestations (#23).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 
 - Fixed Antigravity one-shot runs to forward Headless's configured command timeout to `agy --print-timeout`, so long reasoning runs are not cut off by Agy's independent five-minute default.
+- Updated the bundled Docker image to Antigravity CLI 1.1.8, using the official release assets and published SHA-256 digests for Linux AMD64 and ARM64.
 
 ## 0.5.0 - 2026-07-27
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ ARG TARGETARCH
 ARG CURSOR_AGENT_VERSION=2026.04.17-787b533
 ARG CURSOR_AGENT_SHA256_AMD64=942b2b583239497715f2390336eb8e2df3673703bd167bd59f7be33a27e15c5a
 ARG CURSOR_AGENT_SHA256_ARM64=985191ffc606da1317e1399f99306481f58643f345ed2252033b011504c780ce
-ARG AGY_RELEASE=1.0.9-6003845613092864
-ARG AGY_SHA512_AMD64=9c09eef905ea34079988908067cb716aaeadf3807ea572403d792c5113533213f98f43159d63679408819869bfe143d8e2789e3fab0f28593ffd04f2a7dcf47b
-ARG AGY_SHA512_ARM64=e0b13d0cc3f1337962d1dff7f03f44b2c44b5e07dd483c9633a00235d7b5c8257c6dc5e084b12281aaa18e1c94aa81602c994ee19b5d2e376bc24d85f569372d
+ARG AGY_VERSION=1.1.8
+ARG AGY_SHA256_AMD64=e92e6215532b3ce84455e341944067753ad90f6d24cebcec8002ce137e5162ce
+ARG AGY_SHA256_ARM64=e75cebb03fce0fcad7d3bb682eb84c356a3c50ff8fb3dc4a89d2051f34fca0ab
 
 RUN set -eu; \
   case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
@@ -40,13 +40,13 @@ RUN set -eu; \
 
 RUN set -eu; \
   case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
-    amd64) agy_arch="linux-x64"; agy_file="cli_linux_x64.tar.gz"; agy_sha512="${AGY_SHA512_AMD64}" ;; \
-    arm64) agy_arch="linux-arm"; agy_file="cli_linux_arm64.tar.gz"; agy_sha512="${AGY_SHA512_ARM64}" ;; \
+    amd64) agy_file="agy_cli_linux_x64.tar.gz"; agy_sha256="${AGY_SHA256_AMD64}" ;; \
+    arm64) agy_file="agy_cli_linux_arm64.tar.gz"; agy_sha256="${AGY_SHA256_ARM64}" ;; \
     *) echo "unsupported Antigravity CLI architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
   esac; \
   agy_tarball="/tmp/agy.tar.gz"; \
-  curl "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_RELEASE}/${agy_arch}/${agy_file}" -fsSL -o "${agy_tarball}"; \
-  echo "${agy_sha512}  ${agy_tarball}" | sha512sum -c -; \
+  curl "https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_VERSION}/${agy_file}" -fsSL -o "${agy_tarball}"; \
+  echo "${agy_sha256}  ${agy_tarball}" | sha256sum -c -; \
   tar -xzf "${agy_tarball}" -C /tmp antigravity; \
   install -m 0755 /tmp/antigravity /usr/local/bin/agy; \
   rm -f "${agy_tarball}" /tmp/antigravity

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -292,7 +292,7 @@ Options:
 - `--work-dir`, `-C`: run the agent from a specific working directory.
 - `--docker`: run the agent inside Docker; add `--session` for a durable multi-turn container home.
 - `--modal`: run the agent in a Modal CPU sandbox for one-shot headless execution.
-- `--timeout <s>`: stop one-shot local, Docker, Modal, or `--tmux --wait` execution after the given number of seconds.
+- `--timeout <s>`: stop one-shot local, Docker, Modal, or `--tmux --wait` execution after the given number of seconds. For Antigravity one-shot runs, Headless also forwards this budget to `agy --print-timeout`.
 - `--json`: stream the raw agent JSON trace instead of extracting the final message.
 - `--debug`: stream the raw agent JSON trace and append the extracted final message.
 - `--usage`: append normalized token usage and cost JSON after the final message or streamed `--json` trace.

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -175,6 +175,9 @@ function withAntigravityAllow(args: string[], allow: AllowMode | undefined): str
 function buildAntigravity(options: BuildOptions, env: Env): BuiltCommand {
   const args = withModel([], options.model);
   args.push("-p", options.prompt);
+  if (options.timeoutSeconds !== undefined) {
+    args.push("--print-timeout", `${options.timeoutSeconds}s`);
+  }
   args.push(...withAntigravityAllow([], options.allow));
   if (options.sessionMode === "resume" && options.sessionId) {
     args.push("--conversation", options.sessionId);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1439,6 +1439,7 @@ function applySessionPlan(commandOptions: {
   model?: string;
   allow?: AllowMode;
   reasoningEffort?: ReasoningEffort;
+  timeoutSeconds?: number;
 }, plan: SessionPlan | undefined): typeof commandOptions & {
   sessionAlias?: string;
   sessionId?: string;
@@ -3178,6 +3179,7 @@ async function executeStoredNode(
           model: defaults.model,
           allow,
           reasoningEffort: defaults.reasoningEffort,
+          timeoutSeconds: config.general.timeoutSeconds,
         },
         sessionPlan,
       ),
@@ -4194,6 +4196,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         model: configuredDefaults.model,
         allow,
         reasoningEffort: configuredDefaults.reasoningEffort,
+        timeoutSeconds: commandTimeoutSeconds,
       }, commandSessionPlan),
       env,
     ), parsed.runId, nodeId);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4196,7 +4196,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<number
         model: configuredDefaults.model,
         allow,
         reasoningEffort: configuredDefaults.reasoningEffort,
-        timeoutSeconds: commandTimeoutSeconds,
+        timeoutSeconds: parsed.modal ? modalTimeoutSeconds : commandTimeoutSeconds,
       }, commandSessionPlan),
       env,
     ), parsed.runId, nodeId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface BuildOptions {
   model?: string;
   allow?: AllowMode;
   reasoningEffort?: ReasoningEffort;
+  timeoutSeconds?: number;
   sessionAlias?: string;
   sessionId?: string;
   sessionMode?: "new" | "resume";

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -30,14 +30,13 @@ test("Dockerfile exposes Cursor agent from a non-root path", () => {
   assert.match(dockerfile, /ARG CURSOR_AGENT_VERSION=\d{4}\.\d{2}\.\d{2}-[a-f0-9]+/);
   assert.match(dockerfile, /ARG CURSOR_AGENT_SHA256_AMD64=[a-f0-9]{64}/);
   assert.match(dockerfile, /ARG CURSOR_AGENT_SHA256_ARM64=[a-f0-9]{64}/);
-  assert.match(dockerfile, /ARG AGY_RELEASE=\d+\.\d+\.\d+-\d+/);
-  assert.match(dockerfile, /ARG AGY_SHA512_AMD64=[a-f0-9]{128}/);
-  assert.match(dockerfile, /ARG AGY_SHA512_ARM64=[a-f0-9]{128}/);
+  assert.match(dockerfile, /ARG AGY_VERSION=\d+\.\d+\.\d+/);
+  assert.match(dockerfile, /ARG AGY_SHA256_AMD64=[a-f0-9]{64}/);
+  assert.match(dockerfile, /ARG AGY_SHA256_ARM64=[a-f0-9]{64}/);
   assert.match(dockerfile, /sha256sum -c -/);
   assert.match(dockerfile, /ln -sf \/opt\/cursor-agent\/cursor-agent \/usr\/local\/bin\/cursor-agent/);
   assert.match(dockerfile, /ln -sf \/usr\/local\/bin\/cursor-agent \/usr\/local\/bin\/agent/);
-  assert.match(dockerfile, /storage\.googleapis\.com\/antigravity-public\/antigravity-cli/);
-  assert.match(dockerfile, /sha512sum -c -/);
+  assert.match(dockerfile, /github\.com\/google-antigravity\/antigravity-cli\/releases\/download/);
   assert.match(dockerfile, /install -m 0755 \/tmp\/antigravity \/usr\/local\/bin\/agy/);
   assert.match(dockerfile, /ENV AGY_CLI_DISABLE_AUTO_UPDATE=true/);
 });

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -117,10 +117,25 @@ test("builds ACP adapter command with read-only permission mode", () => {
 });
 
 test("builds Antigravity one-shot command", () => {
-  assert.deepEqual(buildAgentCommand("antigravity", { prompt: "hello", model: "gemini-model", workDir: "/repo/project" }, {}), {
-    command: "agy",
-    args: ["--model", "gemini-model", "-p", "hello", "--dangerously-skip-permissions"],
-  });
+  assert.deepEqual(
+    buildAgentCommand(
+      "antigravity",
+      { prompt: "hello", model: "gemini-model", timeoutSeconds: 900, workDir: "/repo/project" },
+      {},
+    ),
+    {
+      command: "agy",
+      args: [
+        "--model",
+        "gemini-model",
+        "-p",
+        "hello",
+        "--print-timeout",
+        "900s",
+        "--dangerously-skip-permissions",
+      ],
+    },
+  );
 });
 
 test("builds Antigravity command with binary override and sandboxed read-only mode", () => {

--- a/tests/headless.test.ts
+++ b/tests/headless.test.ts
@@ -2869,6 +2869,39 @@ test("CLI applies --timeout to Modal unless --modal-timeout is set", async () =>
   }
 });
 
+test("CLI forwards the effective Modal timeout to Antigravity", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "headless-test-"));
+  try {
+    const projectDir = join(dir, "project");
+    mkdirSync(projectDir);
+
+    const timeoutCases = [
+      { timeoutArgs: [], expectedTimeoutSeconds: 3600 },
+      { timeoutArgs: ["--modal-timeout", "1200"], expectedTimeoutSeconds: 1200 },
+      { timeoutArgs: ["--timeout", "60", "--modal-timeout", "1200"], expectedTimeoutSeconds: 1200 },
+    ];
+
+    for (const { timeoutArgs, expectedTimeoutSeconds } of timeoutCases) {
+      const stdout: string[] = [];
+      assert.equal(
+        await runCli(
+          ["antigravity", "--prompt", "hello", "--work-dir", projectDir, "--modal", ...timeoutArgs, "--print-command"],
+          { env: { ...process.env, HOME: dir }, stdout: (text) => stdout.push(text) },
+        ),
+        0,
+      );
+      assert.match(
+        stdout.join(""),
+        new RegExp(
+          `--timeout ${expectedTimeoutSeconds} .* -- agy -p hello --print-timeout ${expectedTimeoutSeconds}s `,
+        ),
+      );
+    }
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
 test("CLI rejects invalid Modal option combinations", async () => {
   const stderr: string[] = [];
   assert.equal(


### PR DESCRIPTION
## What changed

- Forward Headless's effective one-shot `--timeout` to Antigravity as `agy --print-timeout <seconds>s`.
- Apply the same forwarding to configured run-message timeouts.
- Update the bundled multi-architecture Docker image from Agy 1.0.9 to Agy 1.1.8 using official GitHub release assets and published SHA-256 digests.

## Why

Agy has an independent five-minute print-mode timeout. Long reasoning runs could therefore fail after five minutes even when Headless and its caller configured a larger wall-clock budget. The Docker image was also several Agy releases behind and lacked the latest structured print output and usage support.

## Validation

- `npm run build`
- 435 non-Modal tests passed, 1 skipped
- `npm run pack:check`
- Built `headless-cli:agy-1.1.8` locally
- Verified the built image exposes Agy 1.1.8, `--print-timeout`, and structured `--output-format`

The five existing Modal archive tests still fail with `invalid pax header`; they are unrelated to this change.
